### PR TITLE
Fix Multimembers

### DIFF
--- a/platform/flowglad-next/src/db/tableMethods/membershipMethods.ts
+++ b/platform/flowglad-next/src/db/tableMethods/membershipMethods.ts
@@ -184,6 +184,16 @@ export const updateMembership = createUpdateFunction(
   config
 )
 
+export const unfocusMembershipsForUser = async (
+  userId: string,
+  transaction: DbTransaction
+) => {
+  return transaction
+    .update(memberships)
+    .set({ focused: false })
+    .where(eq(memberships.userId, userId))
+}
+
 export const selectMembershipsTableRowData =
   createCursorPaginatedSelectFunction(
     memberships,

--- a/platform/flowglad-next/src/server/trpcContext.ts
+++ b/platform/flowglad-next/src/server/trpcContext.ts
@@ -22,13 +22,16 @@ export const createContext = async (
   let user: UserRecord | undefined
 
   if (betterAuthUserId) {
-    const [maybeMembership] = await adminTransaction(
+    const memberships = await adminTransaction(
       async ({ transaction }) => {
         return selectMembershipAndOrganizationsByBetterAuthUserId(
           betterAuthUserId,
           transaction
         )
       }
+    )
+    const maybeMembership = memberships.find(
+      (membership) => membership.membership.focused
     )
     if (maybeMembership) {
       const { membership } = maybeMembership

--- a/playground/supabase-auth/.claude/settings.json
+++ b/playground/supabase-auth/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm lint"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/playground/supabase-auth/pnpm-lock.yaml
+++ b/playground/supabase-auth/pnpm-lock.yaml
@@ -99,8 +99,8 @@ importers:
         specifier: 1.0.7
         version: 1.0.7(tailwindcss@3.4.17)
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.1.5
+        version: 4.1.5
     devDependencies:
       '@types/node':
         specifier: ^20.14.2
@@ -2992,6 +2992,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.1.5:
+    resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
+
 snapshots:
 
   '@adobe/css-tools@4.4.2': {}
@@ -3104,7 +3107,7 @@ snapshots:
       '@vercel/mcp-adapter': 0.11.1(@modelcontextprotocol/sdk@1.13.1)(next@15.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       next: 15.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      zod: 3.25.76
+      zod: 4.1.5
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - encoding
@@ -3152,7 +3155,7 @@ snapshots:
       react: 18.3.1
       tailwind-merge: 3.0.2
       tailwindcss-animate: 1.0.7(tailwindcss@3.4.17)
-      zod: 3.25.76
+      zod: 4.1.5
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -3172,7 +3175,7 @@ snapshots:
     dependencies:
       '@flowglad/node': 0.21.0
       '@flowglad/shared': 0.2.4
-      zod: 3.25.76
+      zod: 4.1.5
 
   '@flowglad/shared@0.2.4':
     dependencies:
@@ -3182,7 +3185,7 @@ snapshots:
     dependencies:
       '@flowglad/node': 0.21.0
       date-fns: 4.1.0
-      zod: 3.25.76
+      zod: 4.1.5
 
   '@flowglad/types@file:.yalc/@flowglad/types':
     dependencies:
@@ -6083,3 +6086,5 @@ snapshots:
   zod@3.23.8: {}
 
   zod@3.25.76: {}
+
+  zod@4.1.5: {}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes org switching for users with multiple memberships by enforcing a single focused membership per user. The app context now uses the focused membership to set the environment reliably.

- **Bug Fixes**
  - Added unfocusMembershipsForUser(userId) to clear focus across all memberships in one query.
  - Rewrote updateFocusedMembership to find the target membership by betterAuthUserId, unfocus others, then set the target as focused in a single admin transaction.
  - Context creation now loads all memberships and picks the focused one to determine live/test environment.

- **Dependencies**
  - playground/supabase-auth: bump zod to 4.1.5.

<!-- End of auto-generated description by cubic. -->

