### PR TITLE
Fix: Confirm Checkout Session Attaches Customer If Created

### DIFF
--- a/platform/flowglad-next/src/utils/bookkeeping/confirmCheckoutSession.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/confirmCheckoutSession.ts
@@ -1,4 +1,7 @@
-import { selectCheckoutSessionById } from '@/db/tableMethods/checkoutSessionMethods'
+import {
+  selectCheckoutSessionById,
+  updateCheckoutSession,
+} from '@/db/tableMethods/checkoutSessionMethods'
 import {
   insertCustomer,
   updateCustomer,
@@ -97,6 +100,19 @@ export const confirmCheckoutSessionTransaction = async (
         billingAddress: checkoutSession.billingAddress,
         externalId: core.nanoid(),
         livemode: checkoutSession.livemode,
+      },
+      transaction
+    )
+  }
+  /**
+   * Set the customer id if the checkout session doesn't have one,
+   * (or, defensively, if the checkoutsession's customer id doesn't match the customer id)
+   */
+  if (customer.id !== checkoutSession.customerId) {
+    await updateCheckoutSession(
+      {
+        ...checkoutSession,
+        customerId: customer.id,
       },
       transaction
     )


### PR DESCRIPTION
## What Does this PR Do?
- `confirmCheckoutSession` associates customer record if it's created in the session - solving a class of edge cases
- `rehydrateBillingPeriodItems` actually creates the items rather than creating the next billing period for the subscription