### PR TITLE
Checkout Price Links

### DIFF
--- a/platform/flowglad-next/src/app/add-payment-method/[checkoutSessionId]/page.tsx
+++ b/platform/flowglad-next/src/app/add-payment-method/[checkoutSessionId]/page.tsx
@@ -1,6 +1,6 @@
 import { adminTransaction } from '@/db/adminTransaction'
 import { selectCustomerById } from '@/db/tableMethods/customerMethods'
-import { BillingInfoCore } from '@/db/tableMethods/purchaseMethods'
+import { CheckoutInfoCore } from '@/db/tableMethods/purchaseMethods'
 import { selectCheckoutSessionById } from '@/db/tableMethods/checkoutSessionMethods'
 import {
   CheckoutSessionStatus,
@@ -71,7 +71,7 @@ const CheckoutSessionPage = async ({
     throw new Error('No client secret found')
   }
 
-  const billingInfo: BillingInfoCore = {
+  const checkoutInfo: CheckoutInfoCore = {
     checkoutSession,
     sellerOrganization,
     redirectUrl: core.safeUrl(
@@ -100,7 +100,7 @@ const CheckoutSessionPage = async ({
         </div>
         <div className="flex-0" />
       </div>
-      <CheckoutPageProvider values={billingInfo}>
+      <CheckoutPageProvider values={checkoutInfo}>
         <CheckoutForm />
       </CheckoutPageProvider>
     </div>

--- a/platform/flowglad-next/src/app/checkout/[id]/page.tsx
+++ b/platform/flowglad-next/src/app/checkout/[id]/page.tsx
@@ -3,8 +3,8 @@ import { adminTransaction } from '@/db/adminTransaction'
 import { selectCustomerById } from '@/db/tableMethods/customerMethods'
 import { selectLatestFeeCalculation } from '@/db/tableMethods/feeCalculationMethods'
 import {
-  BillingInfoCore,
-  billingInfoSchema,
+  CheckoutInfoCore,
+  checkoutInfoSchema,
 } from '@/db/tableMethods/purchaseMethods'
 import { selectCheckoutSessionById } from '@/db/tableMethods/checkoutSessionMethods'
 import { selectPriceProductAndOrganizationByPriceWhere } from '@/db/tableMethods/priceMethods'
@@ -142,7 +142,7 @@ const CheckoutSessionPage = async ({
     throw new Error('No client secret found')
   }
 
-  const billingInfo: BillingInfoCore = billingInfoSchema.parse({
+  const checkoutInfo: CheckoutInfoCore = checkoutInfoSchema.parse({
     checkoutSession,
     product,
     price,
@@ -162,7 +162,7 @@ const CheckoutSessionPage = async ({
         : 'single_payment',
   })
 
-  return <CheckoutPage billingInfo={billingInfo} />
+  return <CheckoutPage checkoutInfo={checkoutInfo} />
 }
 
 export default CheckoutSessionPage

--- a/platform/flowglad-next/src/app/hooks/useSetCheckoutSessionCookieEffect.ts
+++ b/platform/flowglad-next/src/app/hooks/useSetCheckoutSessionCookieEffect.ts
@@ -1,12 +1,12 @@
 import { useEffect, useRef } from 'react'
 import { trpc } from '../_trpc/client'
 import { CheckoutFlowType, CheckoutSessionType } from '@/types'
-import { BillingInfoCore } from '@/db/tableMethods/purchaseMethods'
+import { CheckoutInfoCore } from '@/db/tableMethods/purchaseMethods'
 
 export const useSetCheckoutSessionCookieEffect = (
-  billingInfo: BillingInfoCore
+  checkoutInfo: CheckoutInfoCore
 ) => {
-  const { checkoutSession } = billingInfo
+  const { checkoutSession } = checkoutInfo
   const checkoutSessionId = checkoutSession.id
   const setCheckoutSessionCookie =
     trpc.purchases.createSession.useMutation()
@@ -41,13 +41,13 @@ export const useSetCheckoutSessionCookieEffect = (
       })
     }
     if (checkoutSessionType === CheckoutSessionType.Product) {
-      if (billingInfo.flowType === CheckoutFlowType.Invoice) {
+      if (checkoutInfo.flowType === CheckoutFlowType.Invoice) {
         throw Error(
           `Flow type cannot be Invoice while purchase session type is Product. Checkout session id: ${checkoutSessionId}`
         )
       }
       if (
-        billingInfo.flowType === CheckoutFlowType.AddPaymentMethod
+        checkoutInfo.flowType === CheckoutFlowType.AddPaymentMethod
       ) {
         throw Error(
           `Flow type cannot be AddPaymentMethod while purchase session type is Product. Checkout session id: ${checkoutSessionId}`
@@ -55,7 +55,7 @@ export const useSetCheckoutSessionCookieEffect = (
       }
 
       setCheckoutSessionCookie.mutateAsync({
-        productId: billingInfo.product!.id,
+        productId: checkoutInfo.product!.id,
         type: CheckoutSessionType.Product,
         id: checkoutSessionId,
       })

--- a/platform/flowglad-next/src/app/invoice/view/[organizationId]/[invoiceId]/CustomerInvoiceButtonBanner.tsx
+++ b/platform/flowglad-next/src/app/invoice/view/[organizationId]/[invoiceId]/CustomerInvoiceButtonBanner.tsx
@@ -3,14 +3,14 @@ import { useState } from 'react'
 import Button from '@/components/ion/Button'
 import { Invoice } from '@/db/schema/invoices'
 import CheckoutModal from '@/components/CheckoutModal'
-import { BillingInfoCore } from '@/db/tableMethods/purchaseMethods'
+import { CheckoutInfoCore } from '@/db/tableMethods/purchaseMethods'
 
 export const CustomerInvoicePayButtonBanner = ({
   invoice,
-  billingInfo,
+  checkoutInfo,
 }: {
   invoice: Invoice.Record
-  billingInfo: BillingInfoCore
+  checkoutInfo: CheckoutInfoCore
 }) => {
   const [isCheckoutModalOpen, setIsCheckoutModalOpen] =
     useState(false)
@@ -38,7 +38,7 @@ export const CustomerInvoicePayButtonBanner = ({
       <CheckoutModal
         isOpen={isCheckoutModalOpen}
         onClose={() => setIsCheckoutModalOpen(false)}
-        billingInfo={billingInfo}
+        checkoutInfo={checkoutInfo}
         title={`Pay Invoice #${invoice.invoiceNumber}`}
       />
     </>

--- a/platform/flowglad-next/src/app/invoice/view/[organizationId]/[invoiceId]/page.tsx
+++ b/platform/flowglad-next/src/app/invoice/view/[organizationId]/[invoiceId]/page.tsx
@@ -10,7 +10,7 @@ import {
   CustomerInvoiceDownloadReceiptButtonBanner,
   CustomerInvoicePayButtonBanner,
 } from './CustomerInvoiceButtonBanner'
-import { BillingInfoCore } from '@/db/tableMethods/purchaseMethods'
+import { CheckoutInfoCore } from '@/db/tableMethods/purchaseMethods'
 import { adminTransaction } from '@/db/adminTransaction'
 import { findOrCreateInvoiceCheckoutSession } from '@/utils/checkoutSessionState'
 
@@ -80,7 +80,7 @@ const CustomerInvoiceOpenView = async (
     clientSecret = paymentIntent.client_secret
   }
 
-  const billingInfo: BillingInfoCore = {
+  const checkoutInfo: CheckoutInfoCore = {
     customer,
     sellerOrganization: organization,
     flowType: CheckoutFlowType.Invoice,
@@ -133,7 +133,7 @@ const CustomerInvoiceOpenView = async (
 
         <CustomerInvoicePayButtonBanner
           invoice={invoice}
-          billingInfo={billingInfo}
+          checkoutInfo={checkoutInfo}
         />
       </div>
     </div>

--- a/platform/flowglad-next/src/app/price/[priceId]/purchase/page.tsx
+++ b/platform/flowglad-next/src/app/price/[priceId]/purchase/page.tsx
@@ -1,24 +1,7 @@
 import CheckoutPage from '@/components/CheckoutPage'
-import { adminTransaction } from '@/db/adminTransaction'
-import { selectCustomerById } from '@/db/tableMethods/customerMethods'
-import { selectDiscountById } from '@/db/tableMethods/discountMethods'
-import { selectLatestFeeCalculation } from '@/db/tableMethods/feeCalculationMethods'
-import { selectOrganizationById } from '@/db/tableMethods/organizationMethods'
-import { billingInfoSchema } from '@/db/tableMethods/purchaseMethods'
-import {
-  selectPriceProductAndOrganizationByPriceWhere,
-  selectPricesAndProductByProductId,
-} from '@/db/tableMethods/priceMethods'
-import {
-  CheckoutFlowType,
-  PriceType,
-  CheckoutSessionType,
-} from '@/types'
 import core from '@/utils/core'
-import { findOrCreateCheckoutSession } from '@/utils/checkoutSessionState'
-import { getPaymentIntent, getSetupIntent } from '@/utils/stripe'
-import { Price } from '@/db/schema/prices'
 import { notFound } from 'next/navigation'
+import { checkoutInfoForPriceWhere } from '@/utils/checkoutHelpers'
 
 interface PurchasePageProps {
   params: Promise<{
@@ -26,90 +9,18 @@ interface PurchasePageProps {
   }>
 }
 
-const PurchasePage = async ({ params }: PurchasePageProps) => {
+const PricePurchasePage = async ({ params }: PurchasePageProps) => {
   if (core.IS_PROD) {
     return notFound()
   }
   const { priceId } = await params
-  const {
-    product,
-    price,
-    organization,
-    checkoutSession,
-    discount,
-    feeCalculation,
-    maybeCustomer,
-  } = await adminTransaction(async ({ transaction }) => {
-    const [{ product, price }] =
-      await selectPriceProductAndOrganizationByPriceWhere(
-        {
-          id: priceId,
-        },
-        transaction
-      )
-    if (!product.active) {
-      // TODO: ERROR PAGE UI
-      return {
-        product,
-        price,
-      }
-    }
-    const organization = await selectOrganizationById(
-      product.organizationId,
-      transaction
-    )
-
-    const checkoutSession = await findOrCreateCheckoutSession(
-      {
-        productId: product.id,
-        price,
-        organizationId: organization.id,
-        type: CheckoutSessionType.Product,
-      },
-      transaction
-    )
-
-    const discount = checkoutSession.discountId
-      ? await selectDiscountById(
-          checkoutSession.discountId,
-          transaction
-        )
-      : null
-
-    const feeCalculation = await selectLatestFeeCalculation(
-      {
-        checkoutSessionId: checkoutSession.id,
-        priceId: price.id,
-      },
-      transaction
-    )
-
-    const maybeCustomer = checkoutSession.customerId
-      ? await selectCustomerById(
-          checkoutSession.customerId,
-          transaction
-        )
-      : null
-
-    return {
-      product,
-      price,
-      organization,
-      checkoutSession,
-      discount,
-      feeCalculation,
-      maybeCustomer,
-    }
+  const { checkoutInfo, success } = await checkoutInfoForPriceWhere({
+    id: priceId,
   })
-
-  return (
-    <>
-      <div>
-        <h1>{product.name}</h1>
-        <p>{price.name}</p>
-      </div>
-    </>
-  )
+  if (!success) {
+    return notFound()
+  }
+  return <CheckoutPage checkoutInfo={checkoutInfo} />
 }
 
-export default PurchasePage
+export default PricePurchasePage

--- a/platform/flowglad-next/src/app/price/[priceId]/purchase/page.tsx
+++ b/platform/flowglad-next/src/app/price/[priceId]/purchase/page.tsx
@@ -2,6 +2,7 @@ import CheckoutPage from '@/components/CheckoutPage'
 import core from '@/utils/core'
 import { notFound } from 'next/navigation'
 import { checkoutInfoForPriceWhere } from '@/utils/checkoutHelpers'
+import CheckoutNotValidPage from '@/components/CheckoutNotValidPage'
 
 interface PurchasePageProps {
   params: Promise<{
@@ -14,11 +15,14 @@ const PricePurchasePage = async ({ params }: PurchasePageProps) => {
     return notFound()
   }
   const { priceId } = await params
-  const { checkoutInfo, success } = await checkoutInfoForPriceWhere({
-    id: priceId,
-  })
+  const { checkoutInfo, success, organization } =
+    await checkoutInfoForPriceWhere({
+      id: priceId,
+    })
   if (!success) {
-    return notFound()
+    return (
+      <CheckoutNotValidPage organizationName={organization.name} />
+    )
   }
   return <CheckoutPage checkoutInfo={checkoutInfo} />
 }

--- a/platform/flowglad-next/src/app/product/[productId]/purchase/page.tsx
+++ b/platform/flowglad-next/src/app/product/[productId]/purchase/page.tsx
@@ -1,20 +1,6 @@
 import CheckoutPage from '@/components/CheckoutPage'
-import { adminTransaction } from '@/db/adminTransaction'
-import { selectCustomerById } from '@/db/tableMethods/customerMethods'
-import { selectDiscountById } from '@/db/tableMethods/discountMethods'
-import { selectLatestFeeCalculation } from '@/db/tableMethods/feeCalculationMethods'
-import { selectOrganizationById } from '@/db/tableMethods/organizationMethods'
-import { billingInfoSchema } from '@/db/tableMethods/purchaseMethods'
-import { selectDefaultPriceAndProductByProductId } from '@/db/tableMethods/priceMethods'
-import {
-  CheckoutFlowType,
-  PriceType,
-  CheckoutSessionType,
-} from '@/types'
-import core from '@/utils/core'
-import { findOrCreateCheckoutSession } from '@/utils/checkoutSessionState'
-import { getPaymentIntent, getSetupIntent } from '@/utils/stripe'
-import { Price } from '@/db/schema/prices'
+import { checkoutInfoForPriceWhere } from '@/utils/checkoutHelpers'
+import { notFound } from 'next/navigation'
 
 interface PurchasePageProps {
   params: Promise<{
@@ -24,116 +10,14 @@ interface PurchasePageProps {
 
 const PurchasePage = async ({ params }: PurchasePageProps) => {
   const { productId } = await params
-  const {
-    product,
-    price,
-    organization,
-    checkoutSession,
-    discount,
-    feeCalculation,
-    maybeCustomer,
-  } = await adminTransaction(async ({ transaction }) => {
-    const { product, defaultPrice } =
-      await selectDefaultPriceAndProductByProductId(
-        productId,
-        transaction
-      )
-    if (!product.active) {
-      // TODO: ERROR PAGE UI
-      return {
-        product,
-      }
-    }
-    const organization = await selectOrganizationById(
-      product.organizationId,
-      transaction
-    )
-
-    /**
-     * Attempt to get the saved purchase session (from cookies).
-     * If not found, or the price id does not match, create a new purchase session
-     * and save it to cookies.
-     */
-    const checkoutSession = await findOrCreateCheckoutSession(
-      {
-        productId: product.id,
-        organizationId: organization.id,
-        price: defaultPrice as Price.Record,
-        type: CheckoutSessionType.Product,
-      },
-      transaction
-    )
-    const discount = checkoutSession.discountId
-      ? await selectDiscountById(
-          checkoutSession.discountId,
-          transaction
-        )
-      : null
-    const feeCalculation = await selectLatestFeeCalculation(
-      {
-        checkoutSessionId: checkoutSession.id,
-      },
-      transaction
-    )
-    const maybeCustomer = checkoutSession.customerId
-      ? await selectCustomerById(
-          checkoutSession.customerId,
-          transaction
-        )
-      : null
-    return {
-      product,
-      price: defaultPrice,
-      organization,
-      checkoutSession,
-      discount,
-      feeCalculation: feeCalculation ?? null,
-      maybeCustomer,
-    }
+  const { checkoutInfo, success } = await checkoutInfoForPriceWhere({
+    id: productId,
   })
 
-  if (!product.active) {
-    // TODO: ERROR PAGE UI
-    return <div>Product is not active</div>
+  if (!success) {
+    return notFound()
   }
-
-  if (!checkoutSession) {
-    return <div>Purchase session not found</div>
-  }
-
-  let clientSecret: string | null = null
-  if (checkoutSession.stripePaymentIntentId) {
-    const paymentIntent = await getPaymentIntent(
-      checkoutSession.stripePaymentIntentId
-    )
-    clientSecret = paymentIntent.client_secret
-  } else if (checkoutSession.stripeSetupIntentId) {
-    const setupIntent = await getSetupIntent(
-      checkoutSession.stripeSetupIntentId
-    )
-    clientSecret = setupIntent.client_secret
-  }
-  const billingInfo = billingInfoSchema.parse({
-    checkoutSession,
-    product,
-    price,
-    sellerOrganization: organization,
-    flowType:
-      price.type === PriceType.SinglePayment
-        ? CheckoutFlowType.SinglePayment
-        : CheckoutFlowType.Subscription,
-    redirectUrl: core.safeUrl(
-      `/purchase/post-payment`,
-      core.envVariable('NEXT_PUBLIC_APP_URL')
-    ),
-    clientSecret,
-    billingAddress: checkoutSession.billingAddress,
-    readonlyCustomerEmail: maybeCustomer?.email,
-    discount,
-    feeCalculation,
-  })
-
-  return <CheckoutPage billingInfo={billingInfo} />
+  return <CheckoutPage checkoutInfo={checkoutInfo} />
 }
 
 export default PurchasePage

--- a/platform/flowglad-next/src/app/product/[productId]/purchase/page.tsx
+++ b/platform/flowglad-next/src/app/product/[productId]/purchase/page.tsx
@@ -1,3 +1,4 @@
+import CheckoutNotValidPage from '@/components/CheckoutNotValidPage'
 import CheckoutPage from '@/components/CheckoutPage'
 import { checkoutInfoForPriceWhere } from '@/utils/checkoutHelpers'
 import { notFound } from 'next/navigation'
@@ -10,12 +11,16 @@ interface PurchasePageProps {
 
 const PurchasePage = async ({ params }: PurchasePageProps) => {
   const { productId } = await params
-  const { checkoutInfo, success } = await checkoutInfoForPriceWhere({
-    id: productId,
-  })
+  const { checkoutInfo, success, organization } =
+    await checkoutInfoForPriceWhere({
+      productId,
+      isDefault: true,
+    })
 
   if (!success) {
-    return notFound()
+    return (
+      <CheckoutNotValidPage organizationName={organization.name} />
+    )
   }
   return <CheckoutPage checkoutInfo={checkoutInfo} />
 }

--- a/platform/flowglad-next/src/app/purchase/pay/[id]/page.tsx
+++ b/platform/flowglad-next/src/app/purchase/pay/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound, redirect } from 'next/navigation'
 import { adminTransaction } from '@/db/adminTransaction'
 import {
-  billingInfoSchema,
+  checkoutInfoSchema,
   selectPurchaseCheckoutParametersById,
 } from '@/db/tableMethods/purchaseMethods'
 import PaymentStatusProcessing from '@/components/PaymentStatusProcessing'
@@ -105,7 +105,7 @@ const PayPurchasePage = async ({
     return <PaymentStatusProcessing />
   }
 
-  const billingInfo = billingInfoSchema.parse({
+  const checkoutInfo = checkoutInfoSchema.parse({
     ...rawContextValues,
     priceType: purchase.priceType,
     purchase,
@@ -116,7 +116,7 @@ const PayPurchasePage = async ({
     clientSecret: stripeIntent.client_secret,
   })
 
-  return <CheckoutPage billingInfo={billingInfo} />
+  return <CheckoutPage checkoutInfo={checkoutInfo} />
 }
 
 export default PayPurchasePage

--- a/platform/flowglad-next/src/app/purchase/pay/test/page.tsx
+++ b/platform/flowglad-next/src/app/purchase/pay/test/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import CheckoutInfo from '@/components/ion/CheckoutInfo'
+import CheckoutDetails from '@/components/ion/CheckoutDetails'
 import CheckoutPageProvider from '@/contexts/checkoutPageContext'
 import { subscriptionCheckoutPageContextValuesWithTrial } from '@/stubs/checkoutContextStubs'
 
-const TestCheckoutInfoPage = () => {
+const TestCheckoutDetailsPage = () => {
   return (
     <CheckoutPageProvider
       values={subscriptionCheckoutPageContextValuesWithTrial}
@@ -16,23 +16,23 @@ const TestCheckoutInfoPage = () => {
           <h2 className="text-xl font-semibold mb-4">
             Subscription with Trial
           </h2>
-          <CheckoutInfo />
+          <CheckoutDetails />
         </section>
 
         <section>
           <h2 className="text-xl font-semibold mb-4">
             Subscription without Trial
           </h2>
-          <CheckoutInfo />
+          <CheckoutDetails />
         </section>
 
         <section>
           <h2 className="text-xl font-semibold mb-4">Installment</h2>
-          <CheckoutInfo />
+          <CheckoutDetails />
         </section>
       </div>
     </CheckoutPageProvider>
   )
 }
 
-export default TestCheckoutInfoPage
+export default TestCheckoutDetailsPage

--- a/platform/flowglad-next/src/app/purchase/pay/test/page.tsx
+++ b/platform/flowglad-next/src/app/purchase/pay/test/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import BillingInfo from '@/components/ion/BillingInfo'
+import CheckoutInfo from '@/components/ion/CheckoutInfo'
 import CheckoutPageProvider from '@/contexts/checkoutPageContext'
 import { subscriptionCheckoutPageContextValuesWithTrial } from '@/stubs/checkoutContextStubs'
 
-const TestBillingInfoPage = () => {
+const TestCheckoutInfoPage = () => {
   return (
     <CheckoutPageProvider
       values={subscriptionCheckoutPageContextValuesWithTrial}
@@ -16,23 +16,23 @@ const TestBillingInfoPage = () => {
           <h2 className="text-xl font-semibold mb-4">
             Subscription with Trial
           </h2>
-          <BillingInfo />
+          <CheckoutInfo />
         </section>
 
         <section>
           <h2 className="text-xl font-semibold mb-4">
             Subscription without Trial
           </h2>
-          <BillingInfo />
+          <CheckoutInfo />
         </section>
 
         <section>
           <h2 className="text-xl font-semibold mb-4">Installment</h2>
-          <BillingInfo />
+          <CheckoutInfo />
         </section>
       </div>
     </CheckoutPageProvider>
   )
 }
 
-export default TestBillingInfoPage
+export default TestCheckoutInfoPage

--- a/platform/flowglad-next/src/app/store/products/[id]/PricesTable.tsx
+++ b/platform/flowglad-next/src/app/store/products/[id]/PricesTable.tsx
@@ -7,7 +7,6 @@ import { useMemo, useState } from 'react'
 import Table from '@/components/ion/Table'
 import { Price } from '@/db/schema/prices'
 import core from '@/utils/core'
-import TableRowPopoverMenu from '@/components/TableRowPopoverMenu'
 import {
   PopoverMenuItem,
   PopoverMenuItemState,
@@ -23,6 +22,7 @@ import SortableColumnHeaderCell from '@/components/ion/SortableColumnHeaderCell'
 import { trpc } from '@/app/_trpc/client'
 import MoreMenuTableCell from '@/components/MoreMenuTableCell'
 import CopyableTextTableCell from '@/components/CopyableTextTableCell'
+import { useCopyTextHandler } from '@/app/hooks/useCopyTextHandler'
 
 const MoreMenuCell = ({
   price,
@@ -34,10 +34,17 @@ const MoreMenuCell = ({
   const [isEditOpen, setIsEditOpen] = useState(false)
   const [isArchiveOpen, setIsArchiveOpen] = useState(false)
   const [isSetDefaultOpen, setIsSetDefaultOpen] = useState(false)
+  const copyTextHandler = useCopyTextHandler({
+    text: `${process.env.NEXT_PUBLIC_APP_URL}/price/${price.id}/purchase`,
+  })
   const items: PopoverMenuItem[] = [
     {
       label: 'Edit price',
       handler: () => setIsEditOpen(true),
+    },
+    {
+      label: 'Copy purchase link',
+      handler: copyTextHandler,
     },
   ]
   /**

--- a/platform/flowglad-next/src/components/CheckoutModal.tsx
+++ b/platform/flowglad-next/src/components/CheckoutModal.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { BillingInfoCore } from '@/db/tableMethods/purchaseMethods'
+import { CheckoutInfoCore } from '@/db/tableMethods/purchaseMethods'
 import CheckoutForm from '@/components/CheckoutForm'
 import CheckoutPageProvider from '@/contexts/checkoutPageContext'
 import Modal from '@/components/ion/Modal'
@@ -9,17 +9,17 @@ import { useSetCheckoutSessionCookieEffect } from '@/app/hooks/useSetCheckoutSes
 interface CheckoutModalProps {
   isOpen: boolean
   onClose: () => void
-  billingInfo: BillingInfoCore
+  checkoutInfo: CheckoutInfoCore
   title?: string
 }
 
 const CheckoutModal = ({
   isOpen,
   onClose,
-  billingInfo,
+  checkoutInfo,
   title,
 }: CheckoutModalProps) => {
-  useSetCheckoutSessionCookieEffect(billingInfo)
+  useSetCheckoutSessionCookieEffect(checkoutInfo)
 
   const checkoutFormContainer = cn(
     'bg-internal',
@@ -28,7 +28,7 @@ const CheckoutModal = ({
 
   return (
     <Modal open={isOpen} onOpenChange={onClose} title={title}>
-      <CheckoutPageProvider values={billingInfo}>
+      <CheckoutPageProvider values={checkoutInfo}>
         <div className={checkoutFormContainer}>
           <CheckoutForm />
         </div>

--- a/platform/flowglad-next/src/components/CheckoutNotValidPage.tsx
+++ b/platform/flowglad-next/src/components/CheckoutNotValidPage.tsx
@@ -1,0 +1,18 @@
+const CheckoutNotValidPage = ({
+  organizationName,
+}: {
+  organizationName: string
+}) => {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-4 text-center">
+      <h1 className="text-3xl font-bold mb-6 text-primary">
+        This offering is no longer available from {organizationName}
+      </h1>
+      <h2 className="text-xl text-secondary">
+        Please reach out to the team if you believe this is a mistake
+      </h2>
+    </div>
+  )
+}
+
+export default CheckoutNotValidPage

--- a/platform/flowglad-next/src/components/CheckoutPage.tsx
+++ b/platform/flowglad-next/src/components/CheckoutPage.tsx
@@ -1,7 +1,7 @@
 'use client'
-import { BillingInfoCore } from '@/db/tableMethods/purchaseMethods'
+import { CheckoutInfoCore } from '@/db/tableMethods/purchaseMethods'
 import CheckoutForm from '@/components/CheckoutForm'
-import BillingInfo from '@/components/ion/BillingInfo'
+import CheckoutInfo from '@/components/ion/CheckoutInfo'
 import CheckoutPageProvider from '@/contexts/checkoutPageContext'
 import { trpc } from '@/app/_trpc/client'
 import { useEffect, useRef } from 'react'
@@ -10,16 +10,16 @@ import { CheckoutFlowType } from '@/types'
 import { useSetCheckoutSessionCookieEffect } from '@/app/hooks/useSetCheckoutSessionCookieEffect'
 
 const CheckoutPage = ({
-  billingInfo,
+  checkoutInfo,
 }: {
-  billingInfo: BillingInfoCore
+  checkoutInfo: CheckoutInfoCore
 }) => {
-  if (billingInfo.flowType === CheckoutFlowType.Invoice) {
+  if (checkoutInfo.flowType === CheckoutFlowType.Invoice) {
     throw Error(
       'Invoice checkout flow cannot be rendered as a Checkout Page'
     )
   }
-  useSetCheckoutSessionCookieEffect(billingInfo)
+  useSetCheckoutSessionCookieEffect(checkoutInfo)
 
   /** Background split overlay for left side of checkout page */
   const leftBackgroundOverlay = core.cn(
@@ -51,7 +51,7 @@ const CheckoutPage = ({
     'lg:pl-8'
   )
   return (
-    <CheckoutPageProvider values={billingInfo}>
+    <CheckoutPageProvider values={checkoutInfo}>
       <div className={leftBackgroundOverlay} />
       <div className={rightBackgroundOverlay} />
       <div className={checkoutContainer}>
@@ -61,7 +61,7 @@ const CheckoutPage = ({
             'lg:justify-end lg:pl-0 lg:pr-8 lg:pt-18'
           )}
         >
-          <BillingInfo />
+          <CheckoutInfo />
         </div>
         <div className={checkoutFormContainer}>
           <CheckoutForm />

--- a/platform/flowglad-next/src/components/CheckoutPage.tsx
+++ b/platform/flowglad-next/src/components/CheckoutPage.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { CheckoutInfoCore } from '@/db/tableMethods/purchaseMethods'
 import CheckoutForm from '@/components/CheckoutForm'
-import CheckoutInfo from '@/components/ion/CheckoutInfo'
+import CheckoutDetails from '@/components/ion/CheckoutDetails'
 import CheckoutPageProvider from '@/contexts/checkoutPageContext'
 import { trpc } from '@/app/_trpc/client'
 import { useEffect, useRef } from 'react'
@@ -61,7 +61,7 @@ const CheckoutPage = ({
             'lg:justify-end lg:pl-0 lg:pr-8 lg:pt-18'
           )}
         >
-          <CheckoutInfo />
+          <CheckoutDetails />
         </div>
         <div className={checkoutFormContainer}>
           <CheckoutForm />

--- a/platform/flowglad-next/src/components/forms/PriceFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/PriceFormFields.tsx
@@ -239,6 +239,11 @@ const PriceFormFields = ({
                 if (value === PriceType.SinglePayment) {
                   setValue('price.intervalCount', null)
                   setValue('price.intervalUnit', null)
+                  setValue('price.usageMeterId', null)
+                  setValue('price.trialPeriodDays', null)
+                }
+                if (value !== PriceType.Usage) {
+                  setValue('price.usageMeterId', null)
                 }
                 field.onChange(value)
               }}

--- a/platform/flowglad-next/src/components/ion/CheckoutDetails.tsx
+++ b/platform/flowglad-next/src/components/ion/CheckoutDetails.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx'
 import BillingHeader from '@/components/ion/BillingHeader'
 import SellerInfo from '@/components/ion/SellerInfo'
 
-const BillingInfo = React.forwardRef<
+const CheckoutDetails = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
@@ -26,6 +26,6 @@ const BillingInfo = React.forwardRef<
   )
 })
 
-BillingInfo.displayName = 'BillingInfo'
+CheckoutDetails.displayName = 'CheckoutDetails'
 
-export default BillingInfo
+export default CheckoutDetails

--- a/platform/flowglad-next/src/contexts/billingInfoContext.tsx
+++ b/platform/flowglad-next/src/contexts/billingInfoContext.tsx
@@ -4,43 +4,43 @@ import { Product } from '@/db/schema/products'
 import { createContext, useContext } from 'react'
 import { Nullish, PriceType } from '@/types'
 import {
-  BillingInfoCore,
-  billingInfoSchema,
+  CheckoutInfoCore,
+  checkoutInfoSchema,
 } from '@/db/tableMethods/purchaseMethods'
 import { BillingAddress } from '@/db/schema/organizations'
 
-export type BillingInfoContextValues = {
+export type CheckoutInfoContextValues = {
   taxAmount?: Nullish<number>
   sellerOrganization?: Pick<Organization.Record, 'logoURL' | 'name'>
   product?: Product.ClientRecord
   type: PriceType
   billingAddress?: Nullish<BillingAddress>
-} & BillingInfoCore
+} & CheckoutInfoCore
 
-const BillingInfoContext = createContext<
-  Partial<BillingInfoContextValues>
+const CheckoutInfoContext = createContext<
+  Partial<CheckoutInfoContextValues>
 >({
   type: PriceType.SinglePayment,
   billingAddress: null,
 })
 
-export const useSafeBillingInfoContext = () => {
-  const billingInfo = useContext(BillingInfoContext)
-  return billingInfoSchema.parse(billingInfo)
+export const useSafeCheckoutInfoContext = () => {
+  const checkoutInfo = useContext(CheckoutInfoContext)
+  return checkoutInfoSchema.parse(checkoutInfo)
 }
 
-const BillingInfoProvider = ({
+const CheckoutInfoProvider = ({
   children,
   values,
 }: {
   children: React.ReactNode
-  values: BillingInfoContextValues
+  values: CheckoutInfoContextValues
 }) => {
   return (
-    <BillingInfoContext.Provider value={values}>
+    <CheckoutInfoContext.Provider value={values}>
       {children}
-    </BillingInfoContext.Provider>
+    </CheckoutInfoContext.Provider>
   )
 }
 
-export default BillingInfoProvider
+export default CheckoutInfoProvider

--- a/platform/flowglad-next/src/contexts/checkoutPageContext.tsx
+++ b/platform/flowglad-next/src/contexts/checkoutPageContext.tsx
@@ -3,12 +3,7 @@ import debounce from 'debounce'
 import { Organization } from '@/db/schema/organizations'
 import { Product } from '@/db/schema/products'
 import { createContext, useContext } from 'react'
-import {
-  CheckoutFlowType,
-  CurrencyCode,
-  Nullish,
-  PriceType,
-} from '@/types'
+import { CheckoutFlowType, CurrencyCode, Nullish } from '@/types'
 import {
   CheckoutInfoCore,
   checkoutInfoSchema,
@@ -138,8 +133,8 @@ const currencyFromCheckoutInfoCore = (
 
 export const useCheckoutPageContext =
   (): CheckoutPageContextValues => {
-    const checkoutInfo = useContext(CheckoutPageContext)
-    const checkoutInfo = checkoutInfoSchema.parse(checkoutInfo)
+    const rawCheckoutInfo = useContext(CheckoutPageContext)
+    const checkoutInfo = checkoutInfoSchema.parse(rawCheckoutInfo)
     const editCheckoutSession =
       trpc.purchases.updateSession.useMutation()
     const editCheckoutSessionPaymentMethodType =

--- a/platform/flowglad-next/src/db/tableMethods/invoiceMethods.ts
+++ b/platform/flowglad-next/src/db/tableMethods/invoiceMethods.ts
@@ -18,7 +18,7 @@ import {
 import { InvoiceStatus } from '@/types'
 import { DbTransaction } from '@/db/types'
 import { and, eq, count, desc } from 'drizzle-orm'
-import { BillingInfoCore } from './purchaseMethods'
+import { CheckoutInfoCore } from './purchaseMethods'
 import { customers } from '@/db/schema/customers'
 import {
   InvoiceLineItem,

--- a/platform/flowglad-next/src/db/tableMethods/paymentMethods.test.ts
+++ b/platform/flowglad-next/src/db/tableMethods/paymentMethods.test.ts
@@ -12,7 +12,6 @@ import {
   safelyUpdatePaymentForRefund,
   safelyUpdatePaymentStatus,
   selectPaymentById,
-  updatePayment,
 } from './paymentMethods'
 import { Payment } from '../schema/payments'
 import { Organization } from '../schema/organizations'

--- a/platform/flowglad-next/src/db/tableMethods/priceMethods.test.ts
+++ b/platform/flowglad-next/src/db/tableMethods/priceMethods.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { adminTransaction } from '@/db/adminTransaction'
+import {
+  setupOrg,
+  setupProduct,
+  setupPrice,
+} from '../../../seedDatabase'
+import { PriceType, IntervalUnit, CurrencyCode } from '@/types'
+import { nanoid } from '@/utils/core'
+import {
+  safelyInsertPrice,
+  safelyUpdatePrice,
+  selectPriceById,
+  selectPricesAndProductByProductId,
+} from './priceMethods'
+import { Price } from '../schema/prices'
+import { Organization } from '../schema/organizations'
+import { Product } from '../schema/products'
+
+describe('priceMethods.ts', () => {
+  let organization: Organization.Record
+  let product: Product.Record
+  let price: Price.Record
+
+  beforeEach(async () => {
+    const setup = await setupOrg()
+    organization = setup.organization
+
+    // Setup product
+    product = await setupProduct({
+      organizationId: organization.id,
+      name: 'Test Product',
+      livemode: true,
+      catalogId: setup.catalog.id,
+    })
+
+    // Setup price
+    price = await setupPrice({
+      productId: product.id,
+      name: 'Test Price',
+      type: PriceType.Subscription,
+      unitPrice: 1000,
+      intervalUnit: IntervalUnit.Month,
+      intervalCount: 1,
+      livemode: true,
+      isDefault: true,
+      setupFeeAmount: 0,
+      trialPeriodDays: 0,
+      currency: CurrencyCode.USD,
+    })
+  })
+
+  describe('safelyInsertPrice', () => {
+    it('successfully inserts a price', async () => {
+      await adminTransaction(async ({ transaction }) => {
+        const newPrice = await safelyInsertPrice(
+          {
+            productId: product.id,
+            name: 'New Price',
+            type: PriceType.Subscription,
+            unitPrice: 2000,
+            intervalUnit: IntervalUnit.Month,
+            intervalCount: 1,
+            livemode: true,
+            isDefault: false,
+            setupFeeAmount: 0,
+            trialPeriodDays: 0,
+            currency: CurrencyCode.USD,
+            externalId: null,
+            active: true,
+            usageMeterId: null,
+          },
+          transaction
+        )
+
+        expect(newPrice.name).toBe('New Price')
+        expect(newPrice.unitPrice).toBe(2000)
+        expect(newPrice.isDefault).toBe(false)
+      })
+    })
+
+    it('sets all other prices to non-default when inserting a default price', async () => {
+      await adminTransaction(async ({ transaction }) => {
+        // First, create another price for the same product
+        const secondPrice = await setupPrice({
+          productId: product.id,
+          name: 'Second Price',
+          type: PriceType.Subscription,
+          unitPrice: 1500,
+          intervalUnit: IntervalUnit.Month,
+          intervalCount: 1,
+          livemode: true,
+          isDefault: false,
+          setupFeeAmount: 0,
+          trialPeriodDays: 0,
+          currency: CurrencyCode.USD,
+        })
+
+        // Now insert a new default price
+        const newDefaultPrice = await safelyInsertPrice(
+          {
+            productId: product.id,
+            name: 'New Default Price',
+            type: PriceType.Subscription,
+            unitPrice: 3000,
+            intervalUnit: IntervalUnit.Month,
+            intervalCount: 1,
+            livemode: true,
+            isDefault: true,
+            setupFeeAmount: 0,
+            trialPeriodDays: 0,
+            currency: CurrencyCode.USD,
+            externalId: null,
+            active: true,
+            usageMeterId: null,
+          },
+          transaction
+        )
+
+        // Verify the new price is default
+        expect(newDefaultPrice.isDefault).toBe(true)
+
+        // Verify the previous default price is no longer default
+        const updatedSecondPrice = await selectPriceById(
+          secondPrice.id,
+          transaction
+        )
+        expect(updatedSecondPrice.isDefault).toBe(false)
+
+        // Verify the original price is no longer default
+        const updatedOriginalPrice = await selectPriceById(
+          price.id,
+          transaction
+        )
+        expect(updatedOriginalPrice.isDefault).toBe(false)
+      })
+    })
+  })
+
+  describe('safelyUpdatePrice', () => {
+    it('successfully updates a price', async () => {
+      await adminTransaction(async ({ transaction }) => {
+        const updatedPrice = await safelyUpdatePrice(
+          {
+            id: price.id,
+            name: 'Updated Price',
+            unitPrice: 2500,
+            type: PriceType.Subscription,
+          },
+          transaction
+        )
+
+        expect(updatedPrice.name).toBe('Updated Price')
+        expect(updatedPrice.unitPrice).toBe(2500)
+        expect(updatedPrice.isDefault).toBe(true) // Should remain default
+      })
+    })
+
+    it('sets all other prices to non-default when updating a price to default', async () => {
+      await adminTransaction(async ({ transaction }) => {
+        // First, create another price for the same product
+        const secondPrice = await setupPrice({
+          productId: product.id,
+          name: 'Second Price',
+          type: PriceType.Subscription,
+          unitPrice: 1500,
+          intervalUnit: IntervalUnit.Month,
+          intervalCount: 1,
+          livemode: true,
+          isDefault: false,
+          setupFeeAmount: 0,
+          trialPeriodDays: 0,
+          currency: CurrencyCode.USD,
+        })
+
+        // Now update the second price to be default
+        const updatedSecondPrice = await safelyUpdatePrice(
+          {
+            id: secondPrice.id,
+            isDefault: true,
+            type: PriceType.Subscription,
+          },
+          transaction
+        )
+
+        // Verify the second price is now default
+        expect(updatedSecondPrice.isDefault).toBe(true)
+
+        // Verify the original price is no longer default
+        const updatedOriginalPrice = await selectPriceById(
+          price.id,
+          transaction
+        )
+        expect(updatedOriginalPrice.isDefault).toBe(false)
+      })
+    })
+
+    it('does not change other prices when updating a non-default price', async () => {
+      await adminTransaction(async ({ transaction }) => {
+        // First, create another price for the same product
+        const secondPrice = await setupPrice({
+          productId: product.id,
+          name: 'Second Price',
+          type: PriceType.Subscription,
+          unitPrice: 1500,
+          intervalUnit: IntervalUnit.Month,
+          intervalCount: 1,
+          livemode: true,
+          isDefault: false,
+          setupFeeAmount: 0,
+          trialPeriodDays: 0,
+          currency: CurrencyCode.USD,
+        })
+
+        // Update the second price without changing its default status
+        const updatedSecondPrice = await safelyUpdatePrice(
+          {
+            id: secondPrice.id,
+            name: 'Updated Second Price',
+            unitPrice: 2000,
+            type: PriceType.Subscription,
+          },
+          transaction
+        )
+
+        // Verify the second price is still not default
+        expect(updatedSecondPrice.isDefault).toBe(false)
+        expect(updatedSecondPrice.name).toBe('Updated Second Price')
+        expect(updatedSecondPrice.unitPrice).toBe(2000)
+
+        // Verify the original price is still default
+        const updatedOriginalPrice = await selectPriceById(
+          price.id,
+          transaction
+        )
+        expect(updatedOriginalPrice.isDefault).toBe(true)
+      })
+    })
+
+    it('retrieves the correct product with prices after updates', async () => {
+      await adminTransaction(async ({ transaction }) => {
+        // Create another price for the same product
+        const secondPrice = await setupPrice({
+          productId: product.id,
+          name: 'Second Price',
+          type: PriceType.Subscription,
+          unitPrice: 1500,
+          intervalUnit: IntervalUnit.Month,
+          intervalCount: 1,
+          livemode: true,
+          isDefault: false,
+          setupFeeAmount: 0,
+          trialPeriodDays: 0,
+          currency: CurrencyCode.USD,
+        })
+
+        // Update the second price to be default
+        await safelyUpdatePrice(
+          {
+            id: secondPrice.id,
+            isDefault: true,
+            type: PriceType.Subscription,
+          },
+          transaction
+        )
+
+        // Get the product with its prices
+        const productWithPrices =
+          await selectPricesAndProductByProductId(
+            product.id,
+            transaction
+          )
+
+        // Verify the product has both prices
+        expect(productWithPrices.prices.length).toBe(2)
+
+        // Verify the default price is the second price
+        expect(productWithPrices.defaultPrice.id).toBe(secondPrice.id)
+        expect(productWithPrices.defaultPrice.isDefault).toBe(true)
+      })
+    })
+  })
+})

--- a/platform/flowglad-next/src/db/tableMethods/priceMethods.ts
+++ b/platform/flowglad-next/src/db/tableMethods/priceMethods.ts
@@ -226,7 +226,7 @@ export const selectDefaultPriceAndProductByProductId = async (
 }
 
 export const selectPriceProductAndOrganizationByPriceWhere = async (
-  whereConditions: Partial<Price.Record>,
+  whereConditions: Price.Where,
   transaction: DbTransaction
 ) => {
   let query = transaction

--- a/platform/flowglad-next/src/middleware.ts
+++ b/platform/flowglad-next/src/middleware.ts
@@ -20,6 +20,7 @@ const publicRoutes = [
   '/api/trpc/public.(.*)',
   '/checkout/(.*)',
   '/add-payment-method/(.*)',
+  '/price/(.*)/purchase',
   /**
    * Purchase session procedures need to be public,
    * otherwise anon users will hit 307 redirects.

--- a/platform/flowglad-next/src/pdf-generation/invoices.tsx
+++ b/platform/flowglad-next/src/pdf-generation/invoices.tsx
@@ -146,7 +146,7 @@ export const DocumentDetails: React.FC<DocumentDetailsProps> = ({
   )
 }
 
-interface BillingInfoProps {
+interface CheckoutInfoProps {
   organization: Organization.Record
   customer: Customer.Record
   billingAddress?: BillingAddress
@@ -193,7 +193,7 @@ const OrganizationContactInfo: React.FC<{
   )
 }
 
-export const BillingInfo: React.FC<BillingInfoProps> = ({
+export const CheckoutInfo: React.FC<CheckoutInfoProps> = ({
   organization,
   customer,
   billingAddress,
@@ -643,7 +643,7 @@ export const InvoiceTemplate: React.FC<InvoiceTemplateProps> = ({
           />
           <DocumentDetails invoice={invoice} mode="invoice" />
           {billingAddress && (
-            <BillingInfo
+            <CheckoutInfo
               organization={organization}
               customer={customer}
               billingAddress={billingAddress}

--- a/platform/flowglad-next/src/pdf-generation/receipts.tsx
+++ b/platform/flowglad-next/src/pdf-generation/receipts.tsx
@@ -3,7 +3,7 @@ import { Container, Head, Body, Html } from '@react-email/components'
 import {
   DocumentHeader,
   DocumentDetails,
-  BillingInfo,
+  CheckoutInfo,
   PaymentInfo,
   InvoiceLineItems,
   InvoiceTotals,
@@ -92,7 +92,7 @@ export const ReceiptTemplate: React.FC<InvoiceTemplateProps> = ({
             paymentData={paymentData}
           />
           {billingAddress && (
-            <BillingInfo
+            <CheckoutInfo
               organization={organization}
               customer={customer}
               billingAddress={billingAddress}

--- a/platform/flowglad-next/src/server/routers/productsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/productsRouter.ts
@@ -1,16 +1,12 @@
 import { protectedProcedure, router } from '../trpc'
 import {
-  insertProduct,
-  updateProduct,
   selectProductsPaginated,
   selectProductById,
   getProductTableRows,
-  ProductRow,
 } from '@/db/tableMethods/productMethods'
 import {
   createProductTransaction,
   editProduct as editProductCatalog,
-  editPriceTransaction,
 } from '@/utils/catalog'
 import {
   createProductSchema,
@@ -26,7 +22,10 @@ import {
   productsPaginatedListSchema,
   productsPaginatedSelectSchema,
 } from '@/db/schema/products'
-import { selectPrices } from '@/db/tableMethods/priceMethods'
+import {
+  safelyUpdatePrice,
+  selectPrices,
+} from '@/db/tableMethods/priceMethods'
 import { selectPricesProductsAndCatalogsForOrganization } from '@/db/tableMethods/priceMethods'
 import * as R from 'ramda'
 import { Price } from '@/db/schema/prices'
@@ -90,10 +89,7 @@ export const editProduct = protectedProcedure
           throw new Error('Product not found or update failed')
         }
         if (input.price) {
-          await editPriceTransaction(
-            { price: input.price },
-            transaction
-          )
+          await safelyUpdatePrice(input.price, transaction)
         }
         return {
           product: updatedProduct,

--- a/platform/flowglad-next/src/stubs/checkoutInfoStubs.ts
+++ b/platform/flowglad-next/src/stubs/checkoutInfoStubs.ts
@@ -10,7 +10,7 @@ import {
   CheckoutSessionStatus,
   CheckoutSessionType,
 } from '@/types'
-import { BillingInfoCore } from '@/db/tableMethods/purchaseMethods'
+import { CheckoutInfoCore } from '@/db/tableMethods/purchaseMethods'
 import { CheckoutSession } from '@/db/schema/checkoutSessions'
 
 const checkoutSession: CheckoutSession.Record = {
@@ -43,7 +43,7 @@ const checkoutSession: CheckoutSession.Record = {
   updatedByCommit: 'test',
 }
 
-const billingInfoDefaults = {
+const checkoutInfoDefaults = {
   redirectUrl: '',
   clientSecret: '',
   checkoutSession,
@@ -54,21 +54,22 @@ const billingInfoDefaults = {
   feeCalculation: null,
 }
 
-export const subscriptionBillingInfoCoreWithTrial: BillingInfoCore = {
-  product: dummyProduct,
-  purchase: subscriptionWithTrialDummyPurchase,
-  price: subscriptionDummyPrice,
-  sellerOrganization: dummyOrganization,
-  flowType: CheckoutFlowType.Subscription,
-  ...billingInfoDefaults,
-}
+export const subscriptionCheckoutInfoCoreWithTrial: CheckoutInfoCore =
+  {
+    product: dummyProduct,
+    purchase: subscriptionWithTrialDummyPurchase,
+    price: subscriptionDummyPrice,
+    sellerOrganization: dummyOrganization,
+    flowType: CheckoutFlowType.Subscription,
+    ...checkoutInfoDefaults,
+  }
 
-export const subscriptionBillingInfoCoreWithoutTrial: BillingInfoCore =
+export const subscriptionCheckoutInfoCoreWithoutTrial: CheckoutInfoCore =
   {
     product: dummyProduct,
     purchase: subscriptionWithoutTrialDummyPurchase,
     price: subscriptionDummyPrice,
     sellerOrganization: dummyOrganization,
     flowType: CheckoutFlowType.Subscription,
-    ...billingInfoDefaults,
+    ...checkoutInfoDefaults,
   }

--- a/platform/flowglad-next/src/utils/catalog.ts
+++ b/platform/flowglad-next/src/utils/catalog.ts
@@ -8,6 +8,7 @@ import {
   bulkInsertPrices,
   insertPrice,
   makePriceDefault,
+  safelyUpdatePrice,
   selectPrices,
   selectPricesAndProductsByProductWhere,
   updatePrice,
@@ -109,13 +110,7 @@ export const editPriceTransaction = async (
     previousPrice?.unitPrice !== price.unitPrice ||
     previousPrice?.intervalUnit !== price.intervalUnit ||
     previousPrice?.intervalCount !== price.intervalCount
-
-  // If we're setting this price as default, update the previous default price
-  if (price.isDefault) {
-    await makePriceDefault(price.id, transaction)
-  }
-
-  return updatePrice(price, transaction)
+  return safelyUpdatePrice(price, transaction)
 }
 
 export const cloneCatalogTransaction = async (

--- a/platform/flowglad-next/src/utils/checkoutHelpers.ts
+++ b/platform/flowglad-next/src/utils/checkoutHelpers.ts
@@ -1,0 +1,158 @@
+import { Price } from '@/db/schema/prices'
+import { CheckoutFlowType } from '@/types'
+import { PriceType } from '@/types'
+import { getPaymentIntent } from './stripe'
+import { getSetupIntent } from './stripe'
+import { findOrCreateCheckoutSession } from './checkoutSessionState'
+import { CheckoutSessionType } from '@/types'
+import { selectDiscountById } from '@/db/tableMethods/discountMethods'
+import { selectCustomerById } from '@/db/tableMethods/customerMethods'
+import { selectLatestFeeCalculation } from '@/db/tableMethods/feeCalculationMethods'
+import { selectPriceProductAndOrganizationByPriceWhere } from '@/db/tableMethods/priceMethods'
+import { adminTransaction } from '@/db/adminTransaction'
+import {
+  CheckoutInfoCore,
+  checkoutInfoSchema,
+  SinglePaymentCheckoutInfoCore,
+} from '@/db/tableMethods/purchaseMethods'
+import core from './core'
+
+interface CheckoutInfoSuccess {
+  checkoutInfo: CheckoutInfoCore
+  success: true
+}
+interface CheckoutInfoError {
+  checkoutInfo: null
+  success: false
+  error: string
+}
+
+type CheckoutInfoResult = CheckoutInfoSuccess | CheckoutInfoError
+export async function checkoutInfoForPriceWhere(
+  priceWhere: Price.Where
+): Promise<CheckoutInfoResult> {
+  const result = await adminTransaction(async ({ transaction }) => {
+    const [{ product, price, organization }] =
+      await selectPriceProductAndOrganizationByPriceWhere(
+        priceWhere,
+        transaction
+      )
+    if (!product.active || !price.active) {
+      // TODO: ERROR PAGE UI
+      return {
+        product,
+        price,
+        organization,
+      }
+    }
+    /**
+     * Attempt to get the saved purchase session (from cookies).
+     * If not found, or the price id does not match, create a new purchase session
+     * and save it to cookies.
+     */
+    const checkoutSession = await findOrCreateCheckoutSession(
+      {
+        productId: product.id,
+        organizationId: organization.id,
+        price,
+        type: CheckoutSessionType.Product,
+      },
+      transaction
+    )
+    const discount = checkoutSession.discountId
+      ? await selectDiscountById(
+          checkoutSession.discountId,
+          transaction
+        )
+      : null
+    const feeCalculation = await selectLatestFeeCalculation(
+      {
+        checkoutSessionId: checkoutSession.id,
+      },
+      transaction
+    )
+    const maybeCustomer = checkoutSession.customerId
+      ? await selectCustomerById(
+          checkoutSession.customerId,
+          transaction
+        )
+      : null
+    return {
+      product,
+      price,
+      organization,
+      checkoutSession,
+      discount,
+      feeCalculation: feeCalculation ?? null,
+      maybeCustomer,
+    }
+  })
+  const { checkoutSession, organization } = result
+  if (!checkoutSession) {
+    // TODO: ERROR PAGE UI
+    return {
+      checkoutInfo: null,
+      success: false,
+      error: `This checkout link is no longer valid. Please contact the ${organization.name} team for assistance.`,
+    }
+  }
+
+  let clientSecret: string | null = null
+  const { product, price, maybeCustomer, discount, feeCalculation } =
+    result
+  if (checkoutSession.stripePaymentIntentId) {
+    const paymentIntent = await getPaymentIntent(
+      checkoutSession.stripePaymentIntentId
+    )
+    clientSecret = paymentIntent.client_secret
+  } else if (checkoutSession.stripeSetupIntentId) {
+    const setupIntent = await getSetupIntent(
+      checkoutSession.stripeSetupIntentId
+    )
+    clientSecret = setupIntent.client_secret
+  }
+  if (price.type === PriceType.SinglePayment) {
+    const rawCheckoutInfo: SinglePaymentCheckoutInfoCore = {
+      product,
+      price,
+      sellerOrganization: organization,
+      flowType: CheckoutFlowType.SinglePayment,
+      redirectUrl: core.safeUrl(
+        `/purchase/post-payment`,
+        core.envVariable('NEXT_PUBLIC_APP_URL')
+      ),
+      clientSecret,
+      checkoutSession,
+      feeCalculation,
+    }
+    return {
+      checkoutInfo: checkoutInfoSchema.parse(rawCheckoutInfo),
+      success: true,
+    }
+  }
+  if (
+    price.type === PriceType.Subscription ||
+    price.type === PriceType.Usage
+  ) {
+    const rawCheckoutInfo: CheckoutInfoCore = {
+      checkoutSession,
+      product,
+      price,
+      sellerOrganization: organization,
+      flowType: CheckoutFlowType.Subscription,
+      redirectUrl: core.safeUrl(
+        `/purchase/post-payment`,
+        core.envVariable('NEXT_PUBLIC_APP_URL')
+      ),
+      clientSecret,
+      readonlyCustomerEmail: maybeCustomer?.email,
+      discount,
+      feeCalculation,
+    }
+    return {
+      checkoutInfo: checkoutInfoSchema.parse(rawCheckoutInfo),
+      success: true,
+    }
+  }
+  throw new Error('Could not derive ')
+}

--- a/platform/flowglad-next/src/utils/checkoutHelpers.ts
+++ b/platform/flowglad-next/src/utils/checkoutHelpers.ts
@@ -16,13 +16,17 @@ import {
   SinglePaymentCheckoutInfoCore,
 } from '@/db/tableMethods/purchaseMethods'
 import core from './core'
+import { Organization } from '@/db/schema/organizations'
 
 interface CheckoutInfoSuccess {
   checkoutInfo: CheckoutInfoCore
+  organization: Organization.Record
   success: true
 }
+
 interface CheckoutInfoError {
   checkoutInfo: null
+  organization: Organization.Record
   success: false
   error: string
 }
@@ -93,6 +97,7 @@ export async function checkoutInfoForPriceWhere(
     return {
       checkoutInfo: null,
       success: false,
+      organization,
       error: `This checkout link is no longer valid. Please contact the ${organization.name} team for assistance.`,
     }
   }
@@ -127,6 +132,7 @@ export async function checkoutInfoForPriceWhere(
     }
     return {
       checkoutInfo: checkoutInfoSchema.parse(rawCheckoutInfo),
+      organization,
       success: true,
     }
   }
@@ -151,6 +157,7 @@ export async function checkoutInfoForPriceWhere(
     }
     return {
       checkoutInfo: checkoutInfoSchema.parse(rawCheckoutInfo),
+      organization,
       success: true,
     }
   }


### PR DESCRIPTION
## What Does this PR Do?
- Creates price-specific checkout links (where previously you could only check out using product links)
- Renames `billingInfo` to `checkoutInfo` in our code, for clarity
- Hoist the logic for constructing checkout session state into its own function for ease of testing, reuse across product and price checkouts
- Create a safer, more stable path for inserting and updating prices