### PR TITLE
fixed date picker crashing site

### DIFF
--- a/platform/flowglad-next/src/components/ion/Datepicker.tsx
+++ b/platform/flowglad-next/src/components/ion/Datepicker.tsx
@@ -103,6 +103,11 @@ function Datepicker({
   }
   useEffect(() => {
     const selectedDate = dayPickerProps.selected as Date | undefined
+    // Check if dates are the same to prevent infinite loop:
+    // - First check: same object reference (fast path)
+    // - Second check: same date value (handles different Date objects for same date)
+    // Without this, Date objects with same value but different references would
+    // continuously trigger onSelect, causing infinite re-renders
     const isSameDate =
       selectedDate === value ||
       (!!selectedDate &&


### PR DESCRIPTION
## What Does this PR Do?

Fix datepicker crashing site
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where the date picker could crash the site due to an infinite loop when selecting dates.

- **Bug Fixes**
 - Improved date comparison logic to prevent repeated updates and site crashes.

<!-- End of auto-generated description by cubic. -->

