### PR TITLE
Fix:product features populating

### DIFF
--- a/platform/flowglad-next/src/components/forms/EditProductModal.tsx
+++ b/platform/flowglad-next/src/components/forms/EditProductModal.tsx
@@ -21,6 +21,27 @@ const EditProductModal: React.FC<EditProductModalProps> = ({
   product,
 }) => {
   const editProduct = trpc.products.edit.useMutation()
+
+  // Fetch current product features for this product via paginated list with filter in cursor
+  // Note: Using limit 100 (max allowed by pagination system). If a product has >100 features,
+  // only the first 100 will be pre-selected. This seems unlikely in practice.
+  const { data: productFeaturesData } =
+    trpc.productFeatures.list.useQuery(
+      {
+        cursor: encodeCursor({
+          parameters: {
+            productId: product.id,
+          },
+          createdAt: new Date(0),
+          direction: 'forward',
+        }),
+        limit: 100,
+      },
+      {
+        enabled: isOpen, // Only fetch when modal is open
+      }
+    )
+
   const { data: pricesData, isLoading: pricesLoading } =
     trpc.prices.list.useQuery({
       cursor: encodeCursor({
@@ -32,6 +53,13 @@ const EditProductModal: React.FC<EditProductModalProps> = ({
       }),
     })
   const prices = pricesData?.data
+
+  // Extract feature IDs from product features
+  const currentFeatureIds =
+    productFeaturesData?.data
+      ?.filter((pf) => !pf.expiredAt)
+      .map((pf) => pf.featureId) || []
+
   return (
     <FormModal
       isOpen={isOpen}
@@ -42,6 +70,7 @@ const EditProductModal: React.FC<EditProductModalProps> = ({
         product,
         price: prices?.[0],
         id: product.id,
+        featureIds: currentFeatureIds,
       }}
       onSubmit={async (item) => {
         await editProduct.mutateAsync(item)


### PR DESCRIPTION
Fixed product features not populating
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the Edit Product modal so existing product features pre-populate correctly. The modal now fetches current features and sets featureIds in the form defaults.

- **Bug Fixes**
  - Query productFeatures.list with productId (cursor-based, limit 100).
  - Fetch only when the modal is open.
  - Exclude expired features; pre-select active featureIds.

<!-- End of auto-generated description by cubic. -->

