### PR TITLE
Fix: Stricter Type Export

### DIFF
--- a/packages/express/CHANGELOG.md
+++ b/packages/express/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @flowglad/express
 
+## 0.10.10
+
+### Patch Changes
+
+- Export type explicitly for request handler input
+- Updated dependencies
+  - @flowglad/server@0.10.10
+  - @flowglad/react@0.10.10
+  - @flowglad/shared@0.10.10
+
 ## 0.10.9
 
 ### Patch Changes

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowglad/express",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/nextjs/CHANGELOG.md
+++ b/packages/nextjs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @flowglad/nextjs
 
+## 0.10.10
+
+### Patch Changes
+
+- Export type explicitly for request handler input
+- Updated dependencies
+  - @flowglad/server@0.10.10
+  - @flowglad/react@0.10.10
+  - @flowglad/shared@0.10.10
+
 ## 0.10.9
 
 ### Patch Changes

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowglad/nextjs",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @flowglad/react
 
+## 0.10.10
+
+### Patch Changes
+
+- Export type explicitly for request handler input
+- Updated dependencies
+  - @flowglad/shared@0.10.10
+
 ## 0.10.9
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowglad/react",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @flowglad/server
 
+## 0.10.10
+
+### Patch Changes
+
+- Export type explicitly for request handler input
+- Updated dependencies
+  - @flowglad/shared@0.10.10
+
 ## 0.10.9
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowglad/server",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,7 +4,7 @@ export { routeToHandlerMap } from './subrouteHandlers'
 export {
   createRequestHandler,
   RequestHandlerError,
-  RequestHandlerInput,
-  RequestHandlerOutput,
-  RequestHandlerOptions,
+  type RequestHandlerInput,
+  type RequestHandlerOutput,
+  type RequestHandlerOptions,
 } from './requestHandler'

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @flowglad/shared
 
+## 0.10.10
+
+### Patch Changes
+
+- Export type explicitly for request handler input
+
 ## 0.10.9
 
 ### Patch Changes

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowglad/shared",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @flowglad/types
 
+## 0.10.10
+
+### Patch Changes
+
+- Export type explicitly for request handler input
+
 ## 0.10.9
 
 ### Patch Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowglad/types",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
## What Does this PR Do?
- Stricter type exports so that there's no export of the `interface` type from `/server`