### PR TITLE
Billing Period Creation Timezone fixes

### DIFF
--- a/platform/flowglad-next/src/scripts/createNextBillingPeriodForSubscription.ts
+++ b/platform/flowglad-next/src/scripts/createNextBillingPeriodForSubscription.ts
@@ -1,0 +1,49 @@
+/* 
+run the following in the terminal
+NODE_ENV=production pnpm tsx src/scripts/createNextBillingPeriodForSubscription.ts subscription_id=sub_...
+*/
+
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
+import runScript from './scriptRunner'
+import { selectSubscriptionById } from '@/db/tableMethods/subscriptionMethods'
+import { attemptToCreateFutureBillingPeriodForSubscription } from '@/subscriptions/billingPeriodHelpers'
+
+async function createNextBillingPeriodForSubscription(
+  db: PostgresJsDatabase
+) {
+  // eslint-disable-next-line no-console
+  // Get the stripe subscription ID from command line arguments
+  const args = process.argv.slice(2)
+  const subscriptionIdArg = args.find((arg) =>
+    arg.startsWith('subscription_id=')
+  )
+
+  if (!subscriptionIdArg) {
+    console.error('Error: billing_period_id argument is required')
+    console.error(
+      'Usage: NODE_ENV=production pnpm tsx src/scripts/rehydrateBillingPeriodItems.ts billing_period_id=bp_...'
+    )
+    process.exit(1)
+  }
+
+  const subscriptionId = subscriptionIdArg.split('=')[1]
+  if (!subscriptionId) {
+    throw new Error(
+      'Please provide a billing period ID as a command line argument'
+    )
+  }
+  await db.transaction(async (transaction) => {
+    const subscription = await selectSubscriptionById(
+      subscriptionId,
+      transaction
+    )
+    const result =
+      await attemptToCreateFutureBillingPeriodForSubscription(
+        subscription,
+        transaction
+      )
+    console.log(`====result`, result)
+  })
+}
+
+runScript(createNextBillingPeriodForSubscription)

--- a/platform/flowglad-next/src/scripts/createRetryBillingRun.ts
+++ b/platform/flowglad-next/src/scripts/createRetryBillingRun.ts
@@ -39,7 +39,7 @@ async function createRetryBillingRun(db: PostgresJsDatabase) {
       transaction
     )
     const scheduledFor = new Date()
-    await createBillingRun(
+    const billingRun = await createBillingRun(
       {
         billingPeriod: billingPeriod,
         paymentMethod,
@@ -48,8 +48,9 @@ async function createRetryBillingRun(db: PostgresJsDatabase) {
       transaction
     )
     console.log(
-      `Billing run created for billing period ${params.billing_period_id}, scheduled for ${scheduledFor}`
+      `Billing run created for billing period ${params.billing_period_id}, scheduled for ${scheduledFor},`
     )
+    console.log(`Billing run created:`, billingRun)
   })
 }
 

--- a/platform/flowglad-next/src/subscriptions/billingIntervalHelpers.ts
+++ b/platform/flowglad-next/src/subscriptions/billingIntervalHelpers.ts
@@ -50,12 +50,12 @@ export function generateNextBillingPeriod({
   let endDate: Date
   if (interval === IntervalUnit.Month) {
     // For monthly intervals, figure out how many days we should use based on startDate's day
-    const startDay = startDate.getDate()
+    const startDay = startDate.getUTCDate()
 
     // Add `intervalCount` months to startDate
     const workingDate = addMonths(startDate, intervalCount)
-    const targetYear = workingDate.getFullYear()
-    const targetMonth = workingDate.getMonth()
+    const targetYear = workingDate.getUTCFullYear()
+    const targetMonth = workingDate.getUTCMonth()
     const daysInTargetMonth = getDaysInMonth(targetYear, targetMonth)
 
     // If the original startDay is 31, but new month has only 30 days, clamp to 30, etc.
@@ -80,30 +80,34 @@ export function generateNextBillingPeriod({
     // If the anchor day was Feb 29 but the new year isn't a leap year, clamp to Feb 28
     // However, we preserve the time from startDate
     if (
-      billingCycleAnchorDate.getMonth() === 1 && // 1 => February
-      billingCycleAnchorDate.getDate() === 29 && // was anchored on Feb 29
+      billingCycleAnchorDate.getUTCMonth() === 1 && // 1 => February
+      billingCycleAnchorDate.getUTCDate() === 29 && // was anchored on Feb 29
       !isLeapYear(baseEndDate) // new year isn't leap
     ) {
       endDate = new Date(
-        baseEndDate.getFullYear(),
-        1, // February
-        28,
-        startDate.getHours(),
-        startDate.getMinutes(),
-        startDate.getSeconds(),
-        startDate.getMilliseconds()
+        Date.UTC(
+          baseEndDate.getUTCFullYear(),
+          1, // February
+          28,
+          startDate.getUTCHours(),
+          startDate.getUTCMinutes(),
+          startDate.getUTCSeconds(),
+          startDate.getUTCMilliseconds()
+        )
       )
     } else {
       // Otherwise, just preserve the date portion from adding years,
       // but also preserve the time portion from startDate
       endDate = new Date(
-        baseEndDate.getFullYear(),
-        baseEndDate.getMonth(),
-        baseEndDate.getDate(),
-        startDate.getHours(),
-        startDate.getMinutes(),
-        startDate.getSeconds(),
-        startDate.getMilliseconds()
+        Date.UTC(
+          baseEndDate.getUTCFullYear(),
+          baseEndDate.getUTCMonth(),
+          baseEndDate.getUTCDate(),
+          startDate.getUTCHours(),
+          startDate.getUTCMinutes(),
+          startDate.getUTCSeconds(),
+          startDate.getUTCMilliseconds()
+        )
       )
     }
   } else {

--- a/platform/flowglad-next/src/subscriptions/billingPeriodHelpers.ts
+++ b/platform/flowglad-next/src/subscriptions/billingPeriodHelpers.ts
@@ -390,11 +390,21 @@ export const attemptToCreateFutureBillingPeriodForSubscription =
       return null
     }
 
-    return createNextBillingPeriodBasedOnPreviousBillingPeriod(
+    const result =
+      await createNextBillingPeriodBasedOnPreviousBillingPeriod(
+        {
+          subscription,
+          billingPeriod: mostRecentBillingPeriod,
+        },
+        transaction
+      )
+    await updateSubscription(
       {
-        subscription,
-        billingPeriod: mostRecentBillingPeriod,
+        id: subscription.id,
+        currentBillingPeriodEnd: result.billingPeriod.endDate,
+        currentBillingPeriodStart: result.billingPeriod.startDate,
       },
       transaction
     )
+    return result
   }


### PR DESCRIPTION
## What Does this PR Do?
- Billing Period start and end dates are built around UTC time
- Subscription current period start and end dates update when creating future subscription anchors