### PR TITLE
Add automatic failure of stale payments

### DIFF
--- a/platform/flowglad-next/src/trigger/fail-stale-payments.ts
+++ b/platform/flowglad-next/src/trigger/fail-stale-payments.ts
@@ -1,0 +1,65 @@
+import { logger, task } from '@trigger.dev/sdk'
+import { adminTransaction } from '@/db/adminTransaction'
+import { selectStalePayments, updatePayment } from '@/db/tableMethods/paymentMethods'
+import { PaymentStatus } from '@/types'
+
+export const failStalePaymentsTask = task({
+  id: 'fail-stale-payments',
+  run: async (payload: { timestamp: Date }, { ctx }) => {
+    logger.log('Starting fail-stale-payments task', { payload, ctx })
+    
+    const sixHoursAgo = new Date(payload.timestamp.getTime() - 6 * 60 * 60 * 1000)
+    
+    return adminTransaction(async ({ transaction }) => {
+      // Find all payments that are in Processing, RequiresConfirmation, or RequiresAction status
+      // and were last updated more than 6 hours ago
+      const stalePayments = await selectStalePayments(sixHoursAgo, transaction)
+      
+      logger.log(`Found ${stalePayments.length} stale payments to mark as failed`, {
+        stalePaymentIds: stalePayments.map(p => p.id),
+      })
+      
+      const failedPaymentIds: string[] = []
+      const errors: Array<{ paymentId: string; error: string }> = []
+      
+      // Update each stale payment to Failed status
+      for (const payment of stalePayments) {
+        try {
+          await updatePayment(
+            {
+              id: payment.id,
+              status: PaymentStatus.Failed,
+              failureMessage: 'Payment timed out after 6 hours in pending state',
+              failureCode: 'payment_timeout',
+            },
+            transaction
+          )
+          failedPaymentIds.push(payment.id)
+          logger.log(`Successfully marked payment ${payment.id} as failed`, {
+            previousStatus: payment.status,
+            organizationId: payment.organizationId,
+            customerId: payment.customerId,
+          })
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error)
+          errors.push({ paymentId: payment.id, error: errorMessage })
+          logger.error(`Failed to update payment ${payment.id}`, {
+            error: errorMessage,
+            payment,
+          })
+        }
+      }
+      
+      const result = {
+        totalStalePayments: stalePayments.length,
+        successfullyFailed: failedPaymentIds.length,
+        failedPaymentIds,
+        errors,
+      }
+      
+      logger.log('Completed fail-stale-payments task', result)
+      
+      return result
+    })
+  },
+})

--- a/platform/flowglad-next/src/trigger/hourly-cron.ts
+++ b/platform/flowglad-next/src/trigger/hourly-cron.ts
@@ -4,6 +4,7 @@ import { schedules } from '@trigger.dev/sdk'
 import { attemptBillingRunsTask } from './attempt-run-all-billings'
 import { attemptCancelScheduledSubscriptionsTask } from './attempt-cancel-scheduled-subscriptions'
 import { attemptTransitionBillingPeriodsTask } from './attempt-transition-billing-periods'
+import { failStalePaymentsTask } from './fail-stale-payments'
 
 export const hourlyCron = schedules.task({
   id: 'hourly-cron',
@@ -41,6 +42,15 @@ export const hourlyCron = schedules.task({
         },
         {
           idempotencyKey: `attempt-transition-billing-periods:${timestamp.toISOString()}`,
+        }
+      )
+
+      await failStalePaymentsTask.trigger(
+        {
+          timestamp,
+        },
+        {
+          idempotencyKey: `fail-stale-payments:${timestamp.toISOString()}`,
         }
       )
     })


### PR DESCRIPTION
## Summary
- Implements scheduled task to automatically fail payments stuck in pending states for >6 hours
- Prevents payments from remaining indefinitely in Processing, RequiresConfirmation, or RequiresAction states
- Runs every hour as part of the existing hourly cron job

## Changes
- Added `selectStalePayments()` function to `paymentMethods.ts` to query stale payments
- Created new trigger task `fail-stale-payments.ts` that marks stale payments as failed
- Integrated task into `hourly-cron.ts` with idempotency key

## Test Plan
- [ ] Verify the hourly cron job continues to run successfully
- [ ] Test that payments in pending states for >6 hours are marked as failed
- [ ] Confirm idempotency prevents duplicate processing
- [ ] Check that terminal state payments are not affected

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Automatically fails payments that sit in pending states for more than 6 hours, preventing them from getting stuck. Runs hourly via cron with idempotency to keep payment states accurate.

- **New Features**
  - Added selectStalePayments to fetch pending payments last updated before a threshold.
  - Created fail-stale-payments task to mark stale payments as Failed with a timeout code and message, with detailed logging.
  - Integrated the task into hourly-cron with an idempotency key per run.

<!-- End of auto-generated description by cubic. -->

