### PR TITLE
Fix Checkout Page Livemode UI: Checks CheckoutSession

### DIFF
--- a/platform/flowglad-next/src/components/PaymentForm.tsx
+++ b/platform/flowglad-next/src/components/PaymentForm.tsx
@@ -500,7 +500,7 @@ const PaymentForm = () => {
               {buttonLabel}
             </Button>
             {errorMessage && <ErrorLabel error={errorMessage} />}
-            {!product?.livemode && (
+            {!checkoutSession.livemode && (
               <div className="p-2 bg-orange-600 justify-center items-center text-center w-full flex mt-4 rounded-md">
                 <div className="text-white text-sm">
                   <p>This is a test mode checkout.</p>


### PR DESCRIPTION
## What Does this PR Do?
- Bugfix: Add Payment Form showed a test mode banner because were checking for product.livemode, and add payment methods have no product - now we check checkoutSession!