### PR TITLE
fix(subscriptions): accept ISO datetime strings in adjust subscriptio…

### DIFF
--- a/platform/flowglad-next/src/db/schema/subscriptionItems.ts
+++ b/platform/flowglad-next/src/db/schema/subscriptionItems.ts
@@ -99,7 +99,10 @@ const baseColumnRefinements = {
   unitPrice: core.safeZodPositiveIntegerOrZero,
   quantity: core.safeZodPositiveInteger,
   metadata: metadataSchema.nullable(),
+  // Accept ISO datetime strings or Date objects
+  addedDate: z.coerce.date(),
   expiredAt: z
+    .coerce
     .date()
     .nullable()
     .describe(


### PR DESCRIPTION
…n schema

## What Does this PR Do?
**What:** Coerce addedDate and expiredAt with z.coerce.date() in subscriptionItems schemas to allow string datetimes.
**Why:** Fixes 400 “invalid_type” errors on POST /api/v1/subscriptions/{id}/adjust when clients send ISO strings.
**Scope:** platform/flowglad-next/src/db/schema/subscriptionItems.ts
**Behavior:** Backward compatible; still enforces static vs usage item field rules.
**Quality:** Lint/typecheck pass locally.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the subscription item schema to accept ISO datetime strings for addedDate and expiredAt, fixing invalid type errors when adjusting subscriptions.

<!-- End of auto-generated description by cubic. -->

