### PR TITLE
Fix: event type mismatch in payment intent succeeded handler

### DIFF
--- a/platform/flowglad-next/src/trigger/stripe/payment-intent-succeeded.ts
+++ b/platform/flowglad-next/src/trigger/stripe/payment-intent-succeeded.ts
@@ -15,12 +15,7 @@ import { sendOrganizationPaymentNotificationEmail } from '@/utils/email'
 import { logger, task } from '@trigger.dev/sdk'
 import Stripe from 'stripe'
 import { generateInvoicePdfIdempotently } from '../generate-invoice-pdf'
-import {
-  FlowgladEventType,
-  EventNoun,
-  InvoiceStatus,
-  LedgerTransactionType,
-} from '@/types'
+import { FlowgladEventType, EventNoun, InvoiceStatus, LedgerTransactionType } from '@/types'
 import { safelyIncrementDiscountRedemptionSubscriptionPayment } from '@/utils/bookkeeping/discountRedemptionTracking'
 import { sendCustomerPaymentSucceededNotificationIdempotently } from '../notifications/send-customer-payment-succeeded-notification'
 import { SettleInvoiceUsageCostsLedgerCommand } from '@/db/ledgerManager/ledgerManagerTypes'
@@ -122,7 +117,7 @@ export const stripePaymentIntentSucceededTask = task({
           processedAt: null,
         },
       ]
-
+    
       return [result, eventInserts]
     }, {})
 

--- a/platform/flowglad-next/src/trigger/stripe/payment-intent-succeeded.ts
+++ b/platform/flowglad-next/src/trigger/stripe/payment-intent-succeeded.ts
@@ -15,7 +15,12 @@ import { sendOrganizationPaymentNotificationEmail } from '@/utils/email'
 import { logger, task } from '@trigger.dev/sdk'
 import Stripe from 'stripe'
 import { generateInvoicePdfIdempotently } from '../generate-invoice-pdf'
-import { FlowgladEventType, EventNoun, InvoiceStatus, LedgerTransactionType } from '@/types'
+import {
+  FlowgladEventType,
+  EventNoun,
+  InvoiceStatus,
+  LedgerTransactionType,
+} from '@/types'
 import { safelyIncrementDiscountRedemptionSubscriptionPayment } from '@/utils/bookkeeping/discountRedemptionTracking'
 import { sendCustomerPaymentSucceededNotificationIdempotently } from '../notifications/send-customer-payment-succeeded-notification'
 import { SettleInvoiceUsageCostsLedgerCommand } from '@/db/ledgerManager/ledgerManagerTypes'
@@ -103,7 +108,7 @@ export const stripePaymentIntentSucceededTask = task({
       const timestamp = new Date()
       const eventInserts: Event.Insert[] = [
         {
-          type: FlowgladEventType.SubscriptionCreated,
+          type: FlowgladEventType.PaymentSucceeded,
           occurredAt: timestamp,
           organizationId: payment.organizationId,
           livemode: payment.livemode,
@@ -117,7 +122,7 @@ export const stripePaymentIntentSucceededTask = task({
           processedAt: null,
         },
       ]
-    
+
       return [result, eventInserts]
     }, {})
 


### PR DESCRIPTION
Fix a mismatch of event type in payment intent succeeded
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Correct the event type emitted in the Stripe payment_intent.succeeded handler from SubscriptionCreated to PaymentSucceeded. This prevents false subscription events and ensures accurate billing analytics and downstream triggers.

<!-- End of auto-generated description by cubic. -->

