### PR TITLE
added shadcn components, css shadcn layer, converted img to next/image

### DIFF
--- a/platform/flowglad-next/package.json
+++ b/platform/flowglad-next/package.json
@@ -186,8 +186,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "5.5.4",
     "vite": "6.0.11",
-    "vitest": "3.0.5",
-    "zlib-sync": "^0.1.9"
+    "vitest": "3.0.5"
   },
   "pnpm": {
     "overrides": {

--- a/platform/flowglad-next/pnpm-lock.yaml
+++ b/platform/flowglad-next/pnpm-lock.yaml
@@ -502,9 +502,6 @@ importers:
       vitest:
         specifier: 3.0.5
         version: 3.0.5(@types/debug@4.1.12)(@types/node@20.17.5)(jiti@1.21.6)(jsdom@26.1.0)(msw@2.7.0(@types/node@20.17.5)(typescript@5.5.4))(terser@5.36.0)(tsx@4.19.2)(yaml@2.6.0)
-      zlib-sync:
-        specifier: ^0.1.9
-        version: 0.1.9
 
 packages:
 
@@ -7349,9 +7346,6 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nan@2.22.0:
-    resolution: {integrity: sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==}
-
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -9429,9 +9423,6 @@ packages:
 
   yup@1.6.1:
     resolution: {integrity: sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==}
-
-  zlib-sync@0.1.9:
-    resolution: {integrity: sha512-DinB43xCjVwIBDpaIvQqHbmDsnYnSt6HJ/yiB2MZQGTqgPcwBSZqLkimXwK8BvdjQ/MaZysb5uEenImncqvCqQ==}
 
   zod-error@1.5.0:
     resolution: {integrity: sha512-zzopKZ/skI9iXpqCEPj+iLCKl9b88E43ehcU+sbRoHuwGd9F1IDVGQ70TyO6kmfiRL1g4IXkjsXK+g1gLYl4WQ==}
@@ -17629,8 +17620,6 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nan@2.22.0: {}
-
   nanoid@3.3.7: {}
 
   nanoid@3.3.8: {}
@@ -20026,10 +20015,6 @@ snapshots:
       tiny-case: 1.0.3
       toposort: 2.0.2
       type-fest: 2.19.0
-
-  zlib-sync@0.1.9:
-    dependencies:
-      nan: 2.22.0
 
   zod-error@1.5.0:
     dependencies:

--- a/platform/flowglad-next/src/app/globals.css
+++ b/platform/flowglad-next/src/app/globals.css
@@ -172,6 +172,24 @@ body {
     --radius: 10px;
     --radius-md: 12px;
     --radius-lg: 16px;
+
+    /* shadcn compatibility layer */
+    --primary-foreground: var(--on-primary);
+    --secondary-foreground: var(--on-neutral);
+    --accent: var(--primary-container);
+    --accent-foreground: var(--on-primary-container);
+    --destructive: var(--danger);
+    --destructive-foreground: var(--on-danger);
+    --input: var(--stroke);
+    --ring: var(--primary);
+    --muted: var(--neutral-container);
+    --muted-foreground: var(--on-neutral-container);
+    --popover: var(--background);
+    --popover-foreground: var(--foreground);
+    --card: var(--background);
+    --card-foreground: var(--foreground);
+    --border: var(--stroke);
+    --radius: 10px;
   }
 
   .dark {
@@ -265,6 +283,24 @@ body {
     --shadow-weak: rgba(0, 0, 0, 0.2);
     --shadow: rgba(0, 0, 0, 0.45);
     --shadow-strong: rgba(0, 0, 0, 0.7);
+
+    /* shadcn compatibility layer */
+    --primary-foreground: var(--on-primary);
+    --secondary-foreground: var(--on-neutral);
+    --accent: var(--primary-container);
+    --accent-foreground: var(--on-primary-container);
+    --destructive: var(--danger);
+    --destructive-foreground: var(--on-danger);
+    --input: var(--stroke);
+    --ring: var(--primary);
+    --muted: var(--neutral-container);
+    --muted-foreground: var(--on-neutral-container);
+    --popover: var(--background);
+    --popover-foreground: var(--foreground);
+    --card: var(--background);
+    --card-foreground: var(--foreground);
+    --border: var(--stroke);
+    --radius: 10px;
   }
 }
 

--- a/platform/flowglad-next/src/app/onboarding/OnboardingStatusTable.tsx
+++ b/platform/flowglad-next/src/app/onboarding/OnboardingStatusTable.tsx
@@ -14,6 +14,7 @@ import RequestStripeConnectOnboardingLinkModal from '@/components/forms/RequestS
 import { Country } from '@/db/schema/countries'
 import Markdown from 'react-markdown'
 import Link from 'next/link'
+import Image from 'next/image'
 import core, { cn } from '@/utils/core'
 import { Tab, Tabs, TabsList } from '@/components/ion/Tab'
 
@@ -173,12 +174,12 @@ const OnboardingStatusTable = ({
   ] = useState(false)
   const apiKeyText = `FLOWGLAD_SECRET_KEY="${secretApiKey}"`
   const mcpServerConfig = {
-      url: core.safeUrl("/mcp", process.env.NEXT_PUBLIC_APP_URL!),
-      headers: {
-        Authorization: `Bearer ${secretApiKey}`
-      },
+    url: core.safeUrl('/mcp', process.env.NEXT_PUBLIC_APP_URL!),
+    headers: {
+      Authorization: `Bearer ${secretApiKey}`,
+    },
   }
-  
+
   return (
     <div className="flex flex-col w-full gap-4">
       <OnboardingStatusRow
@@ -268,12 +269,23 @@ const OnboardingStatusTable = ({
         />
       ))}
       <OnboardingStatusRow
-        key={'integrate-flowglad'}
+        key={'setup-flowglad-mcp-server'}
         completed={false}
         title={`${onboardingChecklistItems.length + 1}. Setup Flowglad MCP Server`}
         description={'Get set up in localhost in a few minutes'}
         actionNode={
-          <a href={`https://cursor.com/install-mcp?name=flowglad&config=${encodeURIComponent(JSON.stringify(mcpServerConfig))}`}><img src="https://cursor.com/deeplink/mcp-install-light.svg" alt="Add flowglad MCP server to Cursor" height="40" style={{ height: '40px' }} /></a>
+          <a
+            href={`https://cursor.com/install-mcp?name=flowglad&config=${encodeURIComponent(JSON.stringify(mcpServerConfig))}`}
+          >
+            <Image
+              src="https://cursor.com/deeplink/mcp-install-light.svg"
+              alt="Add flowglad MCP server to Cursor"
+              height={40}
+              width={120}
+              style={{ height: '40px', width: 'auto' }}
+              unoptimized
+            />
+          </a>
         }
       />
       <NounVerbModal

--- a/platform/flowglad-next/src/components/ui/button.tsx
+++ b/platform/flowglad-next/src/components/ui/button.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/utils/core'
+import DisabledTooltip from '@/components/ion/DisabledTooltip'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+        outline:
+          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+        secondary:
+          'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3 text-xs',
+        lg: 'h-10 rounded-md px-8',
+        icon: 'h-9 w-9',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+  /** Icon to the left of the button text */
+  iconLeading?: React.ReactNode
+  /** Icon to the right of the button text */
+  iconTrailing?: React.ReactNode
+  /** Loading state - currently not implemented(just like in ion) but accepted to prevent React warnings */
+  loading?: boolean
+  /** Tooltip message to show when button is disabled and hovered */
+  disabledTooltip?: string
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      className,
+      variant,
+      size,
+      asChild = false,
+      iconLeading,
+      iconTrailing,
+      children,
+      disabled,
+      disabledTooltip,
+      ...props
+    },
+    ref
+  ) => {
+    const Comp = asChild ? Slot : 'button'
+    const buttonClassName = cn(
+      buttonVariants({ variant, size, className }),
+      disabledTooltip && 'group relative'
+    )
+
+    return (
+      <Comp
+        className={buttonClassName}
+        ref={ref}
+        disabled={disabled}
+        {...props}
+      >
+        {iconLeading}
+        {children}
+        {iconTrailing}
+        {disabled && disabledTooltip && (
+          <DisabledTooltip message={disabledTooltip} />
+        )}
+      </Comp>
+    )
+  }
+)
+Button.displayName = 'Button'
+
+export { Button, buttonVariants }

--- a/platform/flowglad-next/src/components/ui/checkbox.tsx
+++ b/platform/flowglad-next/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/utils/core"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/platform/flowglad-next/src/components/ui/form.tsx
+++ b/platform/flowglad-next/src/components/ui/form.tsx
@@ -1,0 +1,223 @@
+'use client'
+
+import * as React from 'react'
+import * as LabelPrimitive from '@radix-ui/react-label'
+import { Slot } from '@radix-ui/react-slot'
+import { Info } from 'lucide-react'
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from 'react-hook-form'
+
+import { cn } from '@/utils/core'
+import { Label } from '@/components/ui/label'
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error('useFormField should be used within <FormField>')
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        ref={ref}
+        className={cn('space-y-2', className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  )
+})
+FormItem.displayName = 'FormItem'
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & {
+    /** Display required mark to the right of the label */
+    required?: boolean
+  }
+>(({ className, required, ...props }, ref) => {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && 'text-destructive', className)}
+      htmlFor={formItemId}
+      required={required}
+      {...props}
+    />
+  )
+})
+FormLabel.displayName = 'FormLabel'
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } =
+    useFormField()
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+})
+FormControl.displayName = 'FormControl'
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement> & {
+    /** Display hint icon to the left of the description
+     * @default false
+     */
+    showIcon?: boolean
+    /** Display the description with an error state */
+    error?: boolean | string
+    /** Display the description with a disabled state */
+    disabled?: boolean
+  }
+>(
+  (
+    {
+      className,
+      showIcon = false,
+      error,
+      disabled,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const { formDescriptionId } = useFormField()
+
+    return (
+      <p
+        ref={ref}
+        id={formDescriptionId}
+        className={cn(
+          'flex items-center gap-1 text-[0.8rem]',
+          {
+            'text-destructive': error,
+            'text-muted-foreground': !error && !disabled,
+            'text-muted-foreground/50': disabled,
+          },
+          className
+        )}
+        {...props}
+      >
+        {showIcon && <Info className="h-3 w-3" strokeWidth={2} />}
+        {children}
+      </p>
+    )
+  }
+)
+FormDescription.displayName = 'FormDescription'
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? '') : children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn(
+        'text-[0.8rem] font-medium text-destructive',
+        className
+      )}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+})
+FormMessage.displayName = 'FormMessage'
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/platform/flowglad-next/src/components/ui/input.tsx
+++ b/platform/flowglad-next/src/components/ui/input.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react'
+
+import { cn } from '@/utils/core'
+
+interface InputProps extends React.ComponentProps<'input'> {
+  /** Icon to the left of the input text */
+  iconLeading?: React.ReactNode
+  /** Icon to the right of the input text */
+  iconTrailing?: React.ReactNode
+  /** Display the input with an error state */
+  error?: boolean | string
+}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  (
+    { className, type, iconLeading, iconTrailing, error, ...props },
+    ref
+  ) => {
+    if (iconLeading || iconTrailing) {
+      return (
+        <div className="relative flex items-center">
+          {iconLeading && (
+            <div className="absolute left-3 flex items-center text-muted-foreground">
+              {iconLeading}
+            </div>
+          )}
+          <input
+            type={type}
+            className={cn(
+              'flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+              iconLeading && 'pl-10',
+              iconTrailing && 'pr-10',
+              error
+                ? 'border-destructive focus-visible:ring-destructive'
+                : 'border-input focus-visible:ring-ring',
+              className
+            )}
+            ref={ref}
+            {...props}
+          />
+          {iconTrailing && (
+            <div className="absolute right-3 flex items-center text-muted-foreground">
+              {iconTrailing}
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          error
+            ? 'border-destructive focus-visible:ring-destructive'
+            : 'border-input focus-visible:ring-ring',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = 'Input'
+
+export { Input }

--- a/platform/flowglad-next/src/components/ui/label.tsx
+++ b/platform/flowglad-next/src/components/ui/label.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import * as React from 'react'
+import * as LabelPrimitive from '@radix-ui/react-label'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/utils/core'
+
+const labelVariants = cva(
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+)
+
+interface LabelProps
+  extends React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>,
+    VariantProps<typeof labelVariants> {
+  /** Helper text to display to the right of the label */
+  helper?: string
+  /** Display required mark to the right of the label */
+  required?: boolean
+  /** Whether the label is disabled */
+  disabled?: boolean
+  /** Description below the label */
+  description?: string
+  /** HTML ID of the description element */
+  descriptionId?: string
+  /** Classname of the label container (use this to position the label) */
+  className?: string
+  /** Classname of the label (use this to restyle the label) */
+  labelClassName?: string
+}
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  LabelProps
+>(
+  (
+    { 
+      className, 
+      helper, 
+      required, 
+      disabled, 
+      description,
+      descriptionId,
+      labelClassName,
+      children, 
+      ...props 
+    },
+    ref
+  ) => (
+    <div className={cn("flex flex-col gap-1", className)}>
+      <div className="flex items-center gap-2">
+        <LabelPrimitive.Root
+          ref={ref}
+          className={cn(
+            labelVariants(),
+            disabled && 'opacity-50',
+            labelClassName
+          )}
+          {...props}
+        >
+          {children}
+          {required && <span className="text-destructive ml-1">*</span>}
+        </LabelPrimitive.Root>
+        {helper && (
+          <span
+            className={cn(
+              'text-xs text-muted-foreground',
+              disabled && 'opacity-50'
+            )}
+          >
+            ({helper})
+          </span>
+        )}
+      </div>
+      {description && (
+        <p
+          id={descriptionId}
+          className={cn(
+            'text-sm text-muted-foreground',
+            disabled && 'opacity-50'
+          )}
+        >
+          {description}
+        </p>
+      )}
+    </div>
+  )
+)
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/platform/flowglad-next/src/components/ui/radio-group.tsx
+++ b/platform/flowglad-next/src/components/ui/radio-group.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { Circle } from "lucide-react"
+
+import { cn } from "@/utils/core"
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid gap-2", className)}
+      {...props}
+      ref={ref}
+    />
+  )
+})
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+        <Circle className="h-3.5 w-3.5 fill-primary" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+})
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName
+
+export { RadioGroup, RadioGroupItem }

--- a/platform/flowglad-next/src/components/ui/select.tsx
+++ b/platform/flowglad-next/src/components/ui/select.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import * as React from 'react'
+import * as SelectPrimitive from '@radix-ui/react-select'
+import { Check, ChevronDown, ChevronUp } from 'lucide-react'
+
+import { cn } from '@/utils/core'
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<
+    typeof SelectPrimitive.ScrollUpButton
+  >
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1',
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName =
+  SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<
+    typeof SelectPrimitive.ScrollDownButton
+  >
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1',
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = 'popper', ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]',
+        position === 'popper' &&
+          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          'p-1',
+          position === 'popper' &&
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn('px-2 py-1.5 text-sm font-semibold', className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/platform/flowglad-next/src/components/ui/switch.tsx
+++ b/platform/flowglad-next/src/components/ui/switch.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import * as React from 'react'
+import * as SwitchPrimitives from '@radix-ui/react-switch'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/utils/core'
+import { Label } from '@/components/ui/label'
+
+const switchVariants = cva(
+  'peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-secondary',
+  {
+    variants: {
+      size: {
+        sm: 'h-4 w-8',
+        md: 'h-5 w-9',
+        lg: 'h-6 w-12',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  }
+)
+
+const thumbVariants = cva(
+  'pointer-events-none block rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=unchecked]:translate-x-0',
+  {
+    variants: {
+      size: {
+        sm: 'h-3 w-3 data-[state=checked]:translate-x-4',
+        md: 'h-4 w-4 data-[state=checked]:translate-x-4',
+        lg: 'h-5 w-5 data-[state=checked]:translate-x-6',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  }
+)
+
+interface SwitchProps
+  extends React.ComponentPropsWithoutRef<
+      typeof SwitchPrimitives.Root
+    >,
+    VariantProps<typeof switchVariants> {
+  /** Label for the switch */
+  label?: React.ReactNode
+  /** Description, under the label, of the switch */
+  description?: string
+  /** Helper text, to the right of the label */
+  helper?: string
+  /** Custom class name for the thumb */
+  thumbClassName?: string
+  /** Custom class name for when the thumb is checked */
+  checkedClassName?: string
+  /** Custom class name for the label */
+  labelClassName?: string
+}
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  SwitchProps
+>(
+  (
+    {
+      className,
+      size = 'md',
+      required,
+      label,
+      description,
+      helper,
+      thumbClassName,
+      labelClassName,
+      checkedClassName,
+      ...props
+    },
+    ref
+  ) => {
+    const generatedId = React.useId()
+    const id = props.id || generatedId
+
+    return (
+      <span className="flex items-center gap-2 text-sm">
+        <SwitchPrimitives.Root
+          id={id}
+          ref={ref}
+          aria-required={required}
+          aria-describedby={
+            description ? `${id}__description` : undefined
+          }
+          className={cn(
+            switchVariants({ size }),
+            checkedClassName,
+            className
+          )}
+          {...props}
+        >
+          <SwitchPrimitives.Thumb
+            className={cn(thumbVariants({ size }), thumbClassName)}
+          />
+        </SwitchPrimitives.Root>
+        {label && (
+          <Label
+            id={`${id}__label`}
+            htmlFor={id}
+            required={required}
+            helper={helper}
+            description={description}
+            descriptionId={
+              description ? `${id}__description` : undefined
+            }
+            className={labelClassName}
+          >
+            {label}
+          </Label>
+        )}
+      </span>
+    )
+  }
+)
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/platform/flowglad-next/src/components/ui/textarea.tsx
+++ b/platform/flowglad-next/src/components/ui/textarea.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import { useState } from "react"
+
+import { cn } from "@/utils/core"
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  /** Display the maximum length of the textarea in the bottom right corner, has to include the `maxLength` property to work
+   * @default false
+   */
+  showCount?: boolean
+  /** Classname of the textarea (use this to restyle the textarea) */
+  textareaClassName?: string
+}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, textareaClassName, showCount = false, onChange, maxLength, ...props }, ref) => {
+    const [charCount, setCharCount] = useState(0)
+
+    return (
+      <div className={cn("relative", className)}>
+        <textarea
+          maxLength={maxLength}
+          ref={ref}
+          onChange={(e) => {
+            if (onChange) {
+              onChange(e)
+            }
+            setCharCount(e.target.value.length)
+          }}
+          className={cn(
+            "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+            textareaClassName
+          )}
+          {...props}
+        />
+        {showCount && maxLength && (
+          <span className="absolute bottom-3 right-4 text-xs font-normal text-muted-foreground">
+            {charCount} / {maxLength}
+          </span>
+        )}
+      </div>
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea } 

--- a/platform/flowglad-next/tailwind.config.ts
+++ b/platform/flowglad-next/tailwind.config.ts
@@ -687,7 +687,10 @@ const config: Config = {
           'info-pressed': 'var(--on-info-pressed)',
         },
         foreground: 'var(--foreground)',
-        secondary: 'var(--secondary)',
+        secondary: {
+          DEFAULT: 'var(--secondary)',
+          foreground: 'var(--secondary-foreground)',
+        },
         subtle: 'var(--subtle)',
         stroke: {
           DEFAULT: 'var(--stroke)',
@@ -708,15 +711,40 @@ const config: Config = {
           strong: 'var(--primary-strong)',
           hover: 'var(--primary-hover)',
           pressed: 'var(--primary-pressed)',
+          foreground: 'var(--primary-foreground)',
         },
         neutral: {
           accent: 'var(--neutral-accent)',
           container: 'var(--neutral-container)',
           stroke: 'var(--neutral-stroke)',
           DEFAULT: 'var(--neutral)',
+          foreground: 'var(--neutral-foreground)',
           hover: 'var(--neutral-hover)',
           pressed: 'var(--neutral-pressed)',
         },
+        accent: {
+          DEFAULT: 'var(--accent)',
+          foreground: 'var(--accent-foreground)',
+        },
+        destructive: {
+          DEFAULT: 'var(--destructive)',
+          foreground: 'var(--destructive-foreground)',
+        },
+        muted: {
+          DEFAULT: 'var(--muted)',
+          foreground: 'var(--muted-foreground)',
+        },
+        popover: {
+          DEFAULT: 'var(--popover)',
+          foreground: 'var(--popover-foreground)',
+        },
+        card: {
+          DEFAULT: 'var(--card)',
+          foreground: 'var(--card-foreground)',
+        },
+        input: 'var(--input)',
+        ring: 'var(--ring)',
+        border: 'var(--border)',
         success: {
           accent: 'var(--success-accent)',
           container: 'var(--success-container)',
@@ -797,56 +825,6 @@ const config: Config = {
       pattern:
         /^(bg|stroke|fill|text)-(blue|emerald|violet|amber|gray|cyan|pink|lime|fuchsia)-500$/,
       variants: ['hover', 'active'],
-    },
-    {
-      pattern:
-        /^(?:bg|bg-on|text|text-on|border|border-on|fill|ring)-(?:primary|neutral|danger)(?:|-sub|-container|-accent|-pressed|-hover)$/,
-      variants: ['hover', 'ui-selected', 'active'],
-    },
-    {
-      pattern:
-        /^(border)-(stroke)(?:-primary|-neutral|-danger|-info|-warning|-success)$/,
-      variants: ['hover', 'ui-selected', 'active'],
-    },
-    {
-      pattern:
-        /^(?:bg|bg-on|text|text-on|border|border-on|fill|ring)-(?:primary|neutral|danger)(?:|-sub|-container|-accent|-pressed|-hover)$/,
-      variants: ['hover', 'ui-selected', 'active'],
-    },
-    {
-      pattern:
-        /^(border)-(stroke)(?:-primary|-neutral|-danger|-info|-warning|-success)$/,
-      variants: ['hover', 'ui-selected', 'active'],
-    },
-    {
-      pattern:
-        /^(?:bg|bg-on|text|text-on|border|border-on|fill|ring)-(?:primary|neutral|danger)(?:|-sub|-container|-accent|-pressed|-hover)$/,
-      variants: ['hover', 'ui-selected', 'active'],
-    },
-    {
-      pattern:
-        /^(border)-(stroke)(?:-primary|-neutral|-danger|-info|-warning|-success)$/,
-      variants: ['hover', 'ui-selected', 'active'],
-    },
-    {
-      pattern:
-        /^(?:bg|bg-on|text|text-on|border|border-on|fill|ring)-(?:primary|neutral|danger)(?:|-sub|-container|-accent|-pressed|-hover)$/,
-      variants: ['hover', 'ui-selected', 'active'],
-    },
-    {
-      pattern:
-        /^(border)-(stroke)(?:-primary|-neutral|-danger|-info|-warning|-success)$/,
-      variants: ['hover', 'ui-selected', 'active'],
-    },
-    {
-      pattern:
-        /^(?:bg|bg-on|text|text-on|border|border-on|fill|ring)-(?:primary|neutral|danger)(?:|-sub|-container|-accent|-pressed|-hover)$/,
-      variants: ['hover', 'ui-selected', 'active'],
-    },
-    {
-      pattern:
-        /^(border)-(stroke)(?:-primary|-neutral|-danger|-info|-warning|-success)$/,
-      variants: ['hover', 'ui-selected', 'active'],
     },
     {
       pattern:


### PR DESCRIPTION
## What Does this PR Do?

### Create Shadcn Components
- button
- checkbox
- form
- input
- label
- radio-group
- select
- switch
- textarea

converted img to next/image
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added shadcn UI components, updated Tailwind and CSS for shadcn compatibility, and replaced img tags with next/image for better image handling.

- **New Features**
  - Added shadcn-based button, checkbox, form, input, label, radio group, select, switch, and textarea components.
  - Introduced a CSS layer for shadcn variable support.
  - Updated Tailwind config to support new color and style variables.

- **Refactors**
  - Replaced img tags with next/image in onboarding status table for optimized image loading.

<!-- End of auto-generated description by cubic. -->

