### PR TITLE
deploy hosted billing no longer double-listed in deploy-prod

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -28,12 +28,6 @@ env:
   HOSTED_BILLING_SENTRY_AUTH_TOKEN: ${{ secrets.HOSTED_BILLING_SENTRY_AUTH_TOKEN }}
 
 jobs:
-  deploy-hosted-billing-prod:
-    uses: ./.github/workflows/build-and-deploy-hosted-billing.yml
-    with:
-      environment: production
-    secrets: inherit
-
   deploy-flowglad-next-prod:
     uses: ./.github/workflows/build-and-deploy-flowglad-next.yml
     with:

--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -24,12 +24,6 @@ env:
   NEXT_PUBLIC_CDN_URL: ${{ secrets.NEXT_PUBLIC_CDN_URL }}
   HOSTED_BILLING_SENTRY_AUTH_TOKEN: ${{ secrets.HOSTED_BILLING_SENTRY_AUTH_TOKEN }}
 jobs:
-  deploy-hosted-billing-staging:
-    uses: ./.github/workflows/build-and-deploy-hosted-billing.yml
-    with:
-      environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'preview' }}
-    secrets: inherit
-
   deploy-flowglad-next-staging:
     uses: ./.github/workflows/build-and-deploy-flowglad-next.yml
     with:


### PR DESCRIPTION
## What Does this PR Do?
- Removes a duplicate deployment in build step for staging and prod in our Github Action