### PR TITLE
Productionize flowglad theme

### DIFF
--- a/.github/workflows/base-ci-cd.yml
+++ b/.github/workflows/base-ci-cd.yml
@@ -233,9 +233,6 @@ jobs:
 
   packages-react-tests:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/react
     env:
       NEXT_PUBLIC_STACK_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
       NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
@@ -270,6 +267,8 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
         run: pnpm install
+      - name: Run build
+        run: pnpm build
       - name: Run tests
         run: pnpm test
-  
+        working-directory: packages/react

--- a/.github/workflows/base-ci-cd.yml
+++ b/.github/workflows/base-ci-cd.yml
@@ -230,4 +230,46 @@ jobs:
         run: pnpm install-packages
       - name: Run lint
         run: pnpm lint
+
+  packages-react-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/react
+    env:
+      NEXT_PUBLIC_STACK_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
+      NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
+      STACK_SECRET_SERVER_KEY: ${{ secrets.STACK_SECRET_SERVER_KEY }}
+      STRIPE_TEST_MODE_SECRET_KEY: ${{ secrets.STRIPE_TEST_MODE_SECRET_KEY }}
+      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+      TRIGGER_SECRET_KEY: ${{ secrets.TRIGGER_SECRET_KEY }}
+      UNKEY_ROOT_KEY: ${{ secrets.UNKEY_ROOT_KEY }}
+      UNKEY_API_ID: ${{ secrets.UNKEY_API_ID }}
+      NEXT_PUBLIC_CDN_URL: ${{ secrets.NEXT_PUBLIC_CDN_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+      - name: Setup pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run tests
+        run: pnpm test
   

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy Production
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -11,10 +14,15 @@ on:
         options:
           - preview
           - production
-
   push:
     branches:
       - stable
+  workflow_run:
+    workflows: ["Build and Deploy Staging"]
+    types:
+      - completed
+    branches:
+      - main
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,7 +14,9 @@
     "lint": "eslint && tsc --noEmit",
     "yalc:publish": "yalc publish && yalc link",
     "build:declarations": "tsc -p tsconfig.declarations.json",
-    "build:css": "tsx scripts/build-css.ts"
+    "build:css": "tsx scripts/build-css.ts",
+    "pretest": "pnpm build:css",
+    "test": "vitest --reporter=verbose"
   },
   "dependencies": {
     "@flowglad/node": "0.19.3",
@@ -26,6 +28,7 @@
     "axios": "1.8.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "2.1.1",
+    "@adobe/css-tools": "4.4.2",
     "date-fns": "4.1.0",
     "lucide-react": "0.479.0",
     "tailwind-merge": "3.0.2",
@@ -38,10 +41,17 @@
     "@types/react": "18.3.12",
     "autoprefixer": "^10.4.18",
     "eslint": "8.57.0",
+    "jsdom": "26.1.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "ts-node": "^10.9.2",
-    "typescript": "5.8.2"
+    "typescript": "5.8.2",
+    "vitest": "3.0.5",
+    "@vitejs/plugin-react": "4.3.4",
+    "@testing-library/react": "16.3.0",
+    "@types/css": "0.0.38",
+    "@testing-library/dom": "10.4.0",
+    "@testing-library/jest-dom": "6.6.3"
   },
   "exports": {
     ".": {

--- a/packages/react/src/FlowgladProvider.tsx
+++ b/packages/react/src/FlowgladProvider.tsx
@@ -9,6 +9,7 @@ import {
   RequestConfig,
 } from './FlowgladContext'
 import { validateUrl } from './utils'
+import { FlowgladTheme, FlowgladThemeConfig } from './FlowgladTheme'
 const queryClient = new QueryClient()
 
 export interface Appearance {
@@ -20,12 +21,14 @@ export const FlowgladProvider = ({
   loadBilling,
   serverRoute,
   requestConfig,
+  theme,
 }: {
   children: React.ReactNode
   appearance?: Appearance
   requestConfig?: RequestConfig
   serverRoute?: string
   loadBilling: boolean
+  theme?: FlowgladThemeConfig
 }) => {
   validateUrl(serverRoute, 'serverRoute', true)
   return (
@@ -35,7 +38,7 @@ export const FlowgladProvider = ({
         loadBilling={loadBilling}
         requestConfig={requestConfig}
       >
-        {children}
+        <FlowgladTheme theme={theme}>{children}</FlowgladTheme>
       </FlowgladContextProvider>
     </QueryClientProvider>
   )

--- a/packages/react/src/FlowgladProvider.tsx
+++ b/packages/react/src/FlowgladProvider.tsx
@@ -9,7 +9,9 @@ import {
   RequestConfig,
 } from './FlowgladContext'
 import { validateUrl } from './utils'
-import { FlowgladTheme, FlowgladThemeConfig } from './FlowgladTheme'
+import { FlowgladTheme } from './FlowgladTheme'
+import { FlowgladThemeConfig } from './lib/themes'
+
 const queryClient = new QueryClient()
 
 export interface Appearance {

--- a/packages/react/src/FlowgladTheme.test.ts
+++ b/packages/react/src/FlowgladTheme.test.ts
@@ -1,0 +1,1188 @@
+import { describe, it, expect } from 'vitest'
+import {
+  themeEntryToCss,
+  themeToCss,
+  themeEntryToCssAst,
+  themeToCssAst,
+  FlowgladThemeConfig,
+} from './FlowgladTheme'
+
+// Define the FlowgladColors interface for testing
+interface FlowgladColors {
+  containerBackground: string
+  containerForeground: string
+  border: string
+  buttonBackground: string
+  buttonForeground: string
+  destructive: string
+  destructiveForeground: string
+}
+
+// Define types for CSS AST
+interface CssDeclaration {
+  type: string
+  property: string
+  value: string
+}
+
+// Import css-tools dynamically
+let cssTools: { parse: any } | null = null
+
+// Initialize css-tools
+const initCssTools = async () => {
+  if (!cssTools) {
+    const module = await import('@adobe/css-tools')
+    cssTools = {
+      parse: module.parse,
+    }
+  }
+  return cssTools
+}
+
+describe('themeEntryToCssAst', () => {
+  it('should create a valid CSS AST rule for a theme entry', () => {
+    const themeEntry: [keyof FlowgladColors, string] = [
+      'containerBackground',
+      '#ffffff',
+    ]
+    const ast = themeEntryToCssAst(themeEntry)
+
+    expect(ast.type).toBe('rule')
+    expect(ast.selectors).toEqual(['.flowglad-root'])
+    expect(ast.declarations).toHaveLength(1)
+    expect(ast.declarations?.[0].type).toBe('declaration')
+    expect(ast.declarations?.[0].property).toBe(
+      '--flowglad-background'
+    )
+    expect(ast.declarations?.[0].value).toBe('#ffffff')
+  })
+})
+
+describe('themeToCssAst', () => {
+  it('should return an empty stylesheet when theme is undefined', () => {
+    const ast = themeToCssAst(undefined)
+    expect(ast.type).toBe('stylesheet')
+    expect(ast.stylesheet?.rules).toHaveLength(0)
+  })
+
+  it('should create a valid CSS AST stylesheet for a light theme', () => {
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        border: '#cccccc',
+        buttonBackground: '#007bff',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+      dark: {
+        containerBackground: '#121212',
+        containerForeground: '#ffffff',
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const ast = themeToCssAst(theme)
+    expect(ast.type).toBe('stylesheet')
+    expect(ast.stylesheet?.rules).toHaveLength(2)
+
+    const rule = ast.stylesheet?.rules[0]
+    expect(rule.type).toBe('rule')
+    expect(rule.selectors).toEqual(['.flowglad-root'])
+    expect(rule.declarations).toHaveLength(7)
+
+    // Verify that .flowglad-root class doesn't include any styles on its own
+    const rootDeclarations = rule.declarations
+    expect(
+      rootDeclarations.every((d: CssDeclaration) =>
+        d.property.startsWith('--flowglad-')
+      )
+    ).toBe(true)
+    expect(
+      rootDeclarations.some(
+        (d: CssDeclaration) =>
+          d.property === 'background' || d.property === 'color'
+      )
+    ).toBe(false)
+
+    // Check that each property is correctly mapped
+    const declarations = rule.declarations
+    expect(
+      declarations.find(
+        (d: CssDeclaration) => d.property === '--flowglad-background'
+      )?.value
+    ).toBe('#ffffff')
+    expect(
+      declarations.find(
+        (d: CssDeclaration) => d.property === '--flowglad-foreground'
+      )?.value
+    ).toBe('#000000')
+    expect(
+      declarations.find(
+        (d: CssDeclaration) => d.property === '--flowglad-border'
+      )?.value
+    ).toBe('#cccccc')
+    expect(
+      declarations.find(
+        (d: CssDeclaration) => d.property === '--flowglad-button'
+      )?.value
+    ).toBe('#007bff')
+    expect(
+      declarations.find(
+        (d: CssDeclaration) =>
+          d.property === '--flowglad-button-foreground'
+      )?.value
+    ).toBe('#ffffff')
+    expect(
+      declarations.find(
+        (d: CssDeclaration) => d.property === '--flowglad-destructive'
+      )?.value
+    ).toBe('#dc3545')
+    expect(
+      declarations.find(
+        (d: CssDeclaration) =>
+          d.property === '--flowglad-destructive-foreground'
+      )?.value
+    ).toBe('#ffffff')
+  })
+
+  it('should create a valid CSS AST stylesheet for a dark theme', () => {
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        border: '#cccccc',
+        buttonBackground: '#007bff',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+      dark: {
+        containerBackground: '#121212',
+        containerForeground: '#ffffff',
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const ast = themeToCssAst(theme)
+    expect(ast.type).toBe('stylesheet')
+    expect(ast.stylesheet?.rules).toHaveLength(2)
+
+    const darkRule = ast.stylesheet?.rules[1]
+    expect(darkRule.type).toBe('rule')
+    expect(darkRule.selectors).toEqual(['.flowglad-dark'])
+    expect(darkRule.declarations).toHaveLength(7)
+
+    // Verify that .flowglad-dark class doesn't include any styles on its own
+    const darkDeclarations = darkRule.declarations
+    expect(
+      darkDeclarations.every((d: CssDeclaration) =>
+        d.property.startsWith('--flowglad-')
+      )
+    ).toBe(true)
+    expect(
+      darkDeclarations.some(
+        (d: CssDeclaration) =>
+          d.property === 'background' || d.property === 'color'
+      )
+    ).toBe(false)
+
+    // Check that each property is correctly mapped
+    const declarations = darkRule.declarations
+    expect(
+      declarations.find(
+        (d: CssDeclaration) => d.property === '--flowglad-background'
+      )?.value
+    ).toBe('#121212')
+    expect(
+      declarations.find(
+        (d: CssDeclaration) => d.property === '--flowglad-foreground'
+      )?.value
+    ).toBe('#ffffff')
+    expect(
+      declarations.find(
+        (d: CssDeclaration) => d.property === '--flowglad-border'
+      )?.value
+    ).toBe('#333333')
+    expect(
+      declarations.find(
+        (d: CssDeclaration) => d.property === '--flowglad-button'
+      )?.value
+    ).toBe('#0d6efd')
+    expect(
+      declarations.find(
+        (d: CssDeclaration) =>
+          d.property === '--flowglad-button-foreground'
+      )?.value
+    ).toBe('#ffffff')
+    expect(
+      declarations.find(
+        (d: CssDeclaration) => d.property === '--flowglad-destructive'
+      )?.value
+    ).toBe('#dc3545')
+    expect(
+      declarations.find(
+        (d: CssDeclaration) =>
+          d.property === '--flowglad-destructive-foreground'
+      )?.value
+    ).toBe('#ffffff')
+  })
+
+  it('should create a valid CSS AST stylesheet for both light and dark themes', () => {
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        border: '#cccccc',
+        buttonBackground: '#007bff',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+      dark: {
+        containerBackground: '#121212',
+        containerForeground: '#ffffff',
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const ast = themeToCssAst(theme)
+    expect(ast.type).toBe('stylesheet')
+    expect(ast.stylesheet?.rules).toHaveLength(2)
+
+    // Check light theme rule
+    const lightRule = ast.stylesheet?.rules[0]
+    expect(lightRule.type).toBe('rule')
+    expect(lightRule.selectors).toEqual(['.flowglad-root'])
+
+    // Verify that .flowglad-root class doesn't include any styles on its own
+    const rootDeclarations = lightRule.declarations
+    expect(
+      rootDeclarations.every((d: CssDeclaration) =>
+        d.property.startsWith('--flowglad-')
+      )
+    ).toBe(true)
+    expect(
+      rootDeclarations.some(
+        (d: CssDeclaration) =>
+          d.property === 'background' || d.property === 'color'
+      )
+    ).toBe(false)
+
+    // Check dark theme rule
+    const darkRule = ast.stylesheet?.rules[1]
+    expect(darkRule.type).toBe('rule')
+    expect(darkRule.selectors).toEqual(['.flowglad-dark'])
+
+    // Verify that .flowglad-dark class doesn't include any styles on its own
+    const darkDeclarations = darkRule.declarations
+    expect(
+      darkDeclarations.every((d: CssDeclaration) =>
+        d.property.startsWith('--flowglad-')
+      )
+    ).toBe(true)
+    expect(
+      darkDeclarations.some(
+        (d: CssDeclaration) =>
+          d.property === 'background' || d.property === 'color'
+      )
+    ).toBe(false)
+  })
+
+  it('should ensure .flowglad-root class only contains CSS custom properties', () => {
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        border: '#cccccc',
+        buttonBackground: '#007bff',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+      dark: {
+        containerBackground: '#121212',
+        containerForeground: '#ffffff',
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const ast = themeToCssAst(theme)
+    const rootRule = ast.stylesheet?.rules[0]
+    const rootDeclarations = rootRule.declarations
+
+    // Verify all declarations are CSS custom properties
+    expect(
+      rootDeclarations.every((d: CssDeclaration) =>
+        d.property.startsWith('--flowglad-')
+      )
+    ).toBe(true)
+
+    // Verify no direct styling properties are present
+    const directStylingProperties = [
+      'background',
+      'color',
+      'border',
+      'font',
+      'margin',
+      'padding',
+      'display',
+      'position',
+    ]
+    directStylingProperties.forEach((prop) => {
+      expect(
+        rootDeclarations.some(
+          (d: CssDeclaration) => d.property === prop
+        )
+      ).toBe(false)
+    })
+
+    // Verify all properties follow the expected pattern
+    const expectedProperties = [
+      '--flowglad-background',
+      '--flowglad-foreground',
+      '--flowglad-border',
+      '--flowglad-button',
+      '--flowglad-button-foreground',
+      '--flowglad-destructive',
+      '--flowglad-destructive-foreground',
+    ]
+    expectedProperties.forEach((prop) => {
+      expect(
+        rootDeclarations.some(
+          (d: CssDeclaration) => d.property === prop
+        )
+      ).toBe(true)
+    })
+  })
+
+  it('should ensure .flowglad-dark class only contains CSS custom properties', () => {
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        border: '#cccccc',
+        buttonBackground: '#007bff',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+      dark: {
+        containerBackground: '#121212',
+        containerForeground: '#ffffff',
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const ast = themeToCssAst(theme)
+    const darkRule = ast.stylesheet?.rules[1]
+    const darkDeclarations = darkRule.declarations
+
+    // Verify all declarations are CSS custom properties
+    expect(
+      darkDeclarations.every((d: CssDeclaration) =>
+        d.property.startsWith('--flowglad-')
+      )
+    ).toBe(true)
+
+    // Verify no direct styling properties are present
+    const directStylingProperties = [
+      'background',
+      'color',
+      'border',
+      'font',
+      'margin',
+      'padding',
+      'display',
+      'position',
+    ]
+    directStylingProperties.forEach((prop) => {
+      expect(
+        darkDeclarations.some(
+          (d: CssDeclaration) => d.property === prop
+        )
+      ).toBe(false)
+    })
+
+    // Verify all properties follow the expected pattern
+    const expectedProperties = [
+      '--flowglad-background',
+      '--flowglad-foreground',
+      '--flowglad-border',
+      '--flowglad-button',
+      '--flowglad-button-foreground',
+      '--flowglad-destructive',
+      '--flowglad-destructive-foreground',
+    ]
+    expectedProperties.forEach((prop) => {
+      expect(
+        darkDeclarations.some(
+          (d: CssDeclaration) => d.property === prop
+        )
+      ).toBe(true)
+    })
+  })
+
+  it('should not override defaults for properties not defined in partial theme configs', () => {
+    // Create a partial theme config with only some properties defined
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        // containerForeground is not defined
+        border: '#cccccc',
+        // buttonBackground is not defined
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        // destructiveForeground is not defined
+      },
+      dark: {
+        containerBackground: '#121212',
+        // containerForeground is not defined
+        border: '#333333',
+        // buttonBackground is not defined
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        // destructiveForeground is not defined
+      },
+    }
+
+    const ast = themeToCssAst(theme)
+    expect(ast.type).toBe('stylesheet')
+    expect(ast.stylesheet?.rules).toHaveLength(2)
+
+    // Check light theme rule
+    const lightRule = ast.stylesheet?.rules[0]
+    expect(lightRule.type).toBe('rule')
+    expect(lightRule.selectors).toEqual(['.flowglad-root'])
+
+    // Verify only the defined properties are included
+    const lightDeclarations = lightRule.declarations
+    expect(lightDeclarations).toHaveLength(4) // Only 4 properties defined
+
+    // Check that only the defined properties are present
+    const lightProperties = lightDeclarations.map(
+      (d: CssDeclaration) => d.property
+    )
+    expect(lightProperties).toContain('--flowglad-background')
+    expect(lightProperties).not.toContain('--flowglad-foreground')
+    expect(lightProperties).toContain('--flowglad-border')
+    expect(lightProperties).not.toContain('--flowglad-button')
+    expect(lightProperties).toContain('--flowglad-button-foreground')
+    expect(lightProperties).toContain('--flowglad-destructive')
+    expect(lightProperties).not.toContain(
+      '--flowglad-destructive-foreground'
+    )
+
+    // Check dark theme rule
+    const darkRule = ast.stylesheet?.rules[1]
+    expect(darkRule.type).toBe('rule')
+    expect(darkRule.selectors).toEqual(['.flowglad-dark'])
+
+    // Verify only the defined properties are included
+    const darkDeclarations = darkRule.declarations
+    expect(darkDeclarations).toHaveLength(4) // Only 4 properties defined
+
+    // Check that only the defined properties are present
+    const darkProperties = darkDeclarations.map(
+      (d: CssDeclaration) => d.property
+    )
+    expect(darkProperties).toContain('--flowglad-background')
+    expect(darkProperties).not.toContain('--flowglad-foreground')
+    expect(darkProperties).toContain('--flowglad-border')
+    expect(darkProperties).not.toContain('--flowglad-button')
+    expect(darkProperties).toContain('--flowglad-button-foreground')
+    expect(darkProperties).toContain('--flowglad-destructive')
+    expect(darkProperties).not.toContain(
+      '--flowglad-destructive-foreground'
+    )
+  })
+
+  it('should handle theme configs with only light or only dark mode', () => {
+    // Test with only light mode
+    const lightOnlyTheme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        border: '#cccccc',
+        buttonBackground: '#007bff',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const lightOnlyAst = themeToCssAst(lightOnlyTheme)
+    expect(lightOnlyAst.type).toBe('stylesheet')
+    expect(lightOnlyAst.stylesheet?.rules).toHaveLength(1)
+    expect(lightOnlyAst.stylesheet?.rules[0].selectors).toEqual([
+      '.flowglad-root',
+    ])
+    expect(
+      lightOnlyAst.stylesheet?.rules[0].declarations
+    ).toHaveLength(7)
+
+    // Test with only dark mode
+    const darkOnlyTheme: FlowgladThemeConfig = {
+      dark: {
+        containerBackground: '#121212',
+        containerForeground: '#ffffff',
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const darkOnlyAst = themeToCssAst(darkOnlyTheme)
+    expect(darkOnlyAst.type).toBe('stylesheet')
+    expect(darkOnlyAst.stylesheet?.rules).toHaveLength(1)
+    expect(darkOnlyAst.stylesheet?.rules[0].selectors).toEqual([
+      '.flowglad-dark',
+    ])
+    expect(
+      darkOnlyAst.stylesheet?.rules[0].declarations
+    ).toHaveLength(7)
+  })
+
+  it('should handle heterogeneous shapes of light and dark configs', () => {
+    // Create a theme config with different properties defined for light and dark
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        // Other light properties are not defined
+      },
+      dark: {
+        // Only some dark properties are defined
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        destructive: '#dc3545',
+      },
+    }
+
+    const ast = themeToCssAst(theme)
+    expect(ast.type).toBe('stylesheet')
+    expect(ast.stylesheet?.rules).toHaveLength(2)
+
+    // Check light theme rule
+    const lightRule = ast.stylesheet?.rules[0]
+    expect(lightRule.type).toBe('rule')
+    expect(lightRule.selectors).toEqual(['.flowglad-root'])
+
+    // Verify only the defined light properties are included
+    const lightDeclarations = lightRule.declarations
+    expect(lightDeclarations).toHaveLength(2) // Only 2 properties defined for light
+
+    // Check that only the defined light properties are present
+    const lightProperties = lightDeclarations.map(
+      (d: CssDeclaration) => d.property
+    )
+    expect(lightProperties).toContain('--flowglad-background')
+    expect(lightProperties).toContain('--flowglad-foreground')
+    expect(lightProperties).not.toContain('--flowglad-border')
+    expect(lightProperties).not.toContain('--flowglad-button')
+    expect(lightProperties).not.toContain(
+      '--flowglad-button-foreground'
+    )
+    expect(lightProperties).not.toContain('--flowglad-destructive')
+    expect(lightProperties).not.toContain(
+      '--flowglad-destructive-foreground'
+    )
+
+    // Check dark theme rule
+    const darkRule = ast.stylesheet?.rules[1]
+    expect(darkRule.type).toBe('rule')
+    expect(darkRule.selectors).toEqual(['.flowglad-dark'])
+
+    // Verify only the defined dark properties are included
+    const darkDeclarations = darkRule.declarations
+    expect(darkDeclarations).toHaveLength(3) // Only 3 properties defined for dark
+
+    // Check that only the defined dark properties are present
+    const darkProperties = darkDeclarations.map(
+      (d: CssDeclaration) => d.property
+    )
+    expect(darkProperties).not.toContain('--flowglad-background')
+    expect(darkProperties).not.toContain('--flowglad-foreground')
+    expect(darkProperties).toContain('--flowglad-border')
+    expect(darkProperties).toContain('--flowglad-button')
+    expect(darkProperties).not.toContain(
+      '--flowglad-button-foreground'
+    )
+    expect(darkProperties).toContain('--flowglad-destructive')
+    expect(darkProperties).not.toContain(
+      '--flowglad-destructive-foreground'
+    )
+  })
+})
+
+describe('themeEntryToCss', () => {
+  it('should convert a theme entry to a CSS string', async () => {
+    const themeEntry: [keyof FlowgladColors, string] = [
+      'containerBackground',
+      '#ffffff',
+    ]
+    const cssString = await themeEntryToCss(themeEntry)
+
+    // Parse the CSS string to verify it's valid
+    const tools = await initCssTools()
+    const ast = tools.parse(cssString)
+    expect(ast.type).toBe('stylesheet')
+    expect(ast.stylesheet?.rules).toHaveLength(1)
+
+    const rule = ast.stylesheet?.rules[0]
+    expect(rule.type).toBe('rule')
+    expect(rule.selectors).toEqual(['.flowglad-root'])
+    expect(rule.declarations).toHaveLength(1)
+
+    const declaration = rule.declarations?.[0]
+    expect(declaration.property).toBe('--flowglad-background')
+    expect(declaration.value).toBe('#ffffff')
+  })
+})
+
+describe('themeToCss', () => {
+  it('should return an empty string when theme is undefined', async () => {
+    const cssString = await themeToCss(undefined)
+    expect(cssString).toBe('')
+  })
+
+  it('should convert a light theme to a CSS string', async () => {
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        border: '#cccccc',
+        buttonBackground: '#007bff',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+      dark: {
+        containerBackground: '#121212',
+        containerForeground: '#ffffff',
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const cssString = await themeToCss(theme)
+
+    // Parse the CSS string to verify it's valid
+    const tools = await initCssTools()
+    const ast = tools.parse(cssString)
+    expect(ast.type).toBe('stylesheet')
+    expect(ast.stylesheet?.rules).toHaveLength(2)
+
+    const lightRule = ast.stylesheet?.rules[0]
+    expect(lightRule.type).toBe('rule')
+    expect(lightRule.selectors).toEqual(['.flowglad-root'])
+    expect(lightRule.declarations).toHaveLength(7)
+
+    // Verify that .flowglad-root class doesn't include any styles on its own
+    const rootDeclarations = lightRule.declarations
+    expect(
+      rootDeclarations.every((d: CssDeclaration) =>
+        d.property.startsWith('--flowglad-')
+      )
+    ).toBe(true)
+    expect(
+      rootDeclarations.some(
+        (d: CssDeclaration) =>
+          d.property === 'background' || d.property === 'color'
+      )
+    ).toBe(false)
+  })
+
+  it('should convert a dark theme to a CSS string', async () => {
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        border: '#cccccc',
+        buttonBackground: '#007bff',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+      dark: {
+        containerBackground: '#121212',
+        containerForeground: '#ffffff',
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const cssString = await themeToCss(theme)
+
+    // Parse the CSS string to verify it's valid
+    const tools = await initCssTools()
+    const ast = tools.parse(cssString)
+    expect(ast.type).toBe('stylesheet')
+    expect(ast.stylesheet?.rules).toHaveLength(2)
+
+    const darkRule = ast.stylesheet?.rules[1]
+    expect(darkRule.type).toBe('rule')
+    expect(darkRule.selectors).toEqual(['.flowglad-dark'])
+    expect(darkRule.declarations).toHaveLength(7)
+
+    // Verify that .flowglad-dark class doesn't include any styles on its own
+    const darkDeclarations = darkRule.declarations
+    expect(
+      darkDeclarations.every((d: CssDeclaration) =>
+        d.property.startsWith('--flowglad-')
+      )
+    ).toBe(true)
+    expect(
+      darkDeclarations.some(
+        (d: CssDeclaration) =>
+          d.property === 'background' || d.property === 'color'
+      )
+    ).toBe(false)
+  })
+
+  it('should convert both light and dark themes to a CSS string', async () => {
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        border: '#cccccc',
+        buttonBackground: '#007bff',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+      dark: {
+        containerBackground: '#121212',
+        containerForeground: '#ffffff',
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const cssString = await themeToCss(theme)
+
+    // Parse the CSS string to verify it's valid
+    const tools = await initCssTools()
+    const ast = tools.parse(cssString)
+    expect(ast.type).toBe('stylesheet')
+    expect(ast.stylesheet?.rules).toHaveLength(2)
+
+    const lightRule = ast.stylesheet?.rules[0]
+    expect(lightRule.type).toBe('rule')
+    expect(lightRule.selectors).toEqual(['.flowglad-root'])
+
+    // Verify that .flowglad-root class doesn't include any styles on its own
+    const rootDeclarations = lightRule.declarations
+    expect(
+      rootDeclarations.every((d: CssDeclaration) =>
+        d.property.startsWith('--flowglad-')
+      )
+    ).toBe(true)
+    expect(
+      rootDeclarations.some(
+        (d: CssDeclaration) =>
+          d.property === 'background' || d.property === 'color'
+      )
+    ).toBe(false)
+
+    const darkRule = ast.stylesheet?.rules[1]
+    expect(darkRule.type).toBe('rule')
+    expect(darkRule.selectors).toEqual(['.flowglad-dark'])
+
+    // Verify that .flowglad-dark class doesn't include any styles on its own
+    const darkDeclarations = darkRule.declarations
+    expect(
+      darkDeclarations.every((d: CssDeclaration) =>
+        d.property.startsWith('--flowglad-')
+      )
+    ).toBe(true)
+    expect(
+      darkDeclarations.some(
+        (d: CssDeclaration) =>
+          d.property === 'background' || d.property === 'color'
+      )
+    ).toBe(false)
+  })
+
+  it('should ensure .flowglad-root class in CSS string only contains CSS custom properties', async () => {
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        border: '#cccccc',
+        buttonBackground: '#007bff',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+      dark: {
+        containerBackground: '#121212',
+        containerForeground: '#ffffff',
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const cssString = await themeToCss(theme)
+    const tools = await initCssTools()
+    const ast = tools.parse(cssString)
+    const rootRule = ast.stylesheet?.rules[0]
+    const rootDeclarations = rootRule.declarations
+
+    // Verify all declarations are CSS custom properties
+    expect(
+      rootDeclarations.every((d: CssDeclaration) =>
+        d.property.startsWith('--flowglad-')
+      )
+    ).toBe(true)
+
+    // Verify no direct styling properties are present
+    const directStylingProperties = [
+      'background',
+      'color',
+      'border',
+      'font',
+      'margin',
+      'padding',
+      'display',
+      'position',
+    ]
+    directStylingProperties.forEach((prop) => {
+      expect(
+        rootDeclarations.some(
+          (d: CssDeclaration) => d.property === prop
+        )
+      ).toBe(false)
+    })
+
+    // Verify all properties follow the expected pattern
+    const expectedProperties = [
+      '--flowglad-background',
+      '--flowglad-foreground',
+      '--flowglad-border',
+      '--flowglad-button',
+      '--flowglad-button-foreground',
+      '--flowglad-destructive',
+      '--flowglad-destructive-foreground',
+    ]
+    expectedProperties.forEach((prop) => {
+      expect(
+        rootDeclarations.some(
+          (d: CssDeclaration) => d.property === prop
+        )
+      ).toBe(true)
+    })
+  })
+
+  it('should ensure .flowglad-dark class in CSS string only contains CSS custom properties', async () => {
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        border: '#cccccc',
+        buttonBackground: '#007bff',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+      dark: {
+        containerBackground: '#121212',
+        containerForeground: '#ffffff',
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const cssString = await themeToCss(theme)
+    const tools = await initCssTools()
+    const ast = tools.parse(cssString)
+    const darkRule = ast.stylesheet?.rules[1]
+    const darkDeclarations = darkRule.declarations
+
+    // Verify all declarations are CSS custom properties
+    expect(
+      darkDeclarations.every((d: CssDeclaration) =>
+        d.property.startsWith('--flowglad-')
+      )
+    ).toBe(true)
+
+    // Verify no direct styling properties are present
+    const directStylingProperties = [
+      'background',
+      'color',
+      'border',
+      'font',
+      'margin',
+      'padding',
+      'display',
+      'position',
+    ]
+    directStylingProperties.forEach((prop) => {
+      expect(
+        darkDeclarations.some(
+          (d: CssDeclaration) => d.property === prop
+        )
+      ).toBe(false)
+    })
+
+    // Verify all properties follow the expected pattern
+    const expectedProperties = [
+      '--flowglad-background',
+      '--flowglad-foreground',
+      '--flowglad-border',
+      '--flowglad-button',
+      '--flowglad-button-foreground',
+      '--flowglad-destructive',
+      '--flowglad-destructive-foreground',
+    ]
+    expectedProperties.forEach((prop) => {
+      expect(
+        darkDeclarations.some(
+          (d: CssDeclaration) => d.property === prop
+        )
+      ).toBe(true)
+    })
+  })
+
+  it('should not override defaults for properties not defined in partial theme configs', async () => {
+    // Create a partial theme config with only some properties defined
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        // containerForeground is not defined
+        border: '#cccccc',
+        // buttonBackground is not defined
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        // destructiveForeground is not defined
+      },
+      dark: {
+        containerBackground: '#121212',
+        // containerForeground is not defined
+        border: '#333333',
+        // buttonBackground is not defined
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        // destructiveForeground is not defined
+      },
+    }
+
+    const cssString = await themeToCss(theme)
+
+    // Parse the CSS string to verify it's valid
+    const tools = await initCssTools()
+    const ast = tools.parse(cssString)
+    expect(ast.type).toBe('stylesheet')
+    expect(ast.stylesheet?.rules).toHaveLength(2)
+
+    // Check light theme rule
+    const lightRule = ast.stylesheet?.rules[0]
+    expect(lightRule.type).toBe('rule')
+    expect(lightRule.selectors).toEqual(['.flowglad-root'])
+
+    // Verify only the defined properties are included
+    const lightDeclarations = lightRule.declarations
+    expect(lightDeclarations).toHaveLength(4) // Only 4 properties defined
+
+    // Check that only the defined properties are present
+    const lightProperties = lightDeclarations.map(
+      (d: CssDeclaration) => d.property
+    )
+    expect(lightProperties).toContain('--flowglad-background')
+    expect(lightProperties).not.toContain('--flowglad-foreground')
+    expect(lightProperties).toContain('--flowglad-border')
+    expect(lightProperties).not.toContain('--flowglad-button')
+    expect(lightProperties).toContain('--flowglad-button-foreground')
+    expect(lightProperties).toContain('--flowglad-destructive')
+    expect(lightProperties).not.toContain(
+      '--flowglad-destructive-foreground'
+    )
+
+    // Check dark theme rule
+    const darkRule = ast.stylesheet?.rules[1]
+    expect(darkRule.type).toBe('rule')
+    expect(darkRule.selectors).toEqual(['.flowglad-dark'])
+
+    // Verify only the defined properties are included
+    const darkDeclarations = darkRule.declarations
+    expect(darkDeclarations).toHaveLength(4) // Only 4 properties defined
+
+    // Check that only the defined properties are present
+    const darkProperties = darkDeclarations.map(
+      (d: CssDeclaration) => d.property
+    )
+    expect(darkProperties).toContain('--flowglad-background')
+    expect(darkProperties).not.toContain('--flowglad-foreground')
+    expect(darkProperties).toContain('--flowglad-border')
+    expect(darkProperties).not.toContain('--flowglad-button')
+    expect(darkProperties).toContain('--flowglad-button-foreground')
+    expect(darkProperties).toContain('--flowglad-destructive')
+    expect(darkProperties).not.toContain(
+      '--flowglad-destructive-foreground'
+    )
+  })
+
+  it('should handle theme configs with only light or only dark mode', async () => {
+    // Test with only light mode
+    const lightOnlyTheme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        border: '#cccccc',
+        buttonBackground: '#007bff',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const lightOnlyCssString = await themeToCss(lightOnlyTheme)
+    const tools = await initCssTools()
+    const lightOnlyAst = tools.parse(lightOnlyCssString)
+    expect(lightOnlyAst.type).toBe('stylesheet')
+    expect(lightOnlyAst.stylesheet?.rules).toHaveLength(1)
+    expect(lightOnlyAst.stylesheet?.rules[0].selectors).toEqual([
+      '.flowglad-root',
+    ])
+    expect(
+      lightOnlyAst.stylesheet?.rules[0].declarations
+    ).toHaveLength(7)
+
+    // Test with only dark mode
+    const darkOnlyTheme: FlowgladThemeConfig = {
+      dark: {
+        containerBackground: '#121212',
+        containerForeground: '#ffffff',
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        buttonForeground: '#ffffff',
+        destructive: '#dc3545',
+        destructiveForeground: '#ffffff',
+      },
+    }
+
+    const darkOnlyCssString = await themeToCss(darkOnlyTheme)
+    const darkOnlyAst = tools.parse(darkOnlyCssString)
+    expect(darkOnlyAst.type).toBe('stylesheet')
+    expect(darkOnlyAst.stylesheet?.rules).toHaveLength(1)
+    expect(darkOnlyAst.stylesheet?.rules[0].selectors).toEqual([
+      '.flowglad-dark',
+    ])
+    expect(
+      darkOnlyAst.stylesheet?.rules[0].declarations
+    ).toHaveLength(7)
+  })
+
+  it('should handle heterogeneous shapes of light and dark configs', async () => {
+    // Create a theme config with different properties defined for light and dark
+    const theme: FlowgladThemeConfig = {
+      light: {
+        containerBackground: '#ffffff',
+        containerForeground: '#000000',
+        // Other light properties are not defined
+      },
+      dark: {
+        // Only some dark properties are defined
+        border: '#333333',
+        buttonBackground: '#0d6efd',
+        destructive: '#dc3545',
+      },
+    }
+
+    const cssString = await themeToCss(theme)
+
+    // Parse the CSS string to verify it's valid
+    const tools = await initCssTools()
+    const ast = tools.parse(cssString)
+    expect(ast.type).toBe('stylesheet')
+    expect(ast.stylesheet?.rules).toHaveLength(2)
+
+    // Check light theme rule
+    const lightRule = ast.stylesheet?.rules[0]
+    expect(lightRule.type).toBe('rule')
+    expect(lightRule.selectors).toEqual(['.flowglad-root'])
+
+    // Verify only the defined light properties are included
+    const lightDeclarations = lightRule.declarations
+    expect(lightDeclarations).toHaveLength(2) // Only 2 properties defined for light
+
+    // Check that only the defined light properties are present
+    const lightProperties = lightDeclarations.map(
+      (d: CssDeclaration) => d.property
+    )
+    expect(lightProperties).toContain('--flowglad-background')
+    expect(lightProperties).toContain('--flowglad-foreground')
+    expect(lightProperties).not.toContain('--flowglad-border')
+    expect(lightProperties).not.toContain('--flowglad-button')
+    expect(lightProperties).not.toContain(
+      '--flowglad-button-foreground'
+    )
+    expect(lightProperties).not.toContain('--flowglad-destructive')
+    expect(lightProperties).not.toContain(
+      '--flowglad-destructive-foreground'
+    )
+
+    // Check dark theme rule
+    const darkRule = ast.stylesheet?.rules[1]
+    expect(darkRule.type).toBe('rule')
+    expect(darkRule.selectors).toEqual(['.flowglad-dark'])
+
+    // Verify only the defined dark properties are included
+    const darkDeclarations = darkRule.declarations
+    expect(darkDeclarations).toHaveLength(3) // Only 3 properties defined for dark
+
+    // Check that only the defined dark properties are present
+    const darkProperties = darkDeclarations.map(
+      (d: CssDeclaration) => d.property
+    )
+    expect(darkProperties).not.toContain('--flowglad-background')
+    expect(darkProperties).not.toContain('--flowglad-foreground')
+    expect(darkProperties).toContain('--flowglad-border')
+    expect(darkProperties).toContain('--flowglad-button')
+    expect(darkProperties).not.toContain(
+      '--flowglad-button-foreground'
+    )
+    expect(darkProperties).toContain('--flowglad-destructive')
+    expect(darkProperties).not.toContain(
+      '--flowglad-destructive-foreground'
+    )
+  })
+})

--- a/packages/react/src/FlowgladTheme.tsx
+++ b/packages/react/src/FlowgladTheme.tsx
@@ -182,6 +182,7 @@ interface FlowgladColors {
 export interface FlowgladThemeConfig {
   light?: Partial<FlowgladColors>
   dark?: Partial<FlowgladColors>
+  mode?: 'light' | 'dark' | 'system'
 }
 
 interface FlowgladThemeProps {
@@ -193,28 +194,27 @@ interface FlowgladThemeProps {
 
 export function FlowgladTheme({
   children,
-  darkMode,
   theme,
   nonce,
 }: FlowgladThemeProps) {
   const isDarkTheme = useThemeDetector()
   const [cssString, setCssString] = useState<string>('')
-
+  const mode = theme?.mode ?? 'system'
   useEffect(() => {
     // Apply the class to the html element
     document.documentElement.classList.add('flowglad-root')
     // Apply the base theme class to the html element
     document.documentElement.classList.add('flowglad-base-theme')
-    // If darkMode is provided, apply the class to the html element
-    // If darkMode is not provided, use the system theme
-    if (typeof darkMode === 'boolean') {
-      if (darkMode) {
-        document.documentElement.classList.add('flowglad-dark')
-      } else {
-        document.documentElement.classList.remove('flowglad-dark')
-      }
-    } else if (isDarkTheme) {
+
+    // Handle dark mode based on mode prop and system preference
+    if (mode === 'dark') {
       document.documentElement.classList.add('flowglad-dark')
+    } else if (mode === 'light') {
+      document.documentElement.classList.remove('flowglad-dark')
+    } else if (mode === 'system') {
+      document.documentElement.classList.add(
+        isDarkTheme ? 'flowglad-dark' : 'flowglad-root'
+      )
     }
 
     // Generate CSS string
@@ -230,7 +230,7 @@ export function FlowgladTheme({
         'flowglad-base-theme'
       )
     }
-  }, [darkMode, theme])
+  }, [theme, mode, isDarkTheme])
 
   return (
     <>

--- a/packages/react/src/FlowgladTheme.tsx
+++ b/packages/react/src/FlowgladTheme.tsx
@@ -1,15 +1,25 @@
+'use client'
 // @flowglad/react/src/FlowgladTheme.tsx
 import React, { useEffect, useState } from 'react'
 import { styles } from './generated/styles'
 
-interface FlowgladThemeProps {
-  children: React.ReactNode
-  darkMode?: boolean
-  nonce?: string
-}
-
 // Create a stable unique identifier for our styles
 const STYLE_HREF = '@flowglad/react/styles'
+
+// Import css-tools dynamically
+let cssTools: { parse: any; stringify: any } | null = null
+
+// Initialize css-tools
+const initCssTools = async () => {
+  if (!cssTools) {
+    const module = await import('@adobe/css-tools')
+    cssTools = {
+      parse: module.parse,
+      stringify: module.stringify,
+    }
+  }
+  return cssTools
+}
 
 const useThemeDetector = () => {
   const getCurrentTheme = () =>
@@ -29,15 +39,172 @@ const useThemeDetector = () => {
   return isDarkTheme
 }
 
-export const FlowgladTheme: React.FC<FlowgladThemeProps> = ({
+/**
+ * Takes a tuple of [key, value] and returns a CSS AST rule for the theme entry
+ * @param themeEntry
+ * @returns CSS AST rule
+ */
+export function themeEntryToCssAst(
+  themeEntry: [keyof FlowgladColors, string]
+): any {
+  const [key, value] = themeEntry
+  const propertyMap: Record<keyof FlowgladColors, string> = {
+    containerBackground: 'background',
+    containerForeground: 'foreground',
+    border: 'border',
+    buttonBackground: 'button',
+    buttonForeground: 'button-foreground',
+    destructive: 'destructive',
+    destructiveForeground: 'destructive-foreground',
+  }
+
+  return {
+    type: 'rule',
+    selectors: [`.flowglad-root`],
+    declarations: [
+      {
+        type: 'declaration',
+        property: `--flowglad-${propertyMap[key]}`,
+        value,
+      },
+    ],
+  }
+}
+
+/**
+ * Converts a theme object to a CSS AST stylesheet
+ * @param theme The theme object
+ * @returns CSS AST stylesheet
+ */
+export function themeToCssAst(theme?: FlowgladThemeConfig): any {
+  if (!theme) {
+    return {
+      type: 'stylesheet',
+      stylesheet: {
+        rules: [],
+      },
+    }
+  }
+
+  const propertyMap: Record<keyof FlowgladColors, string> = {
+    containerBackground: 'background',
+    containerForeground: 'foreground',
+    border: 'border',
+    buttonBackground: 'button',
+    buttonForeground: 'button-foreground',
+    destructive: 'destructive',
+    destructiveForeground: 'destructive-foreground',
+  }
+
+  const rules: any[] = []
+
+  if (theme.light) {
+    const lightRule: any = {
+      type: 'rule',
+      selectors: ['.flowglad-root'],
+      declarations: Object.entries(theme.light).map(
+        ([key, value]) => ({
+          type: 'declaration',
+          property: `--flowglad-${propertyMap[key as keyof FlowgladColors]}`,
+          value,
+        })
+      ),
+    }
+    rules.push(lightRule)
+  }
+
+  if (theme.dark) {
+    const darkRule: any = {
+      type: 'rule',
+      selectors: ['.flowglad-dark'],
+      declarations: Object.entries(theme.dark).map(
+        ([key, value]) => ({
+          type: 'declaration',
+          property: `--flowglad-${propertyMap[key as keyof FlowgladColors]}`,
+          value,
+        })
+      ),
+    }
+    rules.push(darkRule)
+  }
+
+  return {
+    type: 'stylesheet',
+    stylesheet: {
+      rules,
+    },
+  }
+}
+
+/**
+ * Converts a theme entry to a CSS string
+ * @param themeEntry The theme entry
+ * @returns CSS string
+ */
+export async function themeEntryToCss(
+  themeEntry: [keyof FlowgladColors, string]
+): Promise<string> {
+  const rule = themeEntryToCssAst(themeEntry)
+  const ast: any = {
+    type: 'stylesheet',
+    stylesheet: {
+      rules: [rule],
+    },
+  }
+  const { stringify } = await initCssTools()
+  return stringify(ast)
+}
+
+/**
+ * Converts a theme object to a CSS string
+ * @param theme The theme object
+ * @returns CSS string
+ */
+export async function themeToCss(
+  theme?: FlowgladThemeConfig
+): Promise<string> {
+  const ast = themeToCssAst(theme)
+  const { stringify } = await initCssTools()
+  const css = stringify(ast)
+  return css
+}
+
+interface FlowgladColors {
+  containerBackground: string
+  containerForeground: string
+  border: string
+  buttonBackground: string
+  buttonForeground: string
+  destructive: string
+  destructiveForeground: string
+}
+
+export interface FlowgladThemeConfig {
+  light?: Partial<FlowgladColors>
+  dark?: Partial<FlowgladColors>
+}
+
+interface FlowgladThemeProps {
+  children: React.ReactNode
+  darkMode?: boolean
+  nonce?: string
+  theme?: FlowgladThemeConfig
+}
+
+export function FlowgladTheme({
   children,
   darkMode,
+  theme,
   nonce,
-}) => {
+}: FlowgladThemeProps) {
   const isDarkTheme = useThemeDetector()
+  const [cssString, setCssString] = useState<string>('')
+
   useEffect(() => {
     // Apply the class to the html element
     document.documentElement.classList.add('flowglad-root')
+    // Apply the base theme class to the html element
+    document.documentElement.classList.add('flowglad-base-theme')
     // If darkMode is provided, apply the class to the html element
     // If darkMode is not provided, use the system theme
     if (typeof darkMode === 'boolean') {
@@ -50,21 +217,27 @@ export const FlowgladTheme: React.FC<FlowgladThemeProps> = ({
       document.documentElement.classList.add('flowglad-dark')
     }
 
+    // Generate CSS string
+    themeToCss(theme).then((css) => {
+      setCssString(css)
+    })
+
     // Cleanup function to remove the classes
     return () => {
       document.documentElement.classList.remove(
         'flowglad-root',
-        'flowglad-dark'
+        'flowglad-dark',
+        'flowglad-base-theme'
       )
     }
-  }, [darkMode])
+  }, [darkMode, theme])
 
   return (
     <>
       <style
         suppressHydrationWarning
         dangerouslySetInnerHTML={{
-          __html: styles,
+          __html: `${styles}\n${cssString}`,
         }}
         nonce={nonce}
         // @ts-expect-error - precedence is needed for hoisting

--- a/packages/react/src/FlowgladTheme.tsx
+++ b/packages/react/src/FlowgladTheme.tsx
@@ -2,24 +2,7 @@
 // @flowglad/react/src/FlowgladTheme.tsx
 import React, { useEffect, useState } from 'react'
 import { styles } from './generated/styles'
-
-// Create a stable unique identifier for our styles
-const STYLE_HREF = '@flowglad/react/styles'
-
-// Import css-tools dynamically
-let cssTools: { parse: any; stringify: any } | null = null
-
-// Initialize css-tools
-const initCssTools = async () => {
-  if (!cssTools) {
-    const module = await import('@adobe/css-tools')
-    cssTools = {
-      parse: module.parse,
-      stringify: module.stringify,
-    }
-  }
-  return cssTools
-}
+import { themeToCss, type FlowgladThemeConfig } from './lib/themes'
 
 const useThemeDetector = () => {
   const getCurrentTheme = () =>
@@ -37,152 +20,6 @@ const useThemeDetector = () => {
     return () => darkThemeMq.removeEventListener('change', mqListener)
   }, [])
   return isDarkTheme
-}
-
-/**
- * Takes a tuple of [key, value] and returns a CSS AST rule for the theme entry
- * @param themeEntry
- * @returns CSS AST rule
- */
-export function themeEntryToCssAst(
-  themeEntry: [keyof FlowgladColors, string]
-): any {
-  const [key, value] = themeEntry
-  const propertyMap: Record<keyof FlowgladColors, string> = {
-    containerBackground: 'background',
-    containerForeground: 'foreground',
-    border: 'border',
-    buttonBackground: 'button',
-    buttonForeground: 'button-foreground',
-    destructive: 'destructive',
-    destructiveForeground: 'destructive-foreground',
-  }
-
-  return {
-    type: 'rule',
-    selectors: [`.flowglad-root`],
-    declarations: [
-      {
-        type: 'declaration',
-        property: `--flowglad-${propertyMap[key]}`,
-        value,
-      },
-    ],
-  }
-}
-
-/**
- * Converts a theme object to a CSS AST stylesheet
- * @param theme The theme object
- * @returns CSS AST stylesheet
- */
-export function themeToCssAst(theme?: FlowgladThemeConfig): any {
-  if (!theme) {
-    return {
-      type: 'stylesheet',
-      stylesheet: {
-        rules: [],
-      },
-    }
-  }
-
-  const propertyMap: Record<keyof FlowgladColors, string> = {
-    containerBackground: 'background',
-    containerForeground: 'foreground',
-    border: 'border',
-    buttonBackground: 'button',
-    buttonForeground: 'button-foreground',
-    destructive: 'destructive',
-    destructiveForeground: 'destructive-foreground',
-  }
-
-  const rules: any[] = []
-
-  if (theme.light) {
-    const lightRule: any = {
-      type: 'rule',
-      selectors: ['.flowglad-root'],
-      declarations: Object.entries(theme.light).map(
-        ([key, value]) => ({
-          type: 'declaration',
-          property: `--flowglad-${propertyMap[key as keyof FlowgladColors]}`,
-          value,
-        })
-      ),
-    }
-    rules.push(lightRule)
-  }
-
-  if (theme.dark) {
-    const darkRule: any = {
-      type: 'rule',
-      selectors: ['.flowglad-dark'],
-      declarations: Object.entries(theme.dark).map(
-        ([key, value]) => ({
-          type: 'declaration',
-          property: `--flowglad-${propertyMap[key as keyof FlowgladColors]}`,
-          value,
-        })
-      ),
-    }
-    rules.push(darkRule)
-  }
-
-  return {
-    type: 'stylesheet',
-    stylesheet: {
-      rules,
-    },
-  }
-}
-
-/**
- * Converts a theme entry to a CSS string
- * @param themeEntry The theme entry
- * @returns CSS string
- */
-export async function themeEntryToCss(
-  themeEntry: [keyof FlowgladColors, string]
-): Promise<string> {
-  const rule = themeEntryToCssAst(themeEntry)
-  const ast: any = {
-    type: 'stylesheet',
-    stylesheet: {
-      rules: [rule],
-    },
-  }
-  const { stringify } = await initCssTools()
-  return stringify(ast)
-}
-
-/**
- * Converts a theme object to a CSS string
- * @param theme The theme object
- * @returns CSS string
- */
-export async function themeToCss(
-  theme?: FlowgladThemeConfig
-): Promise<string> {
-  const ast = themeToCssAst(theme)
-  const { stringify } = await initCssTools()
-  const css = stringify(ast)
-  return css
-}
-
-interface FlowgladColors {
-  containerBackground: string
-  containerForeground: string
-  border: string
-  buttonBackground: string
-  buttonForeground: string
-  destructive: string
-  destructiveForeground: string
-}
-
-export interface FlowgladThemeConfig {
-  light?: Partial<FlowgladColors>
-  dark?: Partial<FlowgladColors>
-  mode?: 'light' | 'dark' | 'system'
 }
 
 interface FlowgladThemeProps {
@@ -231,7 +68,6 @@ export function FlowgladTheme({
       )
     }
   }, [theme, mode, isDarkTheme])
-
   return (
     <>
       <style
@@ -240,10 +76,7 @@ export function FlowgladTheme({
           __html: `${styles}\n${cssString}`,
         }}
         nonce={nonce}
-        // @ts-expect-error - precedence is needed for hoisting
-        precedence="high"
-        href={STYLE_HREF}
-        key={STYLE_HREF}
+        data-flowglad-theme
       />
       {children}
     </>

--- a/packages/react/src/components/billing-page.tsx
+++ b/packages/react/src/components/billing-page.tsx
@@ -121,79 +121,76 @@ export function BillingPage({
   }
   const { createAddPaymentMethodCheckoutSession } = billing
   return (
-    <FlowgladTheme darkMode={darkMode}>
-      <div
-        className={cn(
-          'flowglad-flex flowglad-flex-col flowglad-gap-4 flowglad-p-4',
-          className
-        )}
-      >
-        <Section>
-          <CurrentSubscriptionOrPricingTable
-            catalog={billing.catalog!}
-            currentSubscriptions={billing.currentSubscriptions}
-          />
-        </Section>
-        <Section>
-          <SectionTitle
-            button={
-              <Button
-                variant="outline"
-                onClick={() => {
-                  createAddPaymentMethodCheckoutSession({
-                    successUrl: window.location.href,
-                    cancelUrl: window.location.href,
-                    autoRedirect: true,
-                  })
-                }}
-              >
-                Add Payment Method
-              </Button>
-            }
-          >
-            Payment Methods
-          </SectionTitle>
-          <PaymentMethods paymentMethods={billing.paymentMethods} />
-        </Section>
-        <Section>
-          <SectionTitle>Billing Details</SectionTitle>
-          <CustomerBillingDetails
-            name={billing.customer.name ?? ''}
-            email={billing.customer.email}
-            billingAddress={
-              !billing.customer.billingAddress
-                ? undefined
-                : {
-                    line1:
-                      billing.customer.billingAddress.address.line1,
-                    line2:
-                      billing.customer.billingAddress.address.line2 ??
-                      undefined,
-                    city: billing.customer.billingAddress.address
-                      .city,
-                    state:
-                      billing.customer.billingAddress.address.state,
-                    postalCode:
-                      billing.customer.billingAddress.address
-                        .postal_code,
-                    country:
-                      billing.customer.billingAddress.address.country,
-                  }
-            }
-          />
-        </Section>
-        <Section>
-          <SectionTitle>Invoices</SectionTitle>
-          <Invoices
-            invoices={billing.invoices.map(
-              ({ invoice, invoiceLineItems }) => ({
-                ...invoice,
-                lineItems: invoiceLineItems,
-              })
-            )}
-          />
-        </Section>
-      </div>
-    </FlowgladTheme>
+    <div
+      className={cn(
+        'flowglad-flex flowglad-flex-col flowglad-gap-4 flowglad-p-4 flowglad-base-theme',
+        className
+      )}
+    >
+      <Section>
+        <CurrentSubscriptionOrPricingTable
+          catalog={billing.catalog!}
+          currentSubscriptions={billing.currentSubscriptions}
+        />
+      </Section>
+      <Section>
+        <SectionTitle
+          button={
+            <Button
+              variant="outline"
+              onClick={() => {
+                createAddPaymentMethodCheckoutSession({
+                  successUrl: window.location.href,
+                  cancelUrl: window.location.href,
+                  autoRedirect: true,
+                })
+              }}
+            >
+              Add Payment Method
+            </Button>
+          }
+        >
+          Payment Methods
+        </SectionTitle>
+        <PaymentMethods paymentMethods={billing.paymentMethods} />
+      </Section>
+      <Section>
+        <SectionTitle>Billing Details</SectionTitle>
+        <CustomerBillingDetails
+          name={billing.customer.name ?? ''}
+          email={billing.customer.email}
+          billingAddress={
+            !billing.customer.billingAddress
+              ? undefined
+              : {
+                  line1:
+                    billing.customer.billingAddress.address.line1,
+                  line2:
+                    billing.customer.billingAddress.address.line2 ??
+                    undefined,
+                  city: billing.customer.billingAddress.address.city,
+                  state:
+                    billing.customer.billingAddress.address.state,
+                  postalCode:
+                    billing.customer.billingAddress.address
+                      .postal_code,
+                  country:
+                    billing.customer.billingAddress.address.country,
+                }
+          }
+        />
+      </Section>
+      <Section>
+        <SectionTitle>Invoices</SectionTitle>
+        <Invoices
+          invoices={billing.invoices.map(
+            ({ invoice, invoiceLineItems }) => ({
+              ...invoice,
+              lineItems: invoiceLineItems,
+            })
+          )}
+        />
+      </Section>
+    </div>
   )
 }

--- a/packages/react/src/components/cancel-subscription-modal.tsx
+++ b/packages/react/src/components/cancel-subscription-modal.tsx
@@ -29,7 +29,7 @@ export const CancelSubscriptionModal = ({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger
         className={buttonVariants({
-          variant: 'outline',
+          variant: 'destructiveGhost',
           size: 'sm',
         })}
       >

--- a/packages/react/src/components/current-subscription-card.test.tsx
+++ b/packages/react/src/components/current-subscription-card.test.tsx
@@ -1,0 +1,424 @@
+import { render, screen } from '@testing-library/react'
+import {
+  StandardCurrentSubscriptionCard,
+  UsageCurrentSubscriptionCard,
+} from './current-subscription-card'
+import { format } from 'date-fns'
+import { CurrencyCode } from '@flowglad/types'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { SubscriptionCardSubscriptionItem } from '../types'
+
+// Mock the CancelSubscriptionModal component
+vi.mock('./cancel-subscription-modal', () => ({
+  CancelSubscriptionModal: ({
+    subscription,
+    cancelSubscription,
+  }: {
+    subscription: any
+    cancelSubscription: (subscription: any) => void
+  }) => (
+    <button
+      data-testid="cancel-subscription-modal"
+      onClick={() => cancelSubscription(subscription)}
+    >
+      Cancel Subscription
+    </button>
+  ),
+}))
+
+// Mock the PriceLabel component
+vi.mock('./currency-label', () => ({
+  PriceLabel: ({
+    price,
+  }: {
+    price: {
+      currency: string
+      unitPrice: number
+      intervalCount: number
+      intervalUnit: string
+    }
+  }) => (
+    <div data-testid="price-label">
+      {price.currency} {price.unitPrice} / {price.intervalCount}{' '}
+      {price.intervalUnit}
+    </div>
+  ),
+}))
+
+describe('StandardCurrentSubscriptionCard', () => {
+  const defaultProps = {
+    subscription: {
+      id: 'sub_123',
+      cancelScheduledAt: null,
+      trialEnd: null,
+      status: 'active' as const,
+      currentBillingPeriodEnd: '2023-12-31',
+      interval: 'month' as const,
+      intervalCount: 1,
+      canceledAt: null,
+    },
+    product: {
+      name: 'Pro Plan',
+      pluralQuantityLabel: 'Users',
+    },
+    currency: 'USD' as CurrencyCode,
+    subscriptionItems: [
+      {
+        id: 'item_123',
+        quantity: 5,
+        unitPrice: 10,
+        price: {
+          id: 'price_123',
+          type: 'subscription',
+        },
+      } as SubscriptionCardSubscriptionItem,
+    ],
+    isPastDue: false,
+    showTrialEnd: false,
+    shouldShowBillingPeriodEnd: true,
+    onCancel: vi.fn(),
+  }
+
+  it('renders the product name and badge', () => {
+    render(<StandardCurrentSubscriptionCard {...defaultProps} />)
+    expect(screen.getByText('Pro Plan')).toBeInTheDocument()
+    expect(screen.getByText('Current Plan')).toBeInTheDocument()
+  })
+
+  it('displays the quantity when pluralQuantityLabel is provided', () => {
+    render(<StandardCurrentSubscriptionCard {...defaultProps} />)
+    expect(screen.getByText('Users')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+
+  it('does not display quantity section when pluralQuantityLabel is not provided', () => {
+    const propsWithoutQuantity = {
+      ...defaultProps,
+      product: { name: 'Pro Plan' },
+    }
+    render(
+      // @ts-expect-error - plural quantity label is required - but we need to be resilient to its
+      // absence
+      <StandardCurrentSubscriptionCard {...propsWithoutQuantity} />
+    )
+    expect(screen.queryByText('Users')).not.toBeInTheDocument()
+  })
+
+  it('displays the price label with correct information', () => {
+    render(<StandardCurrentSubscriptionCard {...defaultProps} />)
+    const priceLabel = screen.getByTestId('price-label')
+    expect(priceLabel).toHaveTextContent('USD 10 / 1 month')
+  })
+
+  it('shows cancellation date when subscription is scheduled to cancel', () => {
+    const cancelDate = '2023-11-15'
+    const propsWithCancellation = {
+      ...defaultProps,
+      subscription: {
+        ...defaultProps.subscription,
+        cancelScheduledAt: cancelDate,
+      },
+    }
+    render(
+      <StandardCurrentSubscriptionCard {...propsWithCancellation} />
+    )
+    expect(
+      screen.getByText(
+        `Cancels on ${format(new Date(cancelDate), 'MMM d, yyyy')}`
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows trial end date when showTrialEnd is true', () => {
+    const trialEndDate = '2023-11-30'
+    const propsWithTrial = {
+      ...defaultProps,
+      subscription: {
+        ...defaultProps.subscription,
+        trialEnd: trialEndDate,
+      },
+      showTrialEnd: true,
+    }
+    render(<StandardCurrentSubscriptionCard {...propsWithTrial} />)
+    expect(
+      screen.getByText(
+        `Trial ends on ${format(new Date(trialEndDate), 'MMM d, yyyy')}`
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows past due message when isPastDue is true', () => {
+    const propsWithPastDue = {
+      ...defaultProps,
+      isPastDue: true,
+    }
+    render(<StandardCurrentSubscriptionCard {...propsWithPastDue} />)
+    expect(screen.getByText('Payment Past Due')).toBeInTheDocument()
+  })
+
+  it('shows renewal date when shouldShowBillingPeriodEnd is true and not cancelled', () => {
+    render(<StandardCurrentSubscriptionCard {...defaultProps} />)
+    expect(
+      screen.getByText(
+        `Renews on ${format(new Date(defaultProps.subscription.currentBillingPeriodEnd), 'MMM d, yyyy')}`
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('does not show renewal date when subscription is cancelled', () => {
+    const cancelDate = '2023-11-15'
+    const propsWithCancellation = {
+      ...defaultProps,
+      subscription: {
+        ...defaultProps.subscription,
+        cancelScheduledAt: cancelDate,
+      },
+    }
+    render(
+      <StandardCurrentSubscriptionCard {...propsWithCancellation} />
+    )
+    expect(
+      screen.queryByText(
+        `Renews on ${format(new Date(defaultProps.subscription.currentBillingPeriodEnd), 'MMM d, yyyy')}`
+      )
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not show renewal date when shouldShowBillingPeriodEnd is false', () => {
+    const propsWithoutRenewal = {
+      ...defaultProps,
+      shouldShowBillingPeriodEnd: false,
+    }
+    render(
+      <StandardCurrentSubscriptionCard {...propsWithoutRenewal} />
+    )
+    expect(
+      screen.queryByText(
+        `Renews on ${format(new Date(defaultProps.subscription.currentBillingPeriodEnd), 'MMM d, yyyy')}`
+      )
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows cancel subscription modal when not cancelled', () => {
+    render(<StandardCurrentSubscriptionCard {...defaultProps} />)
+    expect(
+      screen.getByTestId('cancel-subscription-modal')
+    ).toBeInTheDocument()
+  })
+
+  it('does not show cancel subscription modal when already cancelled', () => {
+    const cancelDate = '2023-11-15'
+    const propsWithCancellation = {
+      ...defaultProps,
+      subscription: {
+        ...defaultProps.subscription,
+        cancelScheduledAt: cancelDate,
+      },
+    }
+    render(
+      <StandardCurrentSubscriptionCard {...propsWithCancellation} />
+    )
+    expect(
+      screen.queryByTestId('cancel-subscription-modal')
+    ).not.toBeInTheDocument()
+  })
+
+  it('calls onCancel when cancel button is clicked', () => {
+    render(<StandardCurrentSubscriptionCard {...defaultProps} />)
+    const cancelButton = screen.getByTestId(
+      'cancel-subscription-modal'
+    )
+    cancelButton.click()
+    expect(defaultProps.onCancel).toHaveBeenCalledWith(
+      defaultProps.subscription
+    )
+  })
+})
+
+describe('UsageCurrentSubscriptionCard', () => {
+  const defaultProps = {
+    currency: 'USD' as CurrencyCode,
+    subscription: {
+      id: 'sub_123',
+      cancelScheduledAt: null,
+      trialEnd: null,
+      status: 'active' as const,
+      currentBillingPeriodEnd: '2023-12-31',
+      interval: 'month' as const,
+      intervalCount: 1,
+      canceledAt: null,
+    },
+    product: {
+      name: 'Usage Plan',
+      pluralQuantityLabel: 'API Calls',
+    },
+    subscriptionItems: [
+      {
+        id: 'item_123',
+        quantity: 1000,
+        unitPrice: 0.01,
+        price: {
+          id: 'price_123',
+          type: 'usage',
+        },
+      } as SubscriptionCardSubscriptionItem,
+    ],
+    isPastDue: false,
+    showTrialEnd: false,
+    shouldShowBillingPeriodEnd: true,
+    onCancel: vi.fn(),
+  }
+
+  it('renders the product name and badge', () => {
+    render(<UsageCurrentSubscriptionCard {...defaultProps} />)
+    expect(screen.getByText('Usage Plan')).toBeInTheDocument()
+    expect(screen.getByText('Current Plan')).toBeInTheDocument()
+  })
+
+  it('displays the quantity when pluralQuantityLabel is provided', () => {
+    render(<UsageCurrentSubscriptionCard {...defaultProps} />)
+    expect(screen.getByText('API Calls')).toBeInTheDocument()
+    expect(screen.getByText('1000')).toBeInTheDocument()
+  })
+
+  it('does not display quantity section when pluralQuantityLabel is not provided', () => {
+    const propsWithoutQuantity = {
+      ...defaultProps,
+      product: { name: 'Usage Plan' },
+    }
+    // @ts-expect-error - plural quantity label is required - but we need to be resilient to its
+    // absence
+    render(<UsageCurrentSubscriptionCard {...propsWithoutQuantity} />)
+    expect(screen.queryByText('API Calls')).not.toBeInTheDocument()
+  })
+
+  it('displays "Pay as you go, billed monthly" text', () => {
+    render(<UsageCurrentSubscriptionCard {...defaultProps} />)
+    expect(
+      screen.getByText('Pay as you go, billed monthly')
+    ).toBeInTheDocument()
+  })
+
+  it('shows cancellation date when subscription is scheduled to cancel', () => {
+    const cancelDate = '2023-11-15'
+    const propsWithCancellation = {
+      ...defaultProps,
+      subscription: {
+        ...defaultProps.subscription,
+        cancelScheduledAt: cancelDate,
+      },
+    }
+    render(
+      <UsageCurrentSubscriptionCard {...propsWithCancellation} />
+    )
+    expect(
+      screen.getByText(
+        `Cancels on ${format(new Date(cancelDate), 'MMM d, yyyy')}`
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows trial end date when showTrialEnd is true', () => {
+    const trialEndDate = '2023-11-30'
+    const propsWithTrial = {
+      ...defaultProps,
+      subscription: {
+        ...defaultProps.subscription,
+        trialEnd: trialEndDate,
+      },
+      showTrialEnd: true,
+    }
+    render(<UsageCurrentSubscriptionCard {...propsWithTrial} />)
+    expect(
+      screen.getByText(
+        `Trial ends on ${format(new Date(trialEndDate), 'MMM d, yyyy')}`
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows past due message when isPastDue is true', () => {
+    const propsWithPastDue = {
+      ...defaultProps,
+      isPastDue: true,
+    }
+    render(<UsageCurrentSubscriptionCard {...propsWithPastDue} />)
+    expect(screen.getByText('Payment Past Due')).toBeInTheDocument()
+  })
+
+  it('shows renewal date when shouldShowBillingPeriodEnd is true and not cancelled', () => {
+    render(<UsageCurrentSubscriptionCard {...defaultProps} />)
+    expect(
+      screen.getByText(
+        `Renews on ${format(new Date(defaultProps.subscription.currentBillingPeriodEnd), 'MMM d, yyyy')}`
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('does not show renewal date when subscription is cancelled', () => {
+    const cancelDate = '2023-11-15'
+    const propsWithCancellation = {
+      ...defaultProps,
+      subscription: {
+        ...defaultProps.subscription,
+        cancelScheduledAt: cancelDate,
+      },
+    }
+    render(
+      <UsageCurrentSubscriptionCard {...propsWithCancellation} />
+    )
+    expect(
+      screen.queryByText(
+        `Renews on ${format(new Date(defaultProps.subscription.currentBillingPeriodEnd), 'MMM d, yyyy')}`
+      )
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not show renewal date when shouldShowBillingPeriodEnd is false', () => {
+    const propsWithoutRenewal = {
+      ...defaultProps,
+      shouldShowBillingPeriodEnd: false,
+    }
+    render(<UsageCurrentSubscriptionCard {...propsWithoutRenewal} />)
+    expect(
+      screen.queryByText(
+        `Renews on ${format(new Date(defaultProps.subscription.currentBillingPeriodEnd), 'MMM d, yyyy')}`
+      )
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows cancel subscription modal when not cancelled', () => {
+    render(<UsageCurrentSubscriptionCard {...defaultProps} />)
+    expect(
+      screen.getByTestId('cancel-subscription-modal')
+    ).toBeInTheDocument()
+  })
+
+  it('does not show cancel subscription modal when already cancelled', () => {
+    const cancelDate = '2023-11-15'
+    const propsWithCancellation = {
+      ...defaultProps,
+      subscription: {
+        ...defaultProps.subscription,
+        cancelScheduledAt: cancelDate,
+      },
+    }
+    render(
+      <UsageCurrentSubscriptionCard {...propsWithCancellation} />
+    )
+    expect(
+      screen.queryByTestId('cancel-subscription-modal')
+    ).not.toBeInTheDocument()
+  })
+
+  it('calls onCancel when cancel button is clicked', () => {
+    render(<UsageCurrentSubscriptionCard {...defaultProps} />)
+    const cancelButton = screen.getByTestId(
+      'cancel-subscription-modal'
+    )
+    cancelButton.click()
+    expect(defaultProps.onCancel).toHaveBeenCalledWith(
+      defaultProps.subscription
+    )
+  })
+})

--- a/packages/react/src/components/current-subscription-card.tsx
+++ b/packages/react/src/components/current-subscription-card.tsx
@@ -9,7 +9,6 @@ import {
 import { format } from 'date-fns'
 
 import { Badge } from './ui/badge'
-import { Button } from './ui/button'
 import {
   Card,
   CardContent,
@@ -53,7 +52,6 @@ interface StandardCurrentSubscriptionCardProps
 export function UsageCurrentSubscriptionCard({
   subscription,
   product,
-  currency,
   subscriptionItems,
   isPastDue,
   showTrialEnd,

--- a/packages/react/src/components/ui/button.test.tsx
+++ b/packages/react/src/components/ui/button.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { buttonVariants } from './button'
+
+describe('buttonVariants', () => {
+  it('should include destructive classes when destructive variant is set', () => {
+    const classes = buttonVariants({ variant: 'destructive' })
+
+    expect(classes).toContain('flowglad-bg-destructive')
+    expect(classes).toContain('flowglad-text-white')
+    expect(classes).toContain('hover:flowglad-bg-destructive/90')
+    expect(classes).toContain(
+      'flowglad-focus-visible:ring-destructive/20'
+    )
+    expect(classes).toContain(
+      'flowglad-dark:focus-visible:ring-destructive/40'
+    )
+  })
+})

--- a/packages/react/src/components/ui/button.tsx
+++ b/packages/react/src/components/ui/button.tsx
@@ -18,6 +18,10 @@ const buttonVariants = cva(
           'flowglad-bg-destructive flowglad-text-white flowglad-shadow-xs hover:flowglad-bg-destructive/90 flowglad-focus-visible:ring-destructive/20 flowglad-dark:focus-visible:ring-destructive/40',
         outline:
           'flowglad-border flowglad-border-input flowglad-bg-background flowglad-shadow-xs hover:flowglad-bg-accent hover:flowglad-text-accent-foreground',
+        destructiveOutline:
+          'flowglad-border flowglad-border-destructive flowglad-text-destructive flowglad-bg-background flowglad-shadow-xs hover:flowglad-bg-destructive/10 flowglad-focus-visible:ring-destructive/20 flowglad-dark:focus-visible:ring-destructive/40',
+        destructiveGhost:
+          'flowglad-text-destructive hover:flowglad-bg-destructive/10 hover:flowglad-text-destructive flowglad-focus-visible:ring-destructive/20 flowglad-dark:focus-visible:ring-destructive/40',
         secondary:
           'flowglad-bg-secondary flowglad-text-secondary-foreground flowglad-shadow-xs hover:flowglad-bg-secondary/80',
         ghost:

--- a/packages/react/src/globals.css
+++ b/packages/react/src/globals.css
@@ -93,17 +93,16 @@
 }
 
 @layer base {
-  .flowglad-root * {
-    border-color: var(--flowglad-border);
-    outline-color: var(--flowglad-ring);
-    outline-width: 0;
-  }
-
-  .flowglad-root {
+  /* New base theme class that contains all default styles */
+  .flowglad-base-theme {
     font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    border-color: var(--flowglad-border);
+  }
+
+  /* Remove global border-color styles from flowglad-root */
+  .flowglad-root {
+    /* No global styles here, just CSS variables */
   }
 
   .flowglad-root.flowglad-dark {

--- a/packages/react/src/globals.css
+++ b/packages/react/src/globals.css
@@ -7,49 +7,45 @@
 @custom-variant dark (&:is(.dark *));
 
 .flowglad-root {
-  --flowglad-background: 0 0% 100%;
-  --flowglad-foreground: 240 10% 3.9%;
-  --flowglad-card: 0 0% 100%;
-  --flowglad-card-foreground: 240 10% 3.9%;
-  --flowglad-popover: 0 0% 100%;
-  --flowglad-popover-foreground: 240 10% 3.9%;
-  --flowglad-primary: 240 5.9% 10%;
-  --flowglad-primary-foreground: 0 0% 98%;
-  --flowglad-secondary: 240 4.8% 95.9%;
-  --flowglad-secondary-foreground: 240 5.9% 10%;
-  --flowglad-muted: 240 4.8% 95.9%;
-  --flowglad-muted-foreground: 240 3.8% 46.1%;
-  --flowglad-accent: 240 4.8% 95.9%;
-  --flowglad-accent-foreground: 240 5.9% 10%;
-  --flowglad-destructive: 0 84.2% 60.2%;
-  --flowglad-destructive-foreground: 0 0% 98%;
-  --flowglad-border: 240 5.9% 90%;
-  --flowglad-input: 240 5.9% 90%;
-  --flowglad-ring: 240 10% 3.9%;
+  /* --flowglad-background: 0 0% 100%; */
+  /* --flowglad-foreground: hsl(240 10% 3.9%); */
+  /* --flowglad-card: hsl(0 0% 100%);
+  --flowglad-card-foreground: hsl(240 10% 3.9%); */
+  /* --flowglad-primary: hsl(240 5.9% 10%); */
+  /* --flowglad-primary-foreground: hsl(0 0% 98%); */
+  /* --flowglad-secondary: hsl(240 4.8% 95.9%); */
+  /* --flowglad-secondary-foreground: hsl(240 5.9% 10%); */
+  /* --flowglad-muted: hsl(240 4.8% 95.9%); */
+  /* --flowglad-muted-foreground: hsl(240 3.8% 46.1%); */
+  /* --flowglad-accent: hsl(240 4.8% 95.9%); */
+  /* --flowglad-accent-foreground: hsl(240 5.9% 10%); */
+  /* --flowglad-destructive: hsl(0 84.2% 60.2%); */
+  /* --flowglad-destructive-foreground: hsl(0 0% 98%); */
+  /* --flowglad-border: hsl(240 5.9% 90%); */
+  /* --flowglad-input: hsl(240 5.9% 90%); */
+  /* --flowglad-ring: hsl(240 10% 3.9%); */
   --flowglad-radius: 0.5rem;
   --radius: 0.5rem;
 }
 
 .flowglad-dark {
-  --flowglad-background: 240 10% 3.9%;
-  --flowglad-foreground: 0 0% 98%;
-  --flowglad-card: 240 10% 3.9%;
-  --flowglad-card-foreground: 0 0% 98%;
-  --flowglad-popover: 240 10% 3.9%;
-  --flowglad-popover-foreground: 0 0% 98%;
-  --flowglad-primary: 0 0% 98%;
-  --flowglad-primary-foreground: 240 5.9% 10%;
-  --flowglad-secondary: 240 3.7% 15.9%;
-  --flowglad-secondary-foreground: 0 0% 98%;
-  --flowglad-muted: 240 3.7% 15.9%;
-  --flowglad-muted-foreground: 240 5% 64.9%;
-  --flowglad-accent: 240 3.7% 15.9%;
-  --flowglad-accent-foreground: 0 0% 98%;
-  --flowglad-destructive: 0 62.8% 30.6%;
-  --flowglad-destructive-foreground: 0 0% 98%;
-  --flowglad-border: 240 3.7% 15.9%;
-  --flowglad-input: 240 3.7% 15.9%;
-  --flowglad-ring: 240 4.9% 83.9%;
+  /* --flowglad-background: 240 10% 3.9%; */
+  /* --flowglad-foreground: hsl(0 0% 98%); */
+  /* --flowglad-card: hsl(240 10% 3.9%);
+  --flowglad-card-foreground: hsl(0 0% 98%); */
+  /* --flowglad-primary: hsl(0 0% 98%); */
+  /* --flowglad-primary-foreground: hsl(240 5.9% 10%); */
+  /* --flowglad-secondary: hsl(240 3.7% 15.9%); */
+  /* --flowglad-secondary-foreground: hsl(0 0% 98%); */
+  /* --flowglad-muted: hsl(240 3.7% 15.9%); */
+  /* --flowglad-muted-foreground: hsl(240 5% 64.9%); */
+  /* --flowglad-accent: hsl(240 3.7% 15.9%); */
+  /* --flowglad-accent-foreground: hsl(0 0% 98%); */
+  /* --flowglad-destructive: hsl(0 62.8% 30.6%); */
+  /* --flowglad-destructive-foreground: hsl(0 0% 98%); */
+  /* --flowglad-border: hsl(240 3.7% 15.9%); */
+  /* --flowglad-input: hsl(240 3.7% 15.9%); */
+  /* --flowglad-ring: hsl(240 4.9% 83.9%); */
   --flowglad-radius: 0.5rem;
 }
 
@@ -58,8 +54,6 @@
   --color-foreground: var(--foreground);
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
   --color-secondary: var(--secondary);
@@ -73,29 +67,16 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
 }
 
 @layer base {
   /* New base theme class that contains all default styles */
   .flowglad-base-theme {
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    /* font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif; */
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
@@ -106,107 +87,85 @@
   }
 
   .flowglad-root.flowglad-dark {
-    --flowglad-background: 240 10% 3.9%;
-    --flowglad-foreground: 0 0% 98%;
-    --flowglad-card: 240 10% 3.9%;
-    --flowglad-card-foreground: 0 0% 98%;
-    --flowglad-popover: 240 10% 3.9%;
-    --flowglad-popover-foreground: 0 0% 98%;
-    --flowglad-primary: 0 0% 98%;
-    --flowglad-primary-foreground: 240 5.9% 10%;
-    --flowglad-secondary: 240 3.7% 15.9%;
-    --flowglad-secondary-foreground: 0 0% 98%;
-    --flowglad-muted: 240 3.7% 15.9%;
-    --flowglad-muted-foreground: 240 5% 64.9%;
-    --flowglad-accent: 240 3.7% 15.9%;
-    --flowglad-accent-foreground: 0 0% 98%;
-    --flowglad-destructive: 0 62.8% 30.6%;
-    --flowglad-destructive-foreground: 0 0% 98%;
-    --flowglad-border: 240 3.7% 15.9%;
-    --flowglad-input: 240 3.7% 15.9%;
-    --flowglad-ring: 240 4.9% 83.9%;
+    /* --flowglad-background: 240 10% 3.9%; */
+    /* --flowglad-foreground: hsl(0 0% 98%); */
+    /* --flowglad-card: hsl(240 10% 3.9%);
+    --flowglad-card-foreground: hsl(0 0% 98%); */
+    /* --flowglad-primary: hsl(0 0% 98%); */
+    /* --flowglad-primary-foreground: hsl(240 5.9% 10%); */
+    /* --flowglad-secondary: hsl(240 3.7% 15.9%); */
+    /* --flowglad-secondary-foreground: hsl(0 0% 98%); */
+    /* --flowglad-muted: hsl(240 3.7% 15.9%); */
+    /* --flowglad-muted-foreground: hsl(240 5% 64.9%); */
+    /* --flowglad-accent: hsl(240 3.7% 15.9%); */
+    /* --flowglad-accent-foreground: hsl(0 0% 98%); */
+    /* --flowglad-destructive: hsl(0 62.8% 30.6%); */
+    /* --flowglad-destructive-foreground: hsl(0 0% 98%); */
+    /* --flowglad-border: hsl(240 3.7% 15.9%); */
+    /* --flowglad-input: hsl(240 3.7% 15.9%); */
+    /* --flowglad-ring: hsl(240 4.9% 83.9%); */
 
-    /* Chart Colors - Dark */
-    --flowglad-chart-1: 220 70% 50%;
-    --flowglad-chart-2: 160 60% 45%;
-    --flowglad-chart-3: 30 80% 55%;
-    --flowglad-chart-4: 280 65% 60%;
-    --flowglad-chart-5: 340 75% 55%;
-
-    /* Sidebar Colors - Dark */
-    --flowglad-sidebar: 240 5.9% 10%;
-    --flowglad-sidebar-foreground: 240 4.8% 95.9%;
-    --flowglad-sidebar-primary: 224.3 76.3% 48%;
-    --flowglad-sidebar-primary-foreground: 0 0% 100%;
-    --flowglad-sidebar-accent: 240 3.7% 15.9%;
-    --flowglad-sidebar-accent-foreground: 240 4.8% 95.9%;
-    --flowglad-sidebar-border: 240 3.7% 15.9%;
-    --flowglad-sidebar-ring: 217.2 91.2% 59.8%;
   }
 }
 
 @layer utilities {
   /* Background Colors */
-  .flowglad-bg-background { background-color: hsl(var(--flowglad-background)); }
-  .flowglad-bg-foreground { background-color: hsl(var(--flowglad-foreground)); }
-  .flowglad-bg-card { background-color: hsl(var(--flowglad-card)); }
-  .flowglad-bg-card-foreground { background-color: hsl(var(--flowglad-card-foreground)); }
-  .flowglad-bg-popover { background-color: hsl(var(--flowglad-popover)); }
-  .flowglad-bg-popover-foreground { background-color: hsl(var(--flowglad-popover-foreground)); }
-  .flowglad-bg-primary { background-color: hsl(var(--flowglad-primary)); }
-  .flowglad-bg-primary-foreground { background-color: hsl(var(--flowglad-primary-foreground)); }
-  .flowglad-bg-secondary { background-color: hsl(var(--flowglad-secondary)); }
-  .flowglad-bg-secondary-foreground { background-color: hsl(var(--flowglad-secondary-foreground)); }
-  .flowglad-bg-muted { background-color: hsl(var(--flowglad-muted)); }
-  .flowglad-bg-muted-foreground { background-color: hsl(var(--flowglad-muted-foreground)); }
-  .flowglad-bg-accent { background-color: hsl(var(--flowglad-accent)); }
-  .flowglad-bg-accent-foreground { background-color: hsl(var(--flowglad-accent-foreground)); }
-  .flowglad-bg-destructive { background-color: hsl(var(--flowglad-destructive)); }
-  .flowglad-bg-destructive-foreground { background-color: hsl(var(--flowglad-destructive-foreground)); }
+  .flowglad-bg-background { background-color: var(--flowglad-background); }
+  .flowglad-bg-foreground { background-color: var(--flowglad-foreground); }
+  .flowglad-bg-card { background-color: var(--flowglad-card); }
+  .flowglad-bg-card-foreground { background-color: var(--flowglad-card-foreground); }
+  .flowglad-bg-primary { background-color: var(--flowglad-primary); }
+  .flowglad-bg-primary-foreground { background-color: var(--flowglad-primary-foreground); }
+  .flowglad-bg-secondary { background-color: var(--flowglad-secondary); }
+  .flowglad-bg-secondary-foreground { background-color: var(--flowglad-secondary-foreground); }
+  .flowglad-bg-muted { background-color: var(--flowglad-muted); }
+  .flowglad-bg-muted-foreground { background-color: var(--flowglad-muted-foreground); }
+  .flowglad-bg-accent { background-color: var(--flowglad-accent); }
+  .flowglad-bg-accent-foreground { background-color: var(--flowglad-accent-foreground); }
+  .flowglad-bg-destructive { background-color: var(--flowglad-destructive); }
+  .flowglad-bg-destructive-foreground { background-color: var(--flowglad-destructive-foreground); }
 
   /* Text Colors */
-  .flowglad-text-background { color: hsl(var(--flowglad-background)); }
-  .flowglad-text-foreground { color: hsl(var(--flowglad-foreground)); }
-  .flowglad-text-card { color: hsl(var(--flowglad-card)); }
-  .flowglad-text-card-foreground { color: hsl(var(--flowglad-card-foreground)); }
-  .flowglad-text-popover { color: hsl(var(--flowglad-popover)); }
-  .flowglad-text-popover-foreground { color: hsl(var(--flowglad-popover-foreground)); }
-  .flowglad-text-primary { color: hsl(var(--flowglad-primary)); }
-  .flowglad-text-primary-foreground { color: hsl(var(--flowglad-primary-foreground)); }
-  .flowglad-text-secondary { color: hsl(var(--flowglad-secondary)); }
-  .flowglad-text-secondary-foreground { color: hsl(var(--flowglad-secondary-foreground)); }
-  .flowglad-text-muted { color: hsl(var(--flowglad-muted)); }
-  .flowglad-text-muted-foreground { color: hsl(var(--flowglad-muted-foreground)); }
-  .flowglad-text-accent { color: hsl(var(--flowglad-accent)); }
-  .flowglad-text-accent-foreground { color: hsl(var(--flowglad-accent-foreground)); }
-  .flowglad-text-destructive { color: hsl(var(--flowglad-destructive)); }
-  .flowglad-text-destructive-foreground { color: hsl(var(--flowglad-destructive-foreground)); }
+  .flowglad-text-background { color: var(--flowglad-background); }
+  .flowglad-text-foreground { color: var(--flowglad-foreground); }
+  .flowglad-text-card { color: var(--flowglad-card); }
+  .flowglad-text-card-foreground { color: var(--flowglad-card-foreground); }
+  .flowglad-text-primary { color: var(--flowglad-primary); }
+  .flowglad-text-primary-foreground { color: var(--flowglad-primary-foreground); }
+  .flowglad-text-secondary { color: var(--flowglad-secondary); }
+  .flowglad-text-secondary-foreground { color: var(--flowglad-secondary-foreground); }
+  .flowglad-text-muted { color: var(--flowglad-muted); }
+  .flowglad-text-muted-foreground { color: var(--flowglad-muted-foreground); }
+  .flowglad-text-accent { color: var(--flowglad-accent); }
+  .flowglad-text-accent-foreground { color: var(--flowglad-accent-foreground); }
+  .flowglad-text-destructive { color: var(--flowglad-destructive); }
+  .flowglad-text-destructive-foreground { color: var(--flowglad-destructive-foreground); }
 
   /* Border Colors */
-  .flowglad-border { border-color: hsl(var(--flowglad-border)); }
-  .flowglad-border-background { border-color: hsl(var(--flowglad-background)); }
-  .flowglad-border-foreground { border-color: hsl(var(--flowglad-foreground)); }
-  .flowglad-border-card { border-color: hsl(var(--flowglad-card)); }
-  .flowglad-border-card-foreground { border-color: hsl(var(--flowglad-card-foreground)); }
-  .flowglad-border-input { border-color: hsl(var(--flowglad-input)); }
-  .flowglad-border-primary { border-color: hsl(var(--flowglad-primary)); }
-  .flowglad-border-secondary { border-color: hsl(var(--flowglad-secondary)); }
-  .flowglad-border-destructive { border-color: hsl(var(--flowglad-destructive)); }
-  .flowglad-border-muted { border-color: hsl(var(--flowglad-muted)); }
-  .flowglad-border-accent { border-color: hsl(var(--flowglad-accent)); }
+  .flowglad-border { border-color: var(--flowglad-border); }
+  .flowglad-border-background { border-color: var(--flowglad-background); }
+  .flowglad-border-foreground { border-color: var(--flowglad-foreground); }
+  .flowglad-border-card { border-color: var(--flowglad-card); }
+  .flowglad-border-card-foreground { border-color: var(--flowglad-card-foreground); }
+  .flowglad-border-input { border-color: var(--flowglad-input); }
+  .flowglad-border-primary { border-color: var(--flowglad-primary); }
+  .flowglad-border-secondary { border-color: var(--flowglad-secondary); }
+  .flowglad-border-destructive { border-color: var(--flowglad-destructive); }
+  .flowglad-border-muted { border-color: var(--flowglad-muted); }
+  .flowglad-border-accent { border-color: var(--flowglad-accent); }
 
   /* Ring Colors */
-  .flowglad-ring { --tw-ring-color: hsl(var(--flowglad-ring)); }
-  .flowglad-ring-background { --tw-ring-color: hsl(var(--flowglad-background)); }
-  .flowglad-ring-foreground { --tw-ring-color: hsl(var(--flowglad-foreground)); }
-  .flowglad-ring-card { --tw-ring-color: hsl(var(--flowglad-card)); }
-  .flowglad-ring-card-foreground { --tw-ring-color: hsl(var(--flowglad-card-foreground)); }
-  .flowglad-ring-input { --tw-ring-color: hsl(var(--flowglad-input)); }
-  .flowglad-ring-primary { --tw-ring-color: hsl(var(--flowglad-primary)); }
-  .flowglad-ring-secondary { --tw-ring-color: hsl(var(--flowglad-secondary)); }
-  .flowglad-ring-destructive { --tw-ring-color: hsl(var(--flowglad-destructive)); }
-  .flowglad-ring-muted { --tw-ring-color: hsl(var(--flowglad-muted)); }
-  .flowglad-ring-accent { --tw-ring-color: hsl(var(--flowglad-accent)); }
+  .flowglad-ring { --tw-ring-color: var(--flowglad-ring); }
+  .flowglad-ring-background { --tw-ring-color: var(--flowglad-background); }
+  .flowglad-ring-foreground { --tw-ring-color: var(--flowglad-foreground); }
+  .flowglad-ring-card { --tw-ring-color: var(--flowglad-card); }
+  .flowglad-ring-card-foreground { --tw-ring-color: var(--flowglad-card-foreground); }
+  .flowglad-ring-input { --tw-ring-color: var(--flowglad-input); }
+  .flowglad-ring-primary { --tw-ring-color: var(--flowglad-primary); }
+  .flowglad-ring-secondary { --tw-ring-color: var(--flowglad-secondary); }
+  .flowglad-ring-destructive { --tw-ring-color: var(--flowglad-destructive); }
+  .flowglad-ring-muted { --tw-ring-color: var(--flowglad-muted); }
+  .flowglad-ring-accent { --tw-ring-color: var(--flowglad-accent); }
 
   /* Border Radius */
   .flowglad-rounded-sm { border-radius: calc(var(--flowglad-radius) - 4px); }

--- a/packages/react/src/lib/themes.test.ts
+++ b/packages/react/src/lib/themes.test.ts
@@ -5,18 +5,9 @@ import {
   themeEntryToCssAst,
   themeToCssAst,
   FlowgladThemeConfig,
-} from './FlowgladTheme'
-
-// Define the FlowgladColors interface for testing
-interface FlowgladColors {
-  containerBackground: string
-  containerForeground: string
-  border: string
-  buttonBackground: string
-  buttonForeground: string
-  destructive: string
-  destructiveForeground: string
-}
+  type FlowgladColors,
+  defaultTheme,
+} from './themes'
 
 // Define types for CSS AST
 interface CssDeclaration {
@@ -42,7 +33,7 @@ const initCssTools = async () => {
 describe('themeEntryToCssAst', () => {
   it('should create a valid CSS AST rule for a theme entry', () => {
     const themeEntry: [keyof FlowgladColors, string] = [
-      'containerBackground',
+      'background',
       '#ffffff',
     ]
     const ast = themeEntryToCssAst(themeEntry)
@@ -68,20 +59,20 @@ describe('themeToCssAst', () => {
   it('should create a valid CSS AST stylesheet for a light theme', () => {
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
         border: '#cccccc',
-        buttonBackground: '#007bff',
-        buttonForeground: '#ffffff',
+        foreground: '#000000',
+        primary: '#007bff',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
       dark: {
-        containerBackground: '#121212',
-        containerForeground: '#ffffff',
+        background: '#121212',
         border: '#333333',
-        buttonBackground: '#0d6efd',
-        buttonForeground: '#ffffff',
+        foreground: '#ffffff',
+        primary: '#0d6efd',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -129,13 +120,13 @@ describe('themeToCssAst', () => {
     ).toBe('#cccccc')
     expect(
       declarations.find(
-        (d: CssDeclaration) => d.property === '--flowglad-button'
+        (d: CssDeclaration) => d.property === '--flowglad-primary'
       )?.value
     ).toBe('#007bff')
     expect(
       declarations.find(
         (d: CssDeclaration) =>
-          d.property === '--flowglad-button-foreground'
+          d.property === '--flowglad-primary-foreground'
       )?.value
     ).toBe('#ffffff')
     expect(
@@ -154,20 +145,20 @@ describe('themeToCssAst', () => {
   it('should create a valid CSS AST stylesheet for a dark theme', () => {
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
         border: '#cccccc',
-        buttonBackground: '#007bff',
-        buttonForeground: '#ffffff',
+        foreground: '#000000',
+        primary: '#007bff',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
       dark: {
-        containerBackground: '#121212',
-        containerForeground: '#ffffff',
+        background: '#121212',
         border: '#333333',
-        buttonBackground: '#0d6efd',
-        buttonForeground: '#ffffff',
+        foreground: '#ffffff',
+        primary: '#0d6efd',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -215,13 +206,13 @@ describe('themeToCssAst', () => {
     ).toBe('#333333')
     expect(
       declarations.find(
-        (d: CssDeclaration) => d.property === '--flowglad-button'
+        (d: CssDeclaration) => d.property === '--flowglad-primary'
       )?.value
     ).toBe('#0d6efd')
     expect(
       declarations.find(
         (d: CssDeclaration) =>
-          d.property === '--flowglad-button-foreground'
+          d.property === '--flowglad-primary-foreground'
       )?.value
     ).toBe('#ffffff')
     expect(
@@ -240,20 +231,20 @@ describe('themeToCssAst', () => {
   it('should create a valid CSS AST stylesheet for both light and dark themes', () => {
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
         border: '#cccccc',
-        buttonBackground: '#007bff',
-        buttonForeground: '#ffffff',
+        foreground: '#000000',
+        primary: '#007bff',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
       dark: {
-        containerBackground: '#121212',
-        containerForeground: '#ffffff',
+        background: '#121212',
         border: '#333333',
-        buttonBackground: '#0d6efd',
-        buttonForeground: '#ffffff',
+        foreground: '#ffffff',
+        primary: '#0d6efd',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -305,20 +296,20 @@ describe('themeToCssAst', () => {
   it('should ensure .flowglad-root class only contains CSS custom properties', () => {
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
         border: '#cccccc',
-        buttonBackground: '#007bff',
-        buttonForeground: '#ffffff',
+        foreground: '#000000',
+        primary: '#007bff',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
       dark: {
-        containerBackground: '#121212',
-        containerForeground: '#ffffff',
+        background: '#121212',
         border: '#333333',
-        buttonBackground: '#0d6efd',
-        buttonForeground: '#ffffff',
+        foreground: '#ffffff',
+        primary: '#0d6efd',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -359,8 +350,8 @@ describe('themeToCssAst', () => {
       '--flowglad-background',
       '--flowglad-foreground',
       '--flowglad-border',
-      '--flowglad-button',
-      '--flowglad-button-foreground',
+      '--flowglad-primary',
+      '--flowglad-primary-foreground',
       '--flowglad-destructive',
       '--flowglad-destructive-foreground',
     ]
@@ -376,20 +367,20 @@ describe('themeToCssAst', () => {
   it('should ensure .flowglad-dark class only contains CSS custom properties', () => {
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
         border: '#cccccc',
-        buttonBackground: '#007bff',
-        buttonForeground: '#ffffff',
+        foreground: '#000000',
+        primary: '#007bff',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
       dark: {
-        containerBackground: '#121212',
-        containerForeground: '#ffffff',
+        background: '#121212',
         border: '#333333',
-        buttonBackground: '#0d6efd',
-        buttonForeground: '#ffffff',
+        foreground: '#ffffff',
+        primary: '#0d6efd',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -430,8 +421,8 @@ describe('themeToCssAst', () => {
       '--flowglad-background',
       '--flowglad-foreground',
       '--flowglad-border',
-      '--flowglad-button',
-      '--flowglad-button-foreground',
+      '--flowglad-primary',
+      '--flowglad-primary-foreground',
       '--flowglad-destructive',
       '--flowglad-destructive-foreground',
     ]
@@ -448,20 +439,20 @@ describe('themeToCssAst', () => {
     // Create a partial theme config with only some properties defined
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        // containerForeground is not defined
+        background: '#ffffff',
+        // foreground is not defined
         border: '#cccccc',
-        // buttonBackground is not defined
-        buttonForeground: '#ffffff',
+        // primary is not defined
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         // destructiveForeground is not defined
       },
       dark: {
-        containerBackground: '#121212',
-        // containerForeground is not defined
+        background: '#121212',
+        // foreground is not defined
         border: '#333333',
-        // buttonBackground is not defined
-        buttonForeground: '#ffffff',
+        // primary is not defined
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         // destructiveForeground is not defined
       },
@@ -476,57 +467,87 @@ describe('themeToCssAst', () => {
     expect(lightRule.type).toBe('rule')
     expect(lightRule.selectors).toEqual(['.flowglad-root'])
 
-    // Verify only the defined properties are included
+    // Verify only the defined light properties are included
     const lightDeclarations = lightRule.declarations
-    expect(lightDeclarations).toHaveLength(4) // Only 4 properties defined
+    expect(lightDeclarations).toHaveLength(4) // 4 properties defined for light
 
-    // Check that only the defined properties are present
-    const lightProperties = lightDeclarations.map(
-      (d: CssDeclaration) => d.property
+    // Check that properties have the expected values
+    const lightDeclarationsMap = new Map(
+      lightDeclarations.map((d: CssDeclaration) => [
+        d.property,
+        d.value,
+      ])
     )
-    expect(lightProperties).toContain('--flowglad-background')
-    expect(lightProperties).not.toContain('--flowglad-foreground')
-    expect(lightProperties).toContain('--flowglad-border')
-    expect(lightProperties).not.toContain('--flowglad-button')
-    expect(lightProperties).toContain('--flowglad-button-foreground')
-    expect(lightProperties).toContain('--flowglad-destructive')
-    expect(lightProperties).not.toContain(
-      '--flowglad-destructive-foreground'
+    expect(lightDeclarationsMap.get('--flowglad-background')).toBe(
+      '#ffffff'
     )
+    expect(lightDeclarationsMap.get('--flowglad-foreground')).toBe(
+      undefined
+    )
+    expect(lightDeclarationsMap.get('--flowglad-border')).toBe(
+      '#cccccc'
+    )
+    expect(lightDeclarationsMap.get('--flowglad-primary')).toBe(
+      undefined
+    )
+    expect(
+      lightDeclarationsMap.get('--flowglad-primary-foreground')
+    ).toBe('#ffffff')
+    expect(lightDeclarationsMap.get('--flowglad-destructive')).toBe(
+      '#dc3545'
+    )
+    expect(
+      lightDeclarationsMap.get('--flowglad-destructive-foreground')
+    ).toBe(undefined)
 
     // Check dark theme rule
     const darkRule = ast.stylesheet?.rules[1]
     expect(darkRule.type).toBe('rule')
     expect(darkRule.selectors).toEqual(['.flowglad-dark'])
 
-    // Verify only the defined properties are included
+    // Verify only the defined dark properties are included
     const darkDeclarations = darkRule.declarations
-    expect(darkDeclarations).toHaveLength(4) // Only 4 properties defined
+    expect(darkDeclarations).toHaveLength(4) // 4 properties defined for dark
 
-    // Check that only the defined properties are present
-    const darkProperties = darkDeclarations.map(
-      (d: CssDeclaration) => d.property
+    // Check that properties have the expected values
+    const darkDeclarationsMap = new Map(
+      darkDeclarations.map((d: CssDeclaration) => [
+        d.property,
+        d.value,
+      ])
     )
-    expect(darkProperties).toContain('--flowglad-background')
-    expect(darkProperties).not.toContain('--flowglad-foreground')
-    expect(darkProperties).toContain('--flowglad-border')
-    expect(darkProperties).not.toContain('--flowglad-button')
-    expect(darkProperties).toContain('--flowglad-button-foreground')
-    expect(darkProperties).toContain('--flowglad-destructive')
-    expect(darkProperties).not.toContain(
-      '--flowglad-destructive-foreground'
+    expect(darkDeclarationsMap.get('--flowglad-background')).toBe(
+      '#121212'
     )
+    expect(darkDeclarationsMap.get('--flowglad-foreground')).toBe(
+      undefined
+    )
+    expect(darkDeclarationsMap.get('--flowglad-border')).toBe(
+      '#333333'
+    )
+    expect(darkDeclarationsMap.get('--flowglad-primary')).toBe(
+      undefined
+    )
+    expect(
+      darkDeclarationsMap.get('--flowglad-primary-foreground')
+    ).toBe('#ffffff')
+    expect(darkDeclarationsMap.get('--flowglad-destructive')).toBe(
+      '#dc3545'
+    )
+    expect(
+      darkDeclarationsMap.get('--flowglad-destructive-foreground')
+    ).toBe(undefined)
   })
 
   it('should handle theme configs with only light or only dark mode', () => {
     // Test with only light mode
     const lightOnlyTheme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
         border: '#cccccc',
-        buttonBackground: '#007bff',
-        buttonForeground: '#ffffff',
+        foreground: '#000000',
+        primary: '#007bff',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -545,11 +566,11 @@ describe('themeToCssAst', () => {
     // Test with only dark mode
     const darkOnlyTheme: FlowgladThemeConfig = {
       dark: {
-        containerBackground: '#121212',
-        containerForeground: '#ffffff',
+        background: '#121212',
         border: '#333333',
-        buttonBackground: '#0d6efd',
-        buttonForeground: '#ffffff',
+        foreground: '#ffffff',
+        primary: '#0d6efd',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -570,14 +591,14 @@ describe('themeToCssAst', () => {
     // Create a theme config with different properties defined for light and dark
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
+        foreground: '#000000',
         // Other light properties are not defined
       },
       dark: {
         // Only some dark properties are defined
         border: '#333333',
-        buttonBackground: '#0d6efd',
+        primary: '#0d6efd',
         destructive: '#dc3545',
       },
     }
@@ -593,23 +614,36 @@ describe('themeToCssAst', () => {
 
     // Verify only the defined light properties are included
     const lightDeclarations = lightRule.declarations
-    expect(lightDeclarations).toHaveLength(2) // Only 2 properties defined for light
+    expect(lightDeclarations).toHaveLength(2) // 2 declarations set
 
     // Check that only the defined light properties are present
-    const lightProperties = lightDeclarations.map(
-      (d: CssDeclaration) => d.property
+    const lightDeclarationsMap = new Map(
+      lightDeclarations.map((d: CssDeclaration) => [
+        d.property,
+        d.value,
+      ])
     )
-    expect(lightProperties).toContain('--flowglad-background')
-    expect(lightProperties).toContain('--flowglad-foreground')
-    expect(lightProperties).not.toContain('--flowglad-border')
-    expect(lightProperties).not.toContain('--flowglad-button')
-    expect(lightProperties).not.toContain(
-      '--flowglad-button-foreground'
+    expect(lightDeclarationsMap.get('--flowglad-background')).toBe(
+      '#ffffff'
     )
-    expect(lightProperties).not.toContain('--flowglad-destructive')
-    expect(lightProperties).not.toContain(
-      '--flowglad-destructive-foreground'
+    expect(lightDeclarationsMap.get('--flowglad-foreground')).toBe(
+      '#000000'
     )
+    expect(lightDeclarationsMap.get('--flowglad-border')).toBe(
+      undefined
+    )
+    expect(lightDeclarationsMap.get('--flowglad-primary')).toBe(
+      undefined
+    )
+    expect(
+      lightDeclarationsMap.get('--flowglad-primary-foreground')
+    ).toBe(undefined)
+    expect(lightDeclarationsMap.get('--flowglad-destructive')).toBe(
+      undefined
+    )
+    expect(
+      lightDeclarationsMap.get('--flowglad-destructive-foreground')
+    ).toBe(undefined)
 
     // Check dark theme rule
     const darkRule = ast.stylesheet?.rules[1]
@@ -618,30 +652,43 @@ describe('themeToCssAst', () => {
 
     // Verify only the defined dark properties are included
     const darkDeclarations = darkRule.declarations
-    expect(darkDeclarations).toHaveLength(3) // Only 3 properties defined for dark
+    expect(darkDeclarations).toHaveLength(3) // 3 declarations set
 
     // Check that only the defined dark properties are present
-    const darkProperties = darkDeclarations.map(
-      (d: CssDeclaration) => d.property
+    const darkDeclarationsMap = new Map(
+      darkDeclarations.map((d: CssDeclaration) => [
+        d.property,
+        d.value,
+      ])
     )
-    expect(darkProperties).not.toContain('--flowglad-background')
-    expect(darkProperties).not.toContain('--flowglad-foreground')
-    expect(darkProperties).toContain('--flowglad-border')
-    expect(darkProperties).toContain('--flowglad-button')
-    expect(darkProperties).not.toContain(
-      '--flowglad-button-foreground'
+    expect(darkDeclarationsMap.get('--flowglad-background')).toBe(
+      undefined
     )
-    expect(darkProperties).toContain('--flowglad-destructive')
-    expect(darkProperties).not.toContain(
-      '--flowglad-destructive-foreground'
+    expect(darkDeclarationsMap.get('--flowglad-foreground')).toBe(
+      undefined
     )
+    expect(darkDeclarationsMap.get('--flowglad-border')).toBe(
+      '#333333'
+    )
+    expect(darkDeclarationsMap.get('--flowglad-primary')).toBe(
+      '#0d6efd'
+    )
+    expect(
+      darkDeclarationsMap.get('--flowglad-primary-foreground')
+    ).toBe(undefined)
+    expect(darkDeclarationsMap.get('--flowglad-destructive')).toBe(
+      '#dc3545'
+    )
+    expect(
+      darkDeclarationsMap.get('--flowglad-destructive-foreground')
+    ).toBe(undefined)
   })
 })
 
 describe('themeEntryToCss', () => {
   it('should convert a theme entry to a CSS string', async () => {
     const themeEntry: [keyof FlowgladColors, string] = [
-      'containerBackground',
+      'background',
       '#ffffff',
     ]
     const cssString = await themeEntryToCss(themeEntry)
@@ -664,28 +711,29 @@ describe('themeEntryToCss', () => {
 })
 
 describe('themeToCss', () => {
-  it('should return an empty string when theme is undefined', async () => {
+  it('should return a defaults css string when theme is undefined', async () => {
     const cssString = await themeToCss(undefined)
-    expect(cssString).toBe('')
+    const defaultCssString = await themeToCss(defaultTheme)
+    expect(cssString).toBe(defaultCssString)
   })
 
   it('should convert a light theme to a CSS string', async () => {
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
         border: '#cccccc',
-        buttonBackground: '#007bff',
-        buttonForeground: '#ffffff',
+        foreground: '#000000',
+        primary: '#007bff',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
       dark: {
-        containerBackground: '#121212',
-        containerForeground: '#ffffff',
+        background: '#121212',
         border: '#333333',
-        buttonBackground: '#0d6efd',
-        buttonForeground: '#ffffff',
+        foreground: '#ffffff',
+        primary: '#0d6efd',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -702,7 +750,7 @@ describe('themeToCss', () => {
     const lightRule = ast.stylesheet?.rules[0]
     expect(lightRule.type).toBe('rule')
     expect(lightRule.selectors).toEqual(['.flowglad-root'])
-    expect(lightRule.declarations).toHaveLength(7)
+    expect(lightRule.declarations).toHaveLength(17)
 
     // Verify that .flowglad-root class doesn't include any styles on its own
     const rootDeclarations = lightRule.declarations
@@ -722,20 +770,20 @@ describe('themeToCss', () => {
   it('should convert a dark theme to a CSS string', async () => {
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
         border: '#cccccc',
-        buttonBackground: '#007bff',
-        buttonForeground: '#ffffff',
+        foreground: '#000000',
+        primary: '#007bff',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
       dark: {
-        containerBackground: '#121212',
-        containerForeground: '#ffffff',
+        background: '#121212',
         border: '#333333',
-        buttonBackground: '#0d6efd',
-        buttonForeground: '#ffffff',
+        foreground: '#ffffff',
+        primary: '#0d6efd',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -752,7 +800,7 @@ describe('themeToCss', () => {
     const darkRule = ast.stylesheet?.rules[1]
     expect(darkRule.type).toBe('rule')
     expect(darkRule.selectors).toEqual(['.flowglad-dark'])
-    expect(darkRule.declarations).toHaveLength(7)
+    expect(darkRule.declarations).toHaveLength(17)
 
     // Verify that .flowglad-dark class doesn't include any styles on its own
     const darkDeclarations = darkRule.declarations
@@ -772,20 +820,20 @@ describe('themeToCss', () => {
   it('should convert both light and dark themes to a CSS string', async () => {
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
         border: '#cccccc',
-        buttonBackground: '#007bff',
-        buttonForeground: '#ffffff',
+        foreground: '#000000',
+        primary: '#007bff',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
       dark: {
-        containerBackground: '#121212',
-        containerForeground: '#ffffff',
+        background: '#121212',
         border: '#333333',
-        buttonBackground: '#0d6efd',
-        buttonForeground: '#ffffff',
+        foreground: '#ffffff',
+        primary: '#0d6efd',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -839,20 +887,20 @@ describe('themeToCss', () => {
   it('should ensure .flowglad-root class in CSS string only contains CSS custom properties', async () => {
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
         border: '#cccccc',
-        buttonBackground: '#007bff',
-        buttonForeground: '#ffffff',
+        foreground: '#000000',
+        primary: '#007bff',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
       dark: {
-        containerBackground: '#121212',
-        containerForeground: '#ffffff',
+        background: '#121212',
         border: '#333333',
-        buttonBackground: '#0d6efd',
-        buttonForeground: '#ffffff',
+        foreground: '#ffffff',
+        primary: '#0d6efd',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -895,8 +943,8 @@ describe('themeToCss', () => {
       '--flowglad-background',
       '--flowglad-foreground',
       '--flowglad-border',
-      '--flowglad-button',
-      '--flowglad-button-foreground',
+      '--flowglad-primary',
+      '--flowglad-primary-foreground',
       '--flowglad-destructive',
       '--flowglad-destructive-foreground',
     ]
@@ -912,20 +960,20 @@ describe('themeToCss', () => {
   it('should ensure .flowglad-dark class in CSS string only contains CSS custom properties', async () => {
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
         border: '#cccccc',
-        buttonBackground: '#007bff',
-        buttonForeground: '#ffffff',
+        foreground: '#000000',
+        primary: '#007bff',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
       dark: {
-        containerBackground: '#121212',
-        containerForeground: '#ffffff',
+        background: '#121212',
         border: '#333333',
-        buttonBackground: '#0d6efd',
-        buttonForeground: '#ffffff',
+        foreground: '#ffffff',
+        primary: '#0d6efd',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -968,8 +1016,8 @@ describe('themeToCss', () => {
       '--flowglad-background',
       '--flowglad-foreground',
       '--flowglad-border',
-      '--flowglad-button',
-      '--flowglad-button-foreground',
+      '--flowglad-primary',
+      '--flowglad-primary-foreground',
       '--flowglad-destructive',
       '--flowglad-destructive-foreground',
     ]
@@ -986,20 +1034,20 @@ describe('themeToCss', () => {
     // Create a partial theme config with only some properties defined
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        // containerForeground is not defined
+        background: '#ffffff',
+        // foreground is not defined
         border: '#cccccc',
-        // buttonBackground is not defined
-        buttonForeground: '#ffffff',
+        // primary is not defined
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         // destructiveForeground is not defined
       },
       dark: {
-        containerBackground: '#121212',
-        // containerForeground is not defined
+        background: '#121212',
+        // foreground is not defined
         border: '#333333',
-        // buttonBackground is not defined
-        buttonForeground: '#ffffff',
+        // primary is not defined
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         // destructiveForeground is not defined
       },
@@ -1020,55 +1068,85 @@ describe('themeToCss', () => {
 
     // Verify only the defined properties are included
     const lightDeclarations = lightRule.declarations
-    expect(lightDeclarations).toHaveLength(4) // Only 4 properties defined
+    expect(lightDeclarations).toHaveLength(17) // All 17 properties defined for light, because of defaultTheme
 
-    // Check that only the defined properties are present
-    const lightProperties = lightDeclarations.map(
-      (d: CssDeclaration) => d.property
+    // Check that properties have the expected values
+    const lightDeclarationsMap = new Map(
+      lightDeclarations.map((d: CssDeclaration) => [
+        d.property,
+        d.value,
+      ])
     )
-    expect(lightProperties).toContain('--flowglad-background')
-    expect(lightProperties).not.toContain('--flowglad-foreground')
-    expect(lightProperties).toContain('--flowglad-border')
-    expect(lightProperties).not.toContain('--flowglad-button')
-    expect(lightProperties).toContain('--flowglad-button-foreground')
-    expect(lightProperties).toContain('--flowglad-destructive')
-    expect(lightProperties).not.toContain(
-      '--flowglad-destructive-foreground'
+    expect(lightDeclarationsMap.get('--flowglad-background')).toBe(
+      '#ffffff'
     )
+    expect(lightDeclarationsMap.get('--flowglad-foreground')).toBe(
+      'hsl(240 10% 3.9%)'
+    )
+    expect(lightDeclarationsMap.get('--flowglad-border')).toBe(
+      '#cccccc'
+    )
+    expect(lightDeclarationsMap.get('--flowglad-primary')).toBe(
+      'hsl(240 5.9% 10%)'
+    )
+    expect(
+      lightDeclarationsMap.get('--flowglad-primary-foreground')
+    ).toBe('#ffffff')
+    expect(lightDeclarationsMap.get('--flowglad-destructive')).toBe(
+      '#dc3545'
+    )
+    expect(
+      lightDeclarationsMap.get('--flowglad-destructive-foreground')
+    ).toBe('hsl(0 0% 98%)')
 
     // Check dark theme rule
     const darkRule = ast.stylesheet?.rules[1]
     expect(darkRule.type).toBe('rule')
     expect(darkRule.selectors).toEqual(['.flowglad-dark'])
 
-    // Verify only the defined properties are included
+    // Verify only the defined dark properties are included
     const darkDeclarations = darkRule.declarations
-    expect(darkDeclarations).toHaveLength(4) // Only 4 properties defined
+    expect(darkDeclarations).toHaveLength(17) // All 17 properties defined for dark, because of defaultTheme
 
-    // Check that only the defined properties are present
-    const darkProperties = darkDeclarations.map(
-      (d: CssDeclaration) => d.property
+    // Check that properties have the expected values
+    const darkDeclarationsMap = new Map(
+      darkDeclarations.map((d: CssDeclaration) => [
+        d.property,
+        d.value,
+      ])
     )
-    expect(darkProperties).toContain('--flowglad-background')
-    expect(darkProperties).not.toContain('--flowglad-foreground')
-    expect(darkProperties).toContain('--flowglad-border')
-    expect(darkProperties).not.toContain('--flowglad-button')
-    expect(darkProperties).toContain('--flowglad-button-foreground')
-    expect(darkProperties).toContain('--flowglad-destructive')
-    expect(darkProperties).not.toContain(
-      '--flowglad-destructive-foreground'
+    expect(darkDeclarationsMap.get('--flowglad-background')).toBe(
+      '#121212'
     )
+    expect(darkDeclarationsMap.get('--flowglad-foreground')).toBe(
+      'hsl(0 0% 98%)'
+    )
+    expect(darkDeclarationsMap.get('--flowglad-border')).toBe(
+      '#333333'
+    )
+    expect(darkDeclarationsMap.get('--flowglad-primary')).toBe(
+      'hsl(0 0% 98%)'
+    )
+    expect(
+      darkDeclarationsMap.get('--flowglad-primary-foreground')
+    ).toBe('#ffffff')
+    expect(darkDeclarationsMap.get('--flowglad-destructive')).toBe(
+      '#dc3545'
+    )
+    expect(
+      darkDeclarationsMap.get('--flowglad-destructive-foreground')
+    ).toBe('hsl(0 0% 98%)')
   })
 
   it('should handle theme configs with only light or only dark mode', async () => {
     // Test with only light mode
     const lightOnlyTheme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
         border: '#cccccc',
-        buttonBackground: '#007bff',
-        buttonForeground: '#ffffff',
+        foreground: '#000000',
+        primary: '#007bff',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -1078,22 +1156,23 @@ describe('themeToCss', () => {
     const tools = await initCssTools()
     const lightOnlyAst = tools.parse(lightOnlyCssString)
     expect(lightOnlyAst.type).toBe('stylesheet')
-    expect(lightOnlyAst.stylesheet?.rules).toHaveLength(1)
+    // 2 rules: .flowglad-root and .flowglad-dark
+    expect(lightOnlyAst.stylesheet?.rules).toHaveLength(2)
     expect(lightOnlyAst.stylesheet?.rules[0].selectors).toEqual([
       '.flowglad-root',
     ])
     expect(
       lightOnlyAst.stylesheet?.rules[0].declarations
-    ).toHaveLength(7)
+    ).toHaveLength(17)
 
     // Test with only dark mode
     const darkOnlyTheme: FlowgladThemeConfig = {
       dark: {
-        containerBackground: '#121212',
-        containerForeground: '#ffffff',
+        background: '#121212',
         border: '#333333',
-        buttonBackground: '#0d6efd',
-        buttonForeground: '#ffffff',
+        foreground: '#ffffff',
+        primary: '#0d6efd',
+        primaryForeground: '#ffffff',
         destructive: '#dc3545',
         destructiveForeground: '#ffffff',
       },
@@ -1102,27 +1181,30 @@ describe('themeToCss', () => {
     const darkOnlyCssString = await themeToCss(darkOnlyTheme)
     const darkOnlyAst = tools.parse(darkOnlyCssString)
     expect(darkOnlyAst.type).toBe('stylesheet')
-    expect(darkOnlyAst.stylesheet?.rules).toHaveLength(1)
+    expect(darkOnlyAst.stylesheet?.rules).toHaveLength(2)
     expect(darkOnlyAst.stylesheet?.rules[0].selectors).toEqual([
+      '.flowglad-root',
+    ])
+    expect(darkOnlyAst.stylesheet?.rules[1].selectors).toEqual([
       '.flowglad-dark',
     ])
     expect(
       darkOnlyAst.stylesheet?.rules[0].declarations
-    ).toHaveLength(7)
+    ).toHaveLength(17)
   })
 
   it('should handle heterogeneous shapes of light and dark configs', async () => {
     // Create a theme config with different properties defined for light and dark
     const theme: FlowgladThemeConfig = {
       light: {
-        containerBackground: '#ffffff',
-        containerForeground: '#000000',
+        background: '#ffffff',
+        foreground: '#000000',
         // Other light properties are not defined
       },
       dark: {
         // Only some dark properties are defined
         border: '#333333',
-        buttonBackground: '#0d6efd',
+        primary: '#0d6efd',
         destructive: '#dc3545',
       },
     }
@@ -1142,23 +1224,37 @@ describe('themeToCss', () => {
 
     // Verify only the defined light properties are included
     const lightDeclarations = lightRule.declarations
-    expect(lightDeclarations).toHaveLength(2) // Only 2 properties defined for light
+    // All 17 properties defined for light, because of defaultTheme
+    expect(lightDeclarations).toHaveLength(17)
 
     // Check that only the defined light properties are present
-    const lightProperties = lightDeclarations.map(
-      (d: CssDeclaration) => d.property
+    const lightDeclarationsMap = new Map(
+      lightDeclarations.map((d: CssDeclaration) => [
+        d.property,
+        d.value,
+      ])
     )
-    expect(lightProperties).toContain('--flowglad-background')
-    expect(lightProperties).toContain('--flowglad-foreground')
-    expect(lightProperties).not.toContain('--flowglad-border')
-    expect(lightProperties).not.toContain('--flowglad-button')
-    expect(lightProperties).not.toContain(
-      '--flowglad-button-foreground'
+    expect(lightDeclarationsMap.get('--flowglad-background')).toBe(
+      '#ffffff'
     )
-    expect(lightProperties).not.toContain('--flowglad-destructive')
-    expect(lightProperties).not.toContain(
-      '--flowglad-destructive-foreground'
+    expect(lightDeclarationsMap.get('--flowglad-foreground')).toBe(
+      '#000000'
     )
+    expect(lightDeclarationsMap.get('--flowglad-border')).toBe(
+      'hsl(240 5.9% 90%)'
+    )
+    expect(lightDeclarationsMap.get('--flowglad-primary')).toBe(
+      'hsl(240 5.9% 10%)'
+    )
+    expect(
+      lightDeclarationsMap.get('--flowglad-primary-foreground')
+    ).toBe('hsl(0 0% 98%)')
+    expect(lightDeclarationsMap.get('--flowglad-destructive')).toBe(
+      'hsl(0 84.2% 60.2%)'
+    )
+    expect(
+      lightDeclarationsMap.get('--flowglad-destructive-foreground')
+    ).toBe('hsl(0 0% 98%)')
 
     // Check dark theme rule
     const darkRule = ast.stylesheet?.rules[1]
@@ -1167,22 +1263,35 @@ describe('themeToCss', () => {
 
     // Verify only the defined dark properties are included
     const darkDeclarations = darkRule.declarations
-    expect(darkDeclarations).toHaveLength(3) // Only 3 properties defined for dark
+    expect(darkDeclarations).toHaveLength(17) // All 17 properties defined for dark, because of defaultTheme
 
     // Check that only the defined dark properties are present
-    const darkProperties = darkDeclarations.map(
-      (d: CssDeclaration) => d.property
+    const darkDeclarationsMap = new Map(
+      darkDeclarations.map((d: CssDeclaration) => [
+        d.property,
+        d.value,
+      ])
     )
-    expect(darkProperties).not.toContain('--flowglad-background')
-    expect(darkProperties).not.toContain('--flowglad-foreground')
-    expect(darkProperties).toContain('--flowglad-border')
-    expect(darkProperties).toContain('--flowglad-button')
-    expect(darkProperties).not.toContain(
-      '--flowglad-button-foreground'
+    expect(darkDeclarationsMap.get('--flowglad-background')).toBe(
+      'hsl(240 10% 3.9%)'
     )
-    expect(darkProperties).toContain('--flowglad-destructive')
-    expect(darkProperties).not.toContain(
-      '--flowglad-destructive-foreground'
+    expect(darkDeclarationsMap.get('--flowglad-foreground')).toBe(
+      'hsl(0 0% 98%)'
     )
+    expect(darkDeclarationsMap.get('--flowglad-border')).toBe(
+      '#333333'
+    )
+    expect(darkDeclarationsMap.get('--flowglad-primary')).toBe(
+      '#0d6efd'
+    )
+    expect(
+      darkDeclarationsMap.get('--flowglad-primary-foreground')
+    ).toBe('hsl(240 5.9% 10%)')
+    expect(darkDeclarationsMap.get('--flowglad-destructive')).toBe(
+      '#dc3545'
+    )
+    expect(
+      darkDeclarationsMap.get('--flowglad-destructive-foreground')
+    ).toBe('hsl(0 0% 98%)')
   })
 })

--- a/packages/react/src/lib/themes.ts
+++ b/packages/react/src/lib/themes.ts
@@ -1,0 +1,256 @@
+// Import css-tools dynamically
+let cssTools: {
+  parse: (css: string) => CssAstStylesheet
+  stringify: (ast: CssAstStylesheet) => string
+} | null = null
+
+// Initialize css-tools
+const initCssTools = async () => {
+  if (!cssTools) {
+    const module = await import('@adobe/css-tools')
+    cssTools = {
+      parse: module.parse as (css: string) => CssAstStylesheet,
+      stringify: module.stringify as (
+        ast: CssAstStylesheet
+      ) => string,
+    }
+  }
+  return cssTools
+}
+
+const propertyMap: Record<keyof FlowgladColors, string> = {
+  background: 'background',
+  card: 'card',
+  cardForeground: 'card-foreground',
+  border: 'border',
+  primary: 'primary',
+  primaryForeground: 'primary-foreground',
+  foreground: 'foreground',
+  secondary: 'secondary',
+  secondaryForeground: 'secondary-foreground',
+  muted: 'muted',
+  mutedForeground: 'muted-foreground',
+  accent: 'accent',
+  accentForeground: 'accent-foreground',
+  destructive: 'destructive',
+  destructiveForeground: 'destructive-foreground',
+  input: 'input',
+  ring: 'ring',
+}
+
+interface CssAstDeclaration {
+  type: 'declaration'
+  property: string
+  value: string
+}
+
+interface CssAstRule {
+  type: 'rule'
+  selectors: string[]
+  declarations: CssAstDeclaration[]
+}
+
+/**
+ * Takes a tuple of [key, value] and returns a CSS AST rule for the theme entry
+ * @param themeEntry
+ * @returns CSS AST rule
+ */
+export function themeEntryToCssAst(
+  themeEntry: [keyof FlowgladColors, string]
+): CssAstRule {
+  const [key, value] = themeEntry
+
+  return {
+    type: 'rule',
+    selectors: [`.flowglad-root`],
+    declarations: [
+      {
+        type: 'declaration',
+        property: `--flowglad-${propertyMap[key]}`,
+        value,
+      },
+    ],
+  }
+}
+
+interface CssAstStylesheet {
+  type: 'stylesheet'
+  stylesheet: {
+    rules: CssAstRule[]
+  }
+}
+
+/**
+ * Converts a theme object to a CSS AST stylesheet.
+ * This will only include the properties that are defined in the theme object.
+ * It will not include the default values from the defaultTheme.
+ * @param theme The theme object
+ * @returns CSS AST stylesheet
+ */
+export function themeToCssAst(
+  theme?: FlowgladThemeConfig
+): CssAstStylesheet {
+  if (!theme) {
+    return {
+      type: 'stylesheet',
+      stylesheet: {
+        rules: [],
+      },
+    }
+  }
+
+  const rules: CssAstRule[] = []
+
+  if (theme.light) {
+    const lightRule: CssAstRule = {
+      type: 'rule',
+      selectors: ['.flowglad-root'],
+      declarations: Object.entries(theme.light).map(
+        ([key, value]) => ({
+          type: 'declaration',
+          property: `--flowglad-${propertyMap[key as keyof FlowgladColors]}`,
+          value,
+        })
+      ),
+    }
+    rules.push(lightRule)
+  }
+
+  if (theme.dark) {
+    const darkRule: CssAstRule = {
+      type: 'rule',
+      selectors: ['.flowglad-dark'],
+      declarations: Object.entries(theme.dark).map(
+        ([key, value]) => ({
+          type: 'declaration',
+          property: `--flowglad-${propertyMap[key as keyof FlowgladColors]}`,
+          value,
+        })
+      ),
+    }
+    rules.push(darkRule)
+  }
+
+  return {
+    type: 'stylesheet',
+    stylesheet: {
+      rules,
+    },
+  }
+}
+
+/**
+ * Converts a theme entry to a CSS string
+ * @param themeEntry The theme entry
+ * @returns CSS string
+ */
+export async function themeEntryToCss(
+  themeEntry: [keyof FlowgladColors, string]
+): Promise<string> {
+  const rule = themeEntryToCssAst(themeEntry)
+  const ast: CssAstStylesheet = {
+    type: 'stylesheet',
+    stylesheet: {
+      rules: [rule],
+    },
+  }
+  const { stringify } = await initCssTools()
+  return stringify(ast)
+}
+
+/**
+ * Converts a theme object to a CSS string
+ * @param theme The theme object
+ * @returns CSS string
+ */
+export async function themeToCss(
+  theme?: FlowgladThemeConfig
+): Promise<string> {
+  const mergedTheme: FlowgladThemeConfig = {
+    ...defaultTheme,
+    light: {
+      ...defaultTheme.light,
+      ...theme?.light,
+    },
+    dark: {
+      ...defaultTheme.dark,
+      ...theme?.dark,
+    },
+    mode: theme?.mode ?? defaultTheme.mode,
+  }
+  const ast = themeToCssAst(mergedTheme)
+  const { stringify } = await initCssTools()
+  const css = stringify(ast)
+  return css
+}
+
+export interface FlowgladColors {
+  background: string
+  card: string
+  cardForeground: string
+  // containerForeground: string
+  border: string
+  primary: string
+  primaryForeground: string
+  foreground: string
+  secondary: string
+  secondaryForeground: string
+  muted: string
+  mutedForeground: string
+  accent: string
+  accentForeground: string
+  destructive: string
+  destructiveForeground: string
+  input: string
+  ring: string
+  // buttonBackground: string
+  // buttonForeground: string
+}
+
+export interface FlowgladThemeConfig {
+  light?: Partial<FlowgladColors>
+  dark?: Partial<FlowgladColors>
+  mode?: 'light' | 'dark' | 'system'
+}
+
+export const defaultTheme: FlowgladThemeConfig = {
+  light: {
+    background: 'hsl(0 0% 100%)',
+    border: 'hsl(240 5.9% 90%)',
+    card: 'hsl(0 0% 100%)',
+    cardForeground: 'hsl(240 10% 3.9%)',
+    primary: 'hsl(240 5.9% 10%)',
+    primaryForeground: 'hsl(0 0% 98%)',
+    foreground: 'hsl(240 10% 3.9%)',
+    secondary: 'hsl(240 4.8% 95.9%)',
+    secondaryForeground: 'hsl(240 5.9% 10%)',
+    muted: 'hsl(240 4.8% 95.9%)',
+    mutedForeground: 'hsl(240 3.8% 46.1%)',
+    accent: 'hsl(240 4.8% 95.9%)',
+    accentForeground: 'hsl(240 5.9% 10%)',
+    destructive: 'hsl(0 84.2% 60.2%)',
+    destructiveForeground: 'hsl(0 0% 98%)',
+    input: 'hsl(240 5.9% 90%)',
+    ring: 'hsl(240 10% 3.9%)',
+  },
+  dark: {
+    background: 'hsl(240 10% 3.9%)',
+    border: 'hsl(240 3.7% 15.9%)',
+    card: 'hsl(240 10% 3.9%)',
+    cardForeground: 'hsl(0 0% 98%)',
+    primary: 'hsl(0 0% 98%)',
+    primaryForeground: 'hsl(240 5.9% 10%)',
+    foreground: 'hsl(0 0% 98%)',
+    secondary: 'hsl(240 3.7% 15.9%)',
+    secondaryForeground: 'hsl(0 0% 98%)',
+    muted: 'hsl(240 3.7% 15.9%)',
+    mutedForeground: 'hsl(240 5% 64.9%)',
+    accent: 'hsl(240 3.7% 15.9%)',
+    accentForeground: 'hsl(0 0% 98%)',
+    destructive: 'hsl(0 62.8% 30.6%)',
+    destructiveForeground: 'hsl(0 0% 98%)',
+    input: 'hsl(240 3.7% 15.9%)',
+    ring: 'hsl(240 4.9% 83.9%)',
+  },
+  mode: 'system',
+} as const

--- a/packages/react/tailwind.config.ts
+++ b/packages/react/tailwind.config.ts
@@ -9,46 +9,35 @@ export default {
   theme: {
     extend: {
       colors: {
-        background: 'hsl(var(--flowglad-background))',
-        foreground: 'hsl(var(--flowglad-foreground))',
+        background: 'var(--flowglad-background)',
+        foreground: 'var(--flowglad-foreground)',
         card: {
-          DEFAULT: 'hsl(var(--flowglad-card))',
-          foreground: 'hsl(var(--flowglad-card-foreground))',
-        },
-        popover: {
-          DEFAULT: 'hsl(var(--flowglad-popover))',
-          foreground: 'hsl(var(--flowglad-popover-foreground))',
+          DEFAULT: 'var(--flowglad-card)',
+          foreground: 'var(--flowglad-card-foreground)',
         },
         primary: {
-          DEFAULT: 'hsl(var(--flowglad-primary))',
-          foreground: 'hsl(var(--flowglad-primary-foreground))',
+          DEFAULT: 'var(--flowglad-primary)',
+          foreground: 'var(--flowglad-primary-foreground)',
         },
         secondary: {
-          DEFAULT: 'hsl(var(--flowglad-secondary))',
-          foreground: 'hsl(var(--flowglad-secondary-foreground))',
+          DEFAULT: 'var(--flowglad-secondary)',
+          foreground: 'var(--flowglad-secondary-foreground)',
         },
         muted: {
-          DEFAULT: 'hsl(var(--flowglad-muted))',
-          foreground: 'hsl(var(--flowglad-muted-foreground))',
+          DEFAULT: 'var(--flowglad-muted)',
+          foreground: 'var(--flowglad-muted-foreground)',
         },
         accent: {
-          DEFAULT: 'hsl(var(--flowglad-accent))',
-          foreground: 'hsl(var(--flowglad-accent-foreground))',
+          DEFAULT: 'var(--flowglad-accent)',
+          foreground: 'var(--flowglad-accent-foreground)',
         },
         destructive: {
-          DEFAULT: 'hsl(var(--flowglad-destructive))',
-          foreground: 'hsl(var(--flowglad-destructive-foreground))',
+          DEFAULT: 'var(--flowglad-destructive)',
+          foreground: 'var(--flowglad-destructive-foreground)',
         },
-        border: 'hsl(var(--flowglad-border))',
-        input: 'hsl(var(--flowglad-input))',
-        ring: 'hsl(var(--flowglad-ring))',
-        chart: {
-          '1': 'hsl(var(--flowglad-chart-1))',
-          '2': 'hsl(var(--flowglad-chart-2))',
-          '3': 'hsl(var(--flowglad-chart-3))',
-          '4': 'hsl(var(--flowglad-chart-4))',
-          '5': 'hsl(var(--flowglad-chart-5))',
-        },
+        border: 'var(--flowglad-border)',
+        input: 'var(--flowglad-input)',
+        ring: 'var(--flowglad-ring)',
       },
       borderRadius: {
         lg: 'var(--flowglad-radius)',
@@ -102,9 +91,6 @@ export default {
             foreground: 'var(--flowglad-foreground)',
             card: 'var(--flowglad-card)',
             'card-foreground': 'var(--flowglad-card-foreground)',
-            popover: 'var(--flowglad-popover)',
-            'popover-foreground':
-              'var(--flowglad-popover-foreground)',
             primary: 'var(--flowglad-primary)',
             'primary-foreground':
               'var(--flowglad-primary-foreground)',

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -14,5 +14,6 @@
         "@/*": ["./*"]
       }  
     },
-    "include": ["src"]
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
+    "include": ["src", "./vitest.setup.ts"]
   }

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,0 +1,19 @@
+const { defineConfig } = require('vitest/config')
+// import { loadEnv } from 'vite'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+})

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
     include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    /**
+     * Exclude generated styles to prevent infinite re-runs
+     * looped by the script re-executing during the setup step
+     */
+    exclude: ['**/generated/styles.ts', '**/node_modules/**'],
     globals: true,
   },
   resolve: {

--- a/packages/react/vitest.setup.ts
+++ b/packages/react/vitest.setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+afterEach(() => {
+  cleanup()
+})

--- a/packages/react/vitest.setup.ts
+++ b/packages/react/vitest.setup.ts
@@ -1,6 +1,16 @@
 import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
 import { afterEach } from 'vitest'
+import { execSync } from 'child_process'
+import path from 'path'
+
+// Run the CSS build script before tests start
+try {
+  const scriptPath = path.resolve(__dirname, './scripts/build-css.ts')
+  execSync(`tsx ${scriptPath}`, { stdio: 'inherit' })
+} catch (error) {
+  console.error('Failed to build CSS:', error)
+}
 
 afterEach(() => {
   cleanup()

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -27,7 +27,7 @@
     "dotenv": "^16.4.5",
     "eslint": "8.57.0",
     "typescript": "5.8.2",
-    "vitest": "^3.0.5",
+    "vitest": "3.0.5",
     "msw": "^2.7.0"
   },
   "exports": {

--- a/platform/flowglad-next/src/app/layout.tsx
+++ b/platform/flowglad-next/src/app/layout.tsx
@@ -4,7 +4,6 @@ import { Toaster } from 'sonner'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
-import dynamic from 'next/dynamic'
 
 import Providers from './Providers'
 import { cn } from '@/utils/core'

--- a/platform/flowglad-next/src/server/routers/checkoutSessionsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/checkoutSessionsRouter.ts
@@ -286,7 +286,6 @@ export const createCheckoutSession = protectedProcedure
           CheckoutSessionType.AddPaymentMethod
             ? `${process.env.NEXT_PUBLIC_APP_URL}/add-payment-method/${checkoutSession.id}`
             : `${process.env.NEXT_PUBLIC_APP_URL}/checkout/${checkoutSession.id}`
-        console.log('====url', url)
         return {
           checkoutSession: updatedCheckoutSession,
           url,

--- a/platform/flowglad-next/src/server/routers/pricesRouter.ts
+++ b/platform/flowglad-next/src/server/routers/pricesRouter.ts
@@ -71,7 +71,6 @@ export const createPrice = protectedProcedure
         const defaultPrices = [...existingPrices, price].filter(
           (v) => v.isDefault
         )
-        console.log('defaultPrices', defaultPrices)
         if (defaultPrices.length > 1) {
           throw new TRPCError({
             code: 'BAD_REQUEST',

--- a/platform/hosted-billing/package.json
+++ b/platform/hosted-billing/package.json
@@ -10,7 +10,7 @@
     "install-packages": "pnpm install --ignore-workspace"
   },
   "dependencies": {
-    "@flowglad/nextjs": "latest",
+    "@flowglad/nextjs": "0.10.7",
     "@hookform/resolvers": "3.10.0",
     "@radix-ui/react-label": "2.1.4",
     "@stackframe/stack": "^2.7.27",

--- a/platform/hosted-billing/pnpm-lock.yaml
+++ b/platform/hosted-billing/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@flowglad/nextjs':
-        specifier: latest
-        version: 0.10.6(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(next@15.3.1(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)
+        specifier: 0.10.7
+        version: 0.10.7(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(next@15.2.3(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)
       '@hookform/resolvers':
         specifier: 3.10.0
         version: 3.10.0(react-hook-form@7.53.1(react@19.1.0))
@@ -19,7 +19,7 @@ importers:
         version: 2.1.4(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@stackframe/stack':
         specifier: ^2.7.27
-        version: 2.8.8(@babel/core@7.26.10)(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(next@15.3.1(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)
+        version: 2.8.8(@babel/core@7.26.10)(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(next@15.2.3(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)
       '@t3-oss/env-nextjs':
         specifier: ^0.13.0
         version: 0.13.0(arktype@2.1.20)(typescript@5.8.3)(zod@3.24.3)
@@ -42,8 +42,8 @@ importers:
         specifier: 0.479.0
         version: 0.479.0(react@19.1.0)
       next:
-        specifier: 15.3.1
-        version: 15.3.1(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 15.2.3
+        version: 15.2.3(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -404,28 +404,25 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
-  '@flowglad/nextjs@0.10.6':
-    resolution: {integrity: sha512-uY6I/Y1u+GWsA8AXluv7MyVGHIG5FdTuUVZ7Bn1fbj8I7Ok6+Fz77/zt4IY5Rj0n1gDMYK/emhHOqYFmTKjMgw==}
+  '@flowglad/nextjs@0.10.7':
+    resolution: {integrity: sha512-B6IUu+ofk58BFMQVshDLpIxKxnU/bsIEvvXJIvPc/XZQcabz1FP7o9wQg0Lj3ZGBY1xKM67cfNe8hso+NoNWdQ==}
     peerDependencies:
       next: ^14.0.3 || ^15.0.0
       react: ^19.0.0 || ^18.0.0
 
-  '@flowglad/node@0.14.0':
-    resolution: {integrity: sha512-gbvCjpAu2FNpgJ2DPwlTX8tQinKcjiTpnTyxMCFEgV0nRChJB5wR7nkgmCS/Au/SC/Nm8EBAf335WM4FkAlmlQ==}
+  '@flowglad/node@0.19.3':
+    resolution: {integrity: sha512-vCuclxY9EQMp6k+DFR1r6pqrz+O5DHjqYPcnqDVfQ28vGnyyI7WsJ7mHK7ZHvbhunIjzfVdKYP98oCeQKPwPMA==}
 
-  '@flowglad/node@0.19.2':
-    resolution: {integrity: sha512-e789h1LlIwKdCwTKK4V25x6lpwCloWj55vpLu/XUMMbwbFNactYi6WIaKbhv6Lyz/60AxPtoUIzaSbtE1eMQsQ==}
-
-  '@flowglad/react@0.10.6':
-    resolution: {integrity: sha512-klHZESR7YZILkKBzJ7THLlpJkwndtAUYQtBqyPK2HwSQReu1A6aRUM9Ovyd2Eb25pUM5Tan1yizpVLItvoiSow==}
+  '@flowglad/react@0.10.7':
+    resolution: {integrity: sha512-lwny/yWzkW62Bp/Pa3fqlgfuAD4Uc74PZGB8j9TOwG/2MyYmlZ6dDPz36dCcdY48/+g6UWkGxzDwdalyhog2FQ==}
     peerDependencies:
       react: ^19.0.0 || ^18.0.0
 
-  '@flowglad/server@0.10.6':
-    resolution: {integrity: sha512-fq47nWSmBn/jkdjeMn3bVaun/mpEPlLBtnbxMuxq/YRHW+2WVwx+UBkdls9ONYpR5aF1tJkQocrUysS7go4eKA==}
+  '@flowglad/server@0.10.7':
+    resolution: {integrity: sha512-wlVs1fgoDlT95YwCQpQKLF2xucqleAr3AM/ST/S+YOJvaxH/SHRQTQhzzCH8ofHHxqHFYFe6MQgKAGugx0wBOA==}
 
-  '@flowglad/shared@0.10.6':
-    resolution: {integrity: sha512-KxeEKBh++q8f1vyEazhW+AEUIbBt2RGcg2CFqFuZ4maEXoUm7BBnkKdu6fC7nj5X/sOMCRKdy/RMsT7E0Jux3A==}
+  '@flowglad/shared@0.10.7':
+    resolution: {integrity: sha512-hGGsNB2fnwDAjiCOvvK+/rWmcVUocnYMD5Q7wUkuZqZ7iZHFjGCFNwnyzlTCTKD7da4kEBge/81PmuOXlfitHw==}
 
   '@hookform/resolvers@3.10.0':
     resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
@@ -452,112 +449,107 @@ packages:
     resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
     engines: {node: '>=18.18'}
 
-  '@img/sharp-darwin-arm64@0.34.1':
-    resolution: {integrity: sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A==}
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.1':
-    resolution: {integrity: sha512-VfuYgG2r8BpYiOUN+BfYeFo69nP/MIwAtSJ7/Zpxc5QF3KS22z8Pvg3FkrSFJBPNQ7mmcUcYQFBmEQp7eu1F8Q==}
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.1.0':
-    resolution: {integrity: sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA==}
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.1.0':
-    resolution: {integrity: sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ==}
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.1.0':
-    resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-arm@1.1.0':
-    resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-libvips-linux-ppc64@1.1.0':
-    resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-s390x@1.1.0':
-    resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-libvips-linux-x64@1.1.0':
-    resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
-    resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.1.0':
-    resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.34.1':
-    resolution: {integrity: sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ==}
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linux-arm@0.34.1':
-    resolution: {integrity: sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA==}
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-linux-s390x@0.34.1':
-    resolution: {integrity: sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA==}
+  '@img/sharp-linux-s390x@0.33.5':
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-linux-x64@0.34.1':
-    resolution: {integrity: sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==}
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.34.1':
-    resolution: {integrity: sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ==}
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-x64@0.34.1':
-    resolution: {integrity: sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==}
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-wasm32@0.34.1':
-    resolution: {integrity: sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg==}
+  '@img/sharp-wasm32@0.33.5':
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
-  '@img/sharp-win32-ia32@0.34.1':
-    resolution: {integrity: sha512-WKf/NAZITnonBf3U1LfdjoMgNO5JYRSlhovhRhMxXVdvWYveM4kM3L8m35onYIdh75cOMCo1BexgVQcCDzyoWw==}
+  '@img/sharp-win32-ia32@0.33.5':
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.34.1':
-    resolution: {integrity: sha512-hw1iIAHpNE8q3uMIRCgGOeDoz9KtFNarFLQclLxr/LK1VBkj8nby18RjFvr6aP7USRYAjTZW6yisnBWMX571Tw==}
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -591,56 +583,56 @@ packages:
   '@napi-rs/wasm-runtime@0.2.9':
     resolution: {integrity: sha512-OKRBiajrrxB9ATokgEQoG87Z25c67pCpYcCwmXYX8PBftC9pBfN18gnm/fh1wurSLEKIAt+QRFLFCQISrb66Jg==}
 
-  '@next/env@15.3.1':
-    resolution: {integrity: sha512-cwK27QdzrMblHSn9DZRV+DQscHXRuJv6MydlJRpFSqJWZrTYMLzKDeyueJNN9MGd8NNiUKzDQADAf+dMLXX7YQ==}
+  '@next/env@15.2.3':
+    resolution: {integrity: sha512-a26KnbW9DFEUsSxAxKBORR/uD9THoYoKbkpFywMN/AFvboTt94b8+g/07T8J6ACsdLag8/PDU60ov4rPxRAixw==}
 
   '@next/eslint-plugin-next@15.3.1':
     resolution: {integrity: sha512-oEs4dsfM6iyER3jTzMm4kDSbrQJq8wZw5fmT6fg2V3SMo+kgG+cShzLfEV20senZzv8VF+puNLheiGPlBGsv2A==}
 
-  '@next/swc-darwin-arm64@15.3.1':
-    resolution: {integrity: sha512-hjDw4f4/nla+6wysBL07z52Gs55Gttp5Bsk5/8AncQLJoisvTBP0pRIBK/B16/KqQyH+uN4Ww8KkcAqJODYH3w==}
+  '@next/swc-darwin-arm64@15.2.3':
+    resolution: {integrity: sha512-uaBhA8aLbXLqwjnsHSkxs353WrRgQgiFjduDpc7YXEU0B54IKx3vU+cxQlYwPCyC8uYEEX7THhtQQsfHnvv8dw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.3.1':
-    resolution: {integrity: sha512-q+aw+cJ2ooVYdCEqZVk+T4Ni10jF6Fo5DfpEV51OupMaV5XL6pf3GCzrk6kSSZBsMKZtVC1Zm/xaNBFpA6bJ2g==}
+  '@next/swc-darwin-x64@15.2.3':
+    resolution: {integrity: sha512-pVwKvJ4Zk7h+4hwhqOUuMx7Ib02u3gDX3HXPKIShBi9JlYllI0nU6TWLbPT94dt7FSi6mSBhfc2JrHViwqbOdw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.3.1':
-    resolution: {integrity: sha512-wBQ+jGUI3N0QZyWmmvRHjXjTWFy8o+zPFLSOyAyGFI94oJi+kK/LIZFJXeykvgXUk1NLDAEFDZw/NVINhdk9FQ==}
+  '@next/swc-linux-arm64-gnu@15.2.3':
+    resolution: {integrity: sha512-50ibWdn2RuFFkOEUmo9NCcQbbV9ViQOrUfG48zHBCONciHjaUKtHcYFiCwBVuzD08fzvzkWuuZkd4AqbvKO7UQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.3.1':
-    resolution: {integrity: sha512-IIxXEXRti/AulO9lWRHiCpUUR8AR/ZYLPALgiIg/9ENzMzLn3l0NSxVdva7R/VDcuSEBo0eGVCe3evSIHNz0Hg==}
+  '@next/swc-linux-arm64-musl@15.2.3':
+    resolution: {integrity: sha512-2gAPA7P652D3HzR4cLyAuVYwYqjG0mt/3pHSWTCyKZq/N/dJcUAEoNQMyUmwTZWCJRKofB+JPuDVP2aD8w2J6Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.3.1':
-    resolution: {integrity: sha512-bfI4AMhySJbyXQIKH5rmLJ5/BP7bPwuxauTvVEiJ/ADoddaA9fgyNNCcsbu9SlqfHDoZmfI6g2EjzLwbsVTr5A==}
+  '@next/swc-linux-x64-gnu@15.2.3':
+    resolution: {integrity: sha512-ODSKvrdMgAJOVU4qElflYy1KSZRM3M45JVbeZu42TINCMG3anp7YCBn80RkISV6bhzKwcUqLBAmOiWkaGtBA9w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.3.1':
-    resolution: {integrity: sha512-FeAbR7FYMWR+Z+M5iSGytVryKHiAsc0x3Nc3J+FD5NVbD5Mqz7fTSy8CYliXinn7T26nDMbpExRUI/4ekTvoiA==}
+  '@next/swc-linux-x64-musl@15.2.3':
+    resolution: {integrity: sha512-ZR9kLwCWrlYxwEoytqPi1jhPd1TlsSJWAc+H/CJHmHkf2nD92MQpSRIURR1iNgA/kuFSdxB8xIPt4p/T78kwsg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.3.1':
-    resolution: {integrity: sha512-yP7FueWjphQEPpJQ2oKmshk/ppOt+0/bB8JC8svPUZNy0Pi3KbPx2Llkzv1p8CoQa+D2wknINlJpHf3vtChVBw==}
+  '@next/swc-win32-arm64-msvc@15.2.3':
+    resolution: {integrity: sha512-+G2FrDcfm2YDbhDiObDU/qPriWeiz/9cRR0yMWJeTLGGX6/x8oryO3tt7HhodA1vZ8r2ddJPCjtLcpaVl7TE2Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.3.1':
-    resolution: {integrity: sha512-3PMvF2zRJAifcRNni9uMk/gulWfWS+qVI/pagd+4yLF5bcXPZPPH2xlYRYOsUjmCJOXSTAC2PjRzbhsRzR2fDQ==}
+  '@next/swc-win32-x64-msvc@15.2.3':
+    resolution: {integrity: sha512-gHYS9tc+G2W0ZC8rBL+H6RdtXIyk40uLiaos0yj5US85FNhbFEndMA2nW3z47nzOWiSvXTZ5kBClc3rD0zJg0w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2715,8 +2707,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@15.3.1:
-    resolution: {integrity: sha512-8+dDV0xNLOgHlyBxP1GwHGVaNXsmp+2NhZEYrXr24GWLHtt27YrBPbPuHvzlhi7kZNYjeJNR93IF5zfFu5UL0g==}
+  next@15.2.3:
+    resolution: {integrity: sha512-x6eDkZxk2rPpu46E1ZVUWIBhYCLszmUY6fvHBFcbzJ9dD+qRX6vcHusaqqDlnY+VngKzKbAiG2iRCkPbmi8f7w==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -3130,8 +3122,8 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  sharp@0.34.1:
-    resolution: {integrity: sha512-1j0w61+eVxu7DawFJtnfYcvSv6qPFvfTaqzTQ2BLknVhHTwGS8sc63ZBF4rzkWMBVKybo4S5OBtDdZahh2A1xg==}
+  sharp@0.33.5:
+    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
@@ -3483,9 +3475,6 @@ packages:
   yup@1.6.1:
     resolution: {integrity: sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==}
 
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
-
   zod@3.24.3:
     resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
 
@@ -3783,15 +3772,15 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
-  '@flowglad/nextjs@0.10.6(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(next@15.3.1(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)':
+  '@flowglad/nextjs@0.10.7(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(next@15.2.3(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)':
     dependencies:
-      '@flowglad/node': 0.19.2
-      '@flowglad/react': 0.10.6(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)
-      '@flowglad/server': 0.10.6
-      '@flowglad/shared': 0.10.6
-      next: 15.3.1(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@flowglad/node': 0.19.3
+      '@flowglad/react': 0.10.7(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)
+      '@flowglad/server': 0.10.7
+      '@flowglad/shared': 0.10.7
+      next: 15.2.3(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
-      zod: 3.23.8
+      zod: 3.24.3
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -3799,14 +3788,12 @@ snapshots:
       - react-dom
       - tailwindcss
 
-  '@flowglad/node@0.14.0': {}
+  '@flowglad/node@0.19.3': {}
 
-  '@flowglad/node@0.19.2': {}
-
-  '@flowglad/react@0.10.6(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)':
+  '@flowglad/react@0.10.7(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)':
     dependencies:
-      '@flowglad/node': 0.19.2
-      '@flowglad/shared': 0.10.6
+      '@flowglad/node': 0.19.3
+      '@flowglad/shared': 0.10.7
       '@radix-ui/react-dialog': 1.1.11(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slot': 1.2.0(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-tooltip': 1.2.4(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3819,7 +3806,7 @@ snapshots:
       react: 19.1.0
       tailwind-merge: 3.0.2
       tailwindcss-animate: 1.0.7(tailwindcss@3.4.17)
-      zod: 3.23.8
+      zod: 3.24.3
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -3827,17 +3814,17 @@ snapshots:
       - react-dom
       - tailwindcss
 
-  '@flowglad/server@0.10.6':
+  '@flowglad/server@0.10.7':
     dependencies:
-      '@flowglad/node': 0.19.2
-      '@flowglad/shared': 0.10.6
-      zod: 3.23.8
+      '@flowglad/node': 0.19.3
+      '@flowglad/shared': 0.10.7
+      zod: 3.24.3
 
-  '@flowglad/shared@0.10.6':
+  '@flowglad/shared@0.10.7':
     dependencies:
-      '@flowglad/node': 0.14.0
+      '@flowglad/node': 0.19.3
       date-fns: 4.1.0
-      zod: 3.23.8
+      zod: 3.24.3
 
   '@hookform/resolvers@3.10.0(react-hook-form@7.53.1(react@19.1.0))':
     dependencies:
@@ -3856,82 +3843,79 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.2': {}
 
-  '@img/sharp-darwin-arm64@0.34.1':
+  '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.1.0
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.1':
+  '@img/sharp-darwin-x64@0.33.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.1.0
+      '@img/sharp-libvips-darwin-x64': 1.0.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.1.0':
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.1.0':
+  '@img/sharp-libvips-darwin-x64@1.0.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.1.0':
+  '@img/sharp-libvips-linux-arm64@1.0.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.1.0':
+  '@img/sharp-libvips-linux-arm@1.0.5':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.1.0':
+  '@img/sharp-libvips-linux-s390x@1.0.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.1.0':
+  '@img/sharp-libvips-linux-x64@1.0.4':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.1.0':
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.1.0':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.34.1':
+  '@img/sharp-linux-arm64@0.33.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.1.0
+      '@img/sharp-libvips-linux-arm64': 1.0.4
     optional: true
 
-  '@img/sharp-linux-arm@0.34.1':
+  '@img/sharp-linux-arm@0.33.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.1.0
+      '@img/sharp-libvips-linux-arm': 1.0.5
     optional: true
 
-  '@img/sharp-linux-s390x@0.34.1':
+  '@img/sharp-linux-s390x@0.33.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.1.0
+      '@img/sharp-libvips-linux-s390x': 1.0.4
     optional: true
 
-  '@img/sharp-linux-x64@0.34.1':
+  '@img/sharp-linux-x64@0.33.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.1.0
+      '@img/sharp-libvips-linux-x64': 1.0.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.34.1':
+  '@img/sharp-linuxmusl-arm64@0.33.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.1.0
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.34.1':
+  '@img/sharp-linuxmusl-x64@0.33.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.1.0
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
     optional: true
 
-  '@img/sharp-wasm32@0.34.1':
+  '@img/sharp-wasm32@0.33.5':
     dependencies:
       '@emnapi/runtime': 1.4.3
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.1':
+  '@img/sharp-win32-ia32@0.33.5':
     optional: true
 
-  '@img/sharp-win32-x64@0.34.1':
+  '@img/sharp-win32-x64@0.33.5':
     optional: true
 
   '@isaacs/cliui@8.0.2':
@@ -3982,34 +3966,34 @@ snapshots:
       '@tybys/wasm-util': 0.9.0
     optional: true
 
-  '@next/env@15.3.1': {}
+  '@next/env@15.2.3': {}
 
   '@next/eslint-plugin-next@15.3.1':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.3.1':
+  '@next/swc-darwin-arm64@15.2.3':
     optional: true
 
-  '@next/swc-darwin-x64@15.3.1':
+  '@next/swc-darwin-x64@15.2.3':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.3.1':
+  '@next/swc-linux-arm64-gnu@15.2.3':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.3.1':
+  '@next/swc-linux-arm64-musl@15.2.3':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.3.1':
+  '@next/swc-linux-x64-gnu@15.2.3':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.3.1':
+  '@next/swc-linux-x64-musl@15.2.3':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.3.1':
+  '@next/swc-win32-arm64-msvc@15.2.3':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.3.1':
+  '@next/swc-win32-x64-msvc@15.2.3':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -4735,9 +4719,9 @@ snapshots:
 
   '@simplewebauthn/types@11.0.0': {}
 
-  '@stackframe/stack-sc@2.8.8(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(next@15.3.1(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@stackframe/stack-sc@2.8.8(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(next@15.2.3(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      next: 15.3.1(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.2.3(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
@@ -4822,12 +4806,12 @@ snapshots:
       - encoding
       - supports-color
 
-  '@stackframe/stack@2.8.8(@babel/core@7.26.10)(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(next@15.3.1(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)':
+  '@stackframe/stack@2.8.8(@babel/core@7.26.10)(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(next@15.2.3(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)':
     dependencies:
       '@hookform/resolvers': 3.10.0(react-hook-form@7.53.1(react@19.1.0))
       '@oslojs/otp': 1.1.0
       '@simplewebauthn/browser': 11.0.0
-      '@stackframe/stack-sc': 2.8.8(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(next@15.3.1(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@stackframe/stack-sc': 2.8.8(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(next@15.2.3(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@stackframe/stack-shared': 2.8.8(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(yup@1.6.1)
       '@stackframe/stack-ui': 2.8.8(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(yup@1.6.1)
       '@tanstack/react-table': 8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -4837,7 +4821,7 @@ snapshots:
       jose: 5.10.0
       js-cookie: 3.0.5
       lucide-react: 0.378.0(react@19.1.0)
-      next: 15.3.1(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.2.3(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       oauth4webapi: 2.17.0
       qrcode: 1.5.4
       react: 19.1.0
@@ -6354,9 +6338,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.3.1(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.2.3(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@next/env': 15.3.1
+      '@next/env': 15.2.3
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0
@@ -6366,15 +6350,15 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       styled-jsx: 5.1.6(@babel/core@7.26.10)(react@19.1.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.3.1
-      '@next/swc-darwin-x64': 15.3.1
-      '@next/swc-linux-arm64-gnu': 15.3.1
-      '@next/swc-linux-arm64-musl': 15.3.1
-      '@next/swc-linux-x64-gnu': 15.3.1
-      '@next/swc-linux-x64-musl': 15.3.1
-      '@next/swc-win32-arm64-msvc': 15.3.1
-      '@next/swc-win32-x64-msvc': 15.3.1
-      sharp: 0.34.1
+      '@next/swc-darwin-arm64': 15.2.3
+      '@next/swc-darwin-x64': 15.2.3
+      '@next/swc-linux-arm64-gnu': 15.2.3
+      '@next/swc-linux-arm64-musl': 15.2.3
+      '@next/swc-linux-x64-gnu': 15.2.3
+      '@next/swc-linux-x64-musl': 15.2.3
+      '@next/swc-win32-arm64-msvc': 15.2.3
+      '@next/swc-win32-x64-msvc': 15.2.3
+      sharp: 0.33.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -6765,32 +6749,31 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
-  sharp@0.34.1:
+  sharp@0.33.5:
     dependencies:
       color: 4.2.3
       detect-libc: 2.0.4
       semver: 7.7.1
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.1
-      '@img/sharp-darwin-x64': 0.34.1
-      '@img/sharp-libvips-darwin-arm64': 1.1.0
-      '@img/sharp-libvips-darwin-x64': 1.1.0
-      '@img/sharp-libvips-linux-arm': 1.1.0
-      '@img/sharp-libvips-linux-arm64': 1.1.0
-      '@img/sharp-libvips-linux-ppc64': 1.1.0
-      '@img/sharp-libvips-linux-s390x': 1.1.0
-      '@img/sharp-libvips-linux-x64': 1.1.0
-      '@img/sharp-libvips-linuxmusl-arm64': 1.1.0
-      '@img/sharp-libvips-linuxmusl-x64': 1.1.0
-      '@img/sharp-linux-arm': 0.34.1
-      '@img/sharp-linux-arm64': 0.34.1
-      '@img/sharp-linux-s390x': 0.34.1
-      '@img/sharp-linux-x64': 0.34.1
-      '@img/sharp-linuxmusl-arm64': 0.34.1
-      '@img/sharp-linuxmusl-x64': 0.34.1
-      '@img/sharp-wasm32': 0.34.1
-      '@img/sharp-win32-ia32': 0.34.1
-      '@img/sharp-win32-x64': 0.34.1
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-s390x': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-wasm32': 0.33.5
+      '@img/sharp-win32-ia32': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
     optional: true
 
   shebang-command@2.0.0:
@@ -7252,7 +7235,5 @@ snapshots:
       tiny-case: 1.0.3
       toposort: 2.0.2
       type-fest: 2.19.0
-
-  zod@3.23.8: {}
 
   zod@3.24.3: {}

--- a/playground/supabase-auth/app/billing/layout.tsx
+++ b/playground/supabase-auth/app/billing/layout.tsx
@@ -1,7 +1,20 @@
+import Button from '@/components/ui/Button';
+import Card from '@/components/ui/Card';
+
 export default function BillingLayout({
   children
 }: {
   children: React.ReactNode;
 }) {
-  return <div className="max-w-6xl px-6 mx-auto">{children}</div>;
+  return (
+    <div className="max-w-6xl px-6 mx-auto">
+      {children}
+      <div className="flex flex-col gap-4">
+        <Button>Click me</Button>
+        <Card title="Card title" description="Card description">
+          <p>Card content</p>
+        </Card>
+      </div>
+    </div>
+  );
 }

--- a/playground/supabase-auth/app/billing/page.tsx
+++ b/playground/supabase-auth/app/billing/page.tsx
@@ -1,7 +1,5 @@
 import { flowgladServer } from '@/utils/flowglad';
 import InnerPricingTable from './InnerPricingTable';
-// import { BillingPage } from '@flowglad/nextjs';
-// import InnerAttachSubscriptionPaymentMethodPage from './InnerAttachSubscriptionPaymentMethodPage';
 import { BillingPage } from '@flowglad/react';
 
 export default async () => {

--- a/playground/supabase-auth/app/layout.tsx
+++ b/playground/supabase-auth/app/layout.tsx
@@ -27,36 +27,42 @@ export default async function RootLayout({ children }: PropsWithChildren) {
     data: { user }
   } = await supabase.auth.getUser();
   return (
-    <FlowgladProvider
-      loadBilling={!!user}
-      requestConfig={{
-        headers: {
-          test: 'lol'
-        }
-      }}
-      theme={{
-        light: {
-          containerBackground: '#ff0',
-          containerForeground: '#000000',
-          border: '#cccccc',
-          buttonBackground: '#007bff',
-          buttonForeground: '#ffffff',
-          destructive: '#dc3545',
-          destructiveForeground: '#ffffff'
-        },
-        dark: {
-          containerBackground: '#0ff',
-          containerForeground: '#ffffff',
-          border: '#333333',
-          buttonBackground: '#0d6efd',
-          buttonForeground: '#ffffff',
-          destructive: '#dc3545',
-          destructiveForeground: '#ffffff'
-        }
-      }}
-    >
-      <html lang="en">
-        <body className="bg-black">
+    <html lang="en">
+      <body className="bg-black">
+        <FlowgladProvider
+          loadBilling={!!user}
+          requestConfig={{
+            headers: {
+              test: 'lol'
+            }
+          }}
+          theme={{
+            light: {
+              background: 'hsl(0 100% 50%)',
+              card: 'hsl(0 0% 100%)',
+              cardForeground: 'rgba(255, 0, 0, 0.8)',
+              // containerForeground: '#000000',
+              border: '#cccccc'
+              // buttonBackground: '#007bff',
+              // buttonForeground: '#ffffff',
+              // destructive: '#dc3545',
+              // destructiveForeground: '#ffffff'
+            },
+            dark: {
+              // background: 'hsl(0 100% 50%)',
+              // card: 'hsl(125 85% 3.9%)',
+              // cardForeground: 'rgba(255, 0, 0, 0.8)',
+              // foreground: 'rgba(255, 0, 0, 0.5)',
+              // border: 'rgba(0, 255, 0, 0.5)'
+              // containerForeground: '#ffffff',
+              // border: '#0000'
+              // buttonBackground: '#0d6efd',
+              // buttonForeground: '#ffffff',
+              // destructive: '#dc3545',
+              // destructiveForeground: '#ffffff'
+            }
+          }}
+        >
           <Navbar />
           <main
             id="skip"
@@ -68,8 +74,8 @@ export default async function RootLayout({ children }: PropsWithChildren) {
           <Suspense>
             <Toaster />
           </Suspense>
-        </body>
-      </html>
-    </FlowgladProvider>
+        </FlowgladProvider>
+      </body>
+    </html>
   );
 }

--- a/playground/supabase-auth/app/layout.tsx
+++ b/playground/supabase-auth/app/layout.tsx
@@ -29,10 +29,29 @@ export default async function RootLayout({ children }: PropsWithChildren) {
   return (
     <FlowgladProvider
       loadBilling={!!user}
-      darkMode={true}
       requestConfig={{
         headers: {
           test: 'lol'
+        }
+      }}
+      theme={{
+        light: {
+          containerBackground: '#ff0',
+          containerForeground: '#000000',
+          border: '#cccccc',
+          buttonBackground: '#007bff',
+          buttonForeground: '#ffffff',
+          destructive: '#dc3545',
+          destructiveForeground: '#ffffff'
+        },
+        dark: {
+          containerBackground: '#0ff',
+          containerForeground: '#ffffff',
+          border: '#333333',
+          buttonBackground: '#0d6efd',
+          buttonForeground: '#ffffff',
+          destructive: '#dc3545',
+          destructiveForeground: '#ffffff'
         }
       }}
     >

--- a/playground/supabase-auth/package.json
+++ b/playground/supabase-auth/package.json
@@ -39,6 +39,7 @@
     "axios": "1.8.4",
     "class-variance-authority": "^0.7.0",
     "classnames": "^2.5.1",
+    "@adobe/css-tools": "4.4.2",
     "clsx": "2.1.1",
     "date-fns": "4.1.0",
     "lucide-react": "0.479.0",

--- a/playground/supabase-auth/pnpm-lock.yaml
+++ b/playground/supabase-auth/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@adobe/css-tools':
+        specifier: 4.4.2
+        version: 4.4.2
       '@clerk/nextjs':
         specifier: ^6.10.2
         version: 6.12.0(next@15.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -15,8 +18,8 @@ importers:
         specifier: file:.yalc/@flowglad/nextjs
         version: file:.yalc/@flowglad/nextjs(next@15.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@flowglad/node':
-        specifier: 0.19.2
-        version: 0.19.2
+        specifier: 0.19.3
+        version: 0.19.3
       '@flowglad/react':
         specifier: file:.yalc/@flowglad/react
         version: file:.yalc/@flowglad/react(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.17)
@@ -141,6 +144,9 @@ importers:
 
 packages:
 
+  '@adobe/css-tools@4.4.2':
+    resolution: {integrity: sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
@@ -232,11 +238,8 @@ packages:
   '@flowglad/node@0.10.0':
     resolution: {integrity: sha512-Opli078TMhrRo19vsXxg5MN85n8yzNGrDArs6mtb8aaypWSlrbPKagzyVajlkugVBunnoP262UCCF5AtepqHpg==}
 
-  '@flowglad/node@0.14.0':
-    resolution: {integrity: sha512-gbvCjpAu2FNpgJ2DPwlTX8tQinKcjiTpnTyxMCFEgV0nRChJB5wR7nkgmCS/Au/SC/Nm8EBAf335WM4FkAlmlQ==}
-
-  '@flowglad/node@0.19.2':
-    resolution: {integrity: sha512-e789h1LlIwKdCwTKK4V25x6lpwCloWj55vpLu/XUMMbwbFNactYi6WIaKbhv6Lyz/60AxPtoUIzaSbtE1eMQsQ==}
+  '@flowglad/node@0.19.3':
+    resolution: {integrity: sha512-vCuclxY9EQMp6k+DFR1r6pqrz+O5DHjqYPcnqDVfQ28vGnyyI7WsJ7mHK7ZHvbhunIjzfVdKYP98oCeQKPwPMA==}
 
   '@flowglad/react@0.2.4':
     resolution: {integrity: sha512-5Tq2Ol4T5iKe1ZSkLsFP1JdNAzzrb7jKnApDHEblDZZkFfNvbm5y7pcAiDvls+VGMZAzeazCO98nASp43/8WlQ==}
@@ -2733,6 +2736,8 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.2': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@babel/runtime@7.26.9':
@@ -2834,7 +2839,7 @@ snapshots:
 
   '@flowglad/nextjs@file:.yalc/@flowglad/nextjs(next@15.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@flowglad/node': 0.19.2
+      '@flowglad/node': 0.19.3
       '@flowglad/react': 0.2.4(react@18.3.1)
       '@flowglad/server': 0.2.4
       '@flowglad/shared': 0.2.4
@@ -2858,9 +2863,7 @@ snapshots:
 
   '@flowglad/node@0.10.0': {}
 
-  '@flowglad/node@0.14.0': {}
-
-  '@flowglad/node@0.19.2': {}
+  '@flowglad/node@0.19.3': {}
 
   '@flowglad/react@0.2.4(react@18.3.1)':
     dependencies:
@@ -2874,7 +2877,8 @@ snapshots:
 
   '@flowglad/react@file:.yalc/@flowglad/react(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.17)':
     dependencies:
-      '@flowglad/node': 0.19.2
+      '@adobe/css-tools': 4.4.2
+      '@flowglad/node': 0.19.3
       '@flowglad/shared': 0.2.4
       '@radix-ui/react-dialog': 1.1.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.1.2(@types/react@18.3.18)(react@18.3.1)
@@ -2906,7 +2910,7 @@ snapshots:
 
   '@flowglad/server@file:.yalc/@flowglad/server':
     dependencies:
-      '@flowglad/node': 0.19.2
+      '@flowglad/node': 0.19.3
       '@flowglad/shared': 0.2.4
       zod: 3.24.3
 
@@ -2916,7 +2920,7 @@ snapshots:
 
   '@flowglad/shared@file:.yalc/@flowglad/shared':
     dependencies:
-      '@flowglad/node': 0.14.0
+      '@flowglad/node': 0.19.3
       date-fns: 4.1.0
       zod: 3.24.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
 
   packages/react:
     dependencies:
+      '@adobe/css-tools':
+        specifier: 4.4.2
+        version: 4.4.2
       '@flowglad/node':
         specifier: 0.19.3
         version: 0.19.3
@@ -182,18 +185,36 @@ importers:
       '@flowglad/types':
         specifier: workspace:*
         version: link:../types
+      '@testing-library/dom':
+        specifier: 10.4.0
+        version: 10.4.0
+      '@testing-library/jest-dom':
+        specifier: 6.6.3
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: 16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.0)(@types/react@18.3.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/autoprefixer':
         specifier: ^10.2.0
         version: 10.2.4(postcss@8.5.3)
+      '@types/css':
+        specifier: 0.0.38
+        version: 0.0.38
       '@types/react':
         specifier: 18.3.12
         version: 18.3.12
+      '@vitejs/plugin-react':
+        specifier: 4.3.4
+        version: 4.3.4(vite@6.2.6(@types/node@20.17.25)(jiti@1.21.7)(tsx@4.17.0)(yaml@2.7.0))
       autoprefixer:
         specifier: ^10.4.18
         version: 10.4.21(postcss@8.5.3)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
+      jsdom:
+        specifier: 26.1.0
+        version: 26.1.0
       postcss:
         specifier: ^8.4.35
         version: 8.5.3
@@ -206,6 +227,9 @@ importers:
       typescript:
         specifier: 5.8.2
         version: 5.8.2
+      vitest:
+        specifier: 3.0.5
+        version: 3.0.5(@types/node@20.17.25)(jiti@1.21.7)(jsdom@26.1.0)(msw@2.7.4(@types/node@20.17.25)(typescript@5.8.2))(tsx@4.17.0)(yaml@2.7.0)
 
   packages/server:
     dependencies:
@@ -232,8 +256,8 @@ importers:
         specifier: 5.8.2
         version: 5.8.2
       vitest:
-        specifier: ^3.0.5
-        version: 3.1.1(@types/node@20.17.25)(jiti@1.21.7)(msw@2.7.4(@types/node@20.17.25)(typescript@5.8.2))(tsx@4.17.0)(yaml@2.7.0)
+        specifier: 3.0.5
+        version: 3.0.5(@types/node@20.17.25)(jiti@1.21.7)(jsdom@26.1.0)(msw@2.7.4(@types/node@20.17.25)(typescript@5.8.2))(tsx@4.17.0)(yaml@2.7.0)
 
   packages/shared:
     dependencies:
@@ -269,20 +293,101 @@ importers:
 
 packages:
 
+  '@adobe/css-tools@4.4.2':
+    resolution: {integrity: sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@3.1.5':
+    resolution: {integrity: sha512-w7AmVyTTiU41fNLsFDf+gA2Dwtbx2EJtn2pbJNAGSRAg50loXy1uLXA3hEpD8+eydcomTurw09tq5/AyceCaGg==}
+
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.26.8':
+    resolution: {integrity: sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.26.10':
+    resolution: {integrity: sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.27.0':
+    resolution: {integrity: sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.27.0':
+    resolution: {integrity: sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.25.9':
+    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.26.0':
+    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.26.5':
+    resolution: {integrity: sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.25.9':
+    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.27.0':
+    resolution: {integrity: sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.27.0':
+    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.25.9':
+    resolution: {integrity: sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.25.9':
+    resolution: {integrity: sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.26.10':
     resolution: {integrity: sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.27.0':
+    resolution: {integrity: sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.27.0':
+    resolution: {integrity: sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.27.0':
+    resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
   '@bundled-es-modules/cookie@2.0.1':
@@ -364,6 +469,34 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@5.0.2':
+    resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.3':
+    resolution: {integrity: sha512-XBG3talrhid44BY1x3MHzUx/aTG8+x/Zi57M4aTKK9RFB4aLlF3TTSzfzn8nWVHWL3FgAXAxmupmDd6VWww+pw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.4
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/css-color-parser@3.0.9':
+    resolution: {integrity: sha512-wILs5Zk7BU86UArYBJTPy/FMPPKVKHMj1ycCEyf3VUptol0JNRLFU/BZsJ4aiIHJEbSLiizzRrw8Pc1uAEDrXw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.4
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/css-parser-algorithms@3.0.4':
+    resolution: {integrity: sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/css-tokenizer@3.0.3':
+    resolution: {integrity: sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==}
+    engines: {node: '>=18'}
 
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
@@ -1464,6 +1597,29 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.0':
+    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.6.3':
+    resolution: {integrity: sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
 
@@ -1476,9 +1632,24 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/autoprefixer@10.2.4':
     resolution: {integrity: sha512-SMNRug0gJ4m7JeBBgBWEs7p8t66rYywXKFOxpqKlMbMkTR0AyAQV3t46esP94vB8V5cvsenQEPVGMXSqHSihKw==}
     deprecated: This is a stub types definition. autoprefixer provides its own type definitions, so you do not need this installed.
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.20.7':
+    resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
 
   '@types/body-parser@1.19.5':
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
@@ -1488,6 +1659,9 @@ packages:
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/css@0.0.38':
+    resolution: {integrity: sha512-FsAy4pBnrJb8qdKmIyDy582o4Xt8pHwpCwYRmIvXw4dslA7C4436oOM+8XNnMEsV/LSculbFNaZsBZmycDjARw==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1549,11 +1723,17 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
-  '@vitest/expect@3.1.1':
-    resolution: {integrity: sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==}
+  '@vitejs/plugin-react@4.3.4':
+    resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
-  '@vitest/mocker@3.1.1':
-    resolution: {integrity: sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==}
+  '@vitest/expect@3.0.5':
+    resolution: {integrity: sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==}
+
+  '@vitest/mocker@3.0.5':
+    resolution: {integrity: sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -1563,20 +1743,23 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.0.5':
+    resolution: {integrity: sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==}
+
   '@vitest/pretty-format@3.1.1':
     resolution: {integrity: sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==}
 
-  '@vitest/runner@3.1.1':
-    resolution: {integrity: sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==}
+  '@vitest/runner@3.0.5':
+    resolution: {integrity: sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==}
 
-  '@vitest/snapshot@3.1.1':
-    resolution: {integrity: sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==}
+  '@vitest/snapshot@3.0.5':
+    resolution: {integrity: sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==}
 
-  '@vitest/spy@3.1.1':
-    resolution: {integrity: sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==}
+  '@vitest/spy@3.0.5':
+    resolution: {integrity: sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==}
 
-  '@vitest/utils@3.1.1':
-    resolution: {integrity: sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==}
+  '@vitest/utils@3.0.5':
+    resolution: {integrity: sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -1598,6 +1781,10 @@ packages:
 
   add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
+
+  agent-base@7.1.3:
+    resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
+    engines: {node: '>= 14'}
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -1621,6 +1808,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -1648,6 +1839,9 @@ packages:
   aria-hidden@1.2.4:
     resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
@@ -1746,6 +1940,10 @@ packages:
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
+
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1899,6 +2097,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
@@ -1917,13 +2118,24 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
 
+  cssstyle@4.3.1:
+    resolution: {integrity: sha512-ZgW+Jgdd7i52AaLYCriF8Mxqft0gD/R9i9wi6RWBhs1pqdPEzPjym7rvRKi397WmQFf3SlyUsszhw+VVCbx79Q==}
+    engines: {node: '>=18'}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
@@ -1949,6 +2161,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.5.0:
+    resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -1963,6 +2178,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -2005,6 +2224,12 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
@@ -2043,6 +2268,10 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  entities@6.0.0:
+    resolution: {integrity: sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==}
+    engines: {node: '>=0.12'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -2252,6 +2481,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -2304,6 +2537,10 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
 
+  globals@11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
+
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
@@ -2354,9 +2591,21 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-id@4.1.1:
     resolution: {integrity: sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg==}
@@ -2364,6 +2613,10 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
@@ -2377,6 +2630,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   index-to-position@0.1.2:
     resolution: {integrity: sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==}
@@ -2435,6 +2692,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
@@ -2468,6 +2728,20 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -2476,6 +2750,11 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -2515,16 +2794,26 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
   loupe@3.1.3:
     resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lucide-react@0.479.0:
     resolution: {integrity: sha512-aBhNnveRhorBOK7uA4gDjgaf+YlHMdMhQ/3cupk6exM10hWlEU+2QtWYOfhXhjAsmdb6LeKR+NZnow4UxRRiTQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -2571,6 +2860,10 @@ packages:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2664,6 +2957,9 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  nwsapi@2.2.20:
+    resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2738,6 +3034,9 @@ packages:
   parse-json@8.1.0:
     resolution: {integrity: sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==}
     engines: {node: '>=18'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -2942,6 +3241,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2981,6 +3284,13 @@ packages:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
       react: ^19.0.0
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-refresh@0.14.2:
+    resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
+    engines: {node: '>=0.10.0'}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -3039,6 +3349,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
@@ -3079,6 +3393,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3088,8 +3405,16 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
@@ -3223,6 +3548,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -3252,6 +3581,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   synckit@0.9.2:
     resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
@@ -3314,6 +3646,13 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
@@ -3330,8 +3669,16 @@ packages:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -3516,8 +3863,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite-node@3.1.1:
-    resolution: {integrity: sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==}
+  vite-node@3.0.5:
+    resolution: {integrity: sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -3561,16 +3908,16 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.1.1:
-    resolution: {integrity: sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==}
+  vitest@3.0.5:
+    resolution: {integrity: sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.1.1
-      '@vitest/ui': 3.1.1
+      '@vitest/browser': 3.0.5
+      '@vitest/ui': 3.0.5
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -3589,8 +3936,28 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -3627,9 +3994,31 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.18.1:
+    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yaml@2.7.0:
     resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
@@ -3666,7 +4055,22 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.2': {}
+
   '@alloc/quick-lru@5.2.0': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+
+  '@asamuzakjp/css-color@3.1.5':
+    dependencies:
+      '@csstools/css-calc': 2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.9(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -3674,11 +4078,113 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/compat-data@7.26.8': {}
+
+  '@babel/core@7.26.10':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.27.0
+      '@babel/helper-compilation-targets': 7.27.0
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.10)
+      '@babel/helpers': 7.27.0
+      '@babel/parser': 7.27.0
+      '@babel/template': 7.27.0
+      '@babel/traverse': 7.27.0
+      '@babel/types': 7.27.0
+      convert-source-map: 2.0.0
+      debug: 4.4.0
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.27.0':
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.27.0':
+    dependencies:
+      '@babel/compat-data': 7.26.8
+      '@babel/helper-validator-option': 7.25.9
+      browserslist: 4.24.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-module-imports@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.27.0
+      '@babel/types': 7.27.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.10)':
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.27.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.26.5': {}
+
+  '@babel/helper-string-parser@7.25.9': {}
+
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-option@7.25.9': {}
+
+  '@babel/helpers@7.27.0':
+    dependencies:
+      '@babel/template': 7.27.0
+      '@babel/types': 7.27.0
+
+  '@babel/parser@7.27.0':
+    dependencies:
+      '@babel/types': 7.27.0
+
+  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.26.10)':
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.26.10)':
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/runtime@7.26.10':
     dependencies:
       regenerator-runtime: 0.14.1
+
+  '@babel/template@7.27.0':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
+
+  '@babel/traverse@7.27.0':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.27.0
+      '@babel/parser': 7.27.0
+      '@babel/template': 7.27.0
+      '@babel/types': 7.27.0
+      debug: 4.4.0
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.27.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@bundled-es-modules/cookie@2.0.1':
     dependencies:
@@ -3846,6 +4352,26 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@5.0.2': {}
+
+  '@csstools/css-calc@2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/css-color-parser@3.0.9(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/color-helpers': 5.0.2
+      '@csstools/css-calc': 2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/css-tokenizer@3.0.3': {}
 
   '@emnapi/runtime@1.3.1':
     dependencies:
@@ -4619,6 +5145,37 @@ snapshots:
       '@tanstack/query-core': 5.66.0
       react: 19.0.0
 
+  '@testing-library/dom@10.4.0':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/runtime': 7.26.10
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.6.3':
+    dependencies:
+      '@adobe/css-tools': 4.4.2
+      aria-query: 5.3.0
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.17.21
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.0)(@types/react@18.3.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@testing-library/dom': 10.4.0
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 19.0.0
+
   '@tsconfig/node10@1.0.11': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -4627,11 +5184,34 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
+  '@types/aria-query@5.0.4': {}
+
   '@types/autoprefixer@10.2.4(postcss@8.5.3)':
     dependencies:
       autoprefixer: 10.4.21(postcss@8.5.3)
     transitivePeerDependencies:
       - postcss
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.20.7
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.27.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
+
+  '@types/babel__traverse@7.20.7':
+    dependencies:
+      '@babel/types': 7.27.0
 
   '@types/body-parser@1.19.5':
     dependencies:
@@ -4643,6 +5223,8 @@ snapshots:
       '@types/node': 18.19.80
 
   '@types/cookie@0.6.0': {}
+
+  '@types/css@0.0.38': {}
 
   '@types/estree@1.0.6': {}
 
@@ -4710,44 +5292,59 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitest/expect@3.1.1':
+  '@vitejs/plugin-react@4.3.4(vite@6.2.6(@types/node@20.17.25)(jiti@1.21.7)(tsx@4.17.0)(yaml@2.7.0))':
     dependencies:
-      '@vitest/spy': 3.1.1
-      '@vitest/utils': 3.1.1
+      '@babel/core': 7.26.10
+      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.14.2
+      vite: 6.2.6(@types/node@20.17.25)(jiti@1.21.7)(tsx@4.17.0)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.0.5':
+    dependencies:
+      '@vitest/spy': 3.0.5
+      '@vitest/utils': 3.0.5
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.1(msw@2.7.4(@types/node@20.17.25)(typescript@5.8.2))(vite@6.2.6(@types/node@20.17.25)(jiti@1.21.7)(tsx@4.17.0)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.5(msw@2.7.4(@types/node@20.17.25)(typescript@5.8.2))(vite@6.2.6(@types/node@20.17.25)(jiti@1.21.7)(tsx@4.17.0)(yaml@2.7.0))':
     dependencies:
-      '@vitest/spy': 3.1.1
+      '@vitest/spy': 3.0.5
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.7.4(@types/node@20.17.25)(typescript@5.8.2)
       vite: 6.2.6(@types/node@20.17.25)(jiti@1.21.7)(tsx@4.17.0)(yaml@2.7.0)
 
+  '@vitest/pretty-format@3.0.5':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@3.1.1':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.1.1':
+  '@vitest/runner@3.0.5':
     dependencies:
-      '@vitest/utils': 3.1.1
+      '@vitest/utils': 3.0.5
       pathe: 2.0.3
 
-  '@vitest/snapshot@3.1.1':
+  '@vitest/snapshot@3.0.5':
     dependencies:
-      '@vitest/pretty-format': 3.1.1
+      '@vitest/pretty-format': 3.0.5
       magic-string: 0.30.17
       pathe: 2.0.3
 
-  '@vitest/spy@3.1.1':
+  '@vitest/spy@3.0.5':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/utils@3.1.1':
+  '@vitest/utils@3.0.5':
     dependencies:
-      '@vitest/pretty-format': 3.1.1
+      '@vitest/pretty-format': 3.0.5
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
@@ -4767,6 +5364,8 @@ snapshots:
   acorn@8.14.1: {}
 
   add-stream@1.0.0: {}
+
+  agent-base@7.1.3: {}
 
   ajv@6.12.6:
     dependencies:
@@ -4788,6 +5387,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
 
@@ -4811,6 +5412,10 @@ snapshots:
   aria-hidden@1.2.4:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-flatten@1.1.1: {}
 
@@ -4921,6 +5526,11 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.1.3
       pathval: 2.0.0
+
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   chalk@4.1.2:
     dependencies:
@@ -5085,6 +5695,8 @@ snapshots:
     dependencies:
       meow: 13.2.0
 
+  convert-source-map@2.0.0: {}
+
   cookie-signature@1.0.6: {}
 
   cookie@0.7.1: {}
@@ -5099,9 +5711,21 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
+  cssstyle@4.3.1:
+    dependencies:
+      '@asamuzakjp/css-color': 3.1.5
+      rrweb-cssom: 0.8.0
+
   csstype@3.1.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   date-fns@4.1.0: {}
 
@@ -5115,6 +5739,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.5.0: {}
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
@@ -5122,6 +5748,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   destroy@1.2.0: {}
 
@@ -5149,6 +5777,10 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dot-prop@5.3.0:
     dependencies:
@@ -5180,6 +5812,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@6.0.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -5510,6 +6144,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gensync@1.0.0-beta.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
@@ -5582,6 +6218,8 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  globals@11.12.0: {}
+
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
@@ -5630,6 +6268,10 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -5638,9 +6280,27 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.0
+    transitivePeerDependencies:
+      - supports-color
+
   human-id@4.1.1: {}
 
   iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -5652,6 +6312,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   index-to-position@0.1.2: {}
 
@@ -5693,6 +6355,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
@@ -5722,11 +6386,42 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.3.1
+      data-urls: 5.0.0
+      decimal.js: 10.5.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.20
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsesc@3.1.0: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@2.2.3: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -5761,13 +6456,21 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  lodash@4.17.21: {}
+
   loupe@3.1.3: {}
 
   lru-cache@10.4.3: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lucide-react@0.479.0(react@19.0.0):
     dependencies:
       react: 19.0.0
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -5799,6 +6502,8 @@ snapshots:
       mime-db: 1.52.0
 
   mime@1.6.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -5897,6 +6602,8 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
+  nwsapi@2.2.20: {}
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -5965,6 +6672,10 @@ snapshots:
       '@babel/code-frame': 7.26.2
       index-to-position: 0.1.2
       type-fest: 4.37.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.0
 
   parseurl@1.3.3: {}
 
@@ -6073,6 +6784,12 @@ snapshots:
 
   prettier@3.5.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -6109,6 +6826,10 @@ snapshots:
     dependencies:
       react: 19.0.0
       scheduler: 0.25.0
+
+  react-is@17.0.2: {}
+
+  react-refresh@0.14.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@18.3.12)(react@19.0.0):
     dependencies:
@@ -6170,6 +6891,11 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   regenerator-runtime@0.14.1: {}
 
   require-directory@2.1.1: {}
@@ -6219,6 +6945,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.35.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -6227,7 +6955,13 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.25.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.7.1: {}
 
@@ -6406,6 +7140,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   styled-jsx@5.1.6(react@19.0.0):
@@ -6428,6 +7166,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   synckit@0.9.2:
     dependencies:
@@ -6500,6 +7240,12 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
@@ -6517,7 +7263,15 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
 
@@ -6681,7 +7435,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.1.1(@types/node@20.17.25)(jiti@1.21.7)(tsx@4.17.0)(yaml@2.7.0):
+  vite-node@3.0.5(@types/node@20.17.25)(jiti@1.21.7)(tsx@4.17.0)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
@@ -6714,15 +7468,15 @@ snapshots:
       tsx: 4.17.0
       yaml: 2.7.0
 
-  vitest@3.1.1(@types/node@20.17.25)(jiti@1.21.7)(msw@2.7.4(@types/node@20.17.25)(typescript@5.8.2))(tsx@4.17.0)(yaml@2.7.0):
+  vitest@3.0.5(@types/node@20.17.25)(jiti@1.21.7)(jsdom@26.1.0)(msw@2.7.4(@types/node@20.17.25)(typescript@5.8.2))(tsx@4.17.0)(yaml@2.7.0):
     dependencies:
-      '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(msw@2.7.4(@types/node@20.17.25)(typescript@5.8.2))(vite@6.2.6(@types/node@20.17.25)(jiti@1.21.7)(tsx@4.17.0)(yaml@2.7.0))
+      '@vitest/expect': 3.0.5
+      '@vitest/mocker': 3.0.5(msw@2.7.4(@types/node@20.17.25)(typescript@5.8.2))(vite@6.2.6(@types/node@20.17.25)(jiti@1.21.7)(tsx@4.17.0)(yaml@2.7.0))
       '@vitest/pretty-format': 3.1.1
-      '@vitest/runner': 3.1.1
-      '@vitest/snapshot': 3.1.1
-      '@vitest/spy': 3.1.1
-      '@vitest/utils': 3.1.1
+      '@vitest/runner': 3.0.5
+      '@vitest/snapshot': 3.0.5
+      '@vitest/spy': 3.0.5
+      '@vitest/utils': 3.0.5
       chai: 5.2.0
       debug: 4.4.0
       expect-type: 1.2.1
@@ -6734,10 +7488,11 @@ snapshots:
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
       vite: 6.2.6(@types/node@20.17.25)(jiti@1.21.7)(tsx@4.17.0)(yaml@2.7.0)
-      vite-node: 3.1.1(@types/node@20.17.25)(jiti@1.21.7)(tsx@4.17.0)(yaml@2.7.0)
+      vite-node: 3.0.5(@types/node@20.17.25)(jiti@1.21.7)(tsx@4.17.0)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.17.25
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -6752,7 +7507,24 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   webidl-conversions@4.0.2: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@7.1.0:
     dependencies:
@@ -6793,7 +7565,15 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  ws@8.18.1: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yaml@2.7.0: {}
 


### PR DESCRIPTION
## What Does this PR Do?
- Adds theming support to `FlowgladProvider`, so you can customize the color theming of the `billing-page` and other embedded components to match your app, using css variables!
- Fixes many longstanding issues in our theming by solving border styling bugs and React hoisting problems in the FlowgladTheme component
- Adds a suite of 47 new unit tests to `@flowglad/react` that now run on every single push. The current suite covers our theming logic as well as our `CurrentSubscriptionCard` component which has lots of conditional rendering state to model