### PR TITLE
Fix: Update PricingModel labels to use sentence case

### DIFF
--- a/platform/flowglad-next/src/components/forms/ClonePricingModelModal.tsx
+++ b/platform/flowglad-next/src/components/forms/ClonePricingModelModal.tsx
@@ -23,14 +23,14 @@ const ClonePricingModelModal: React.FC<
     <FormModal
       isOpen={isOpen}
       setIsOpen={setIsOpen}
-      title="Clone PricingModel"
+      title="Clone Pricing Model"
       formSchema={clonePricingModelInputSchema}
       defaultValues={{
         id: pricingModel.id,
         name: `${pricingModel.name} (Copy)`,
       }}
       onSubmit={clonePricingModelMutation.mutateAsync}
-      submitButtonText="Clone PricingModel"
+      submitButtonText="Clone Pricing Model"
     >
       <ClonePricingModelFormFields />
     </FormModal>

--- a/platform/flowglad-next/src/components/forms/PricingModelSelect.tsx
+++ b/platform/flowglad-next/src/components/forms/PricingModelSelect.tsx
@@ -51,7 +51,7 @@ const PricingModelSelect = ({
       name={name}
       render={({ field }) => (
         <FormItem>
-          <FormLabel>PricingModel</FormLabel>
+          <FormLabel>Pricing model</FormLabel>
           <FormControl>
             {isLoadingPricingModels ? (
               <Skeleton className="h-9 w-full" />

--- a/platform/flowglad-next/src/components/forms/SetPricingModelAsDefaultModal.tsx
+++ b/platform/flowglad-next/src/components/forms/SetPricingModelAsDefaultModal.tsx
@@ -54,7 +54,7 @@ const SetPricingModelAsDefaultModal: React.FC<
   return (
     <Modal
       trigger={trigger}
-      title="Set Default PricingModel"
+      title="Set Default Pricing Model"
       open={isOpen}
       onOpenChange={setIsOpen}
       footer={
@@ -75,7 +75,7 @@ const SetPricingModelAsDefaultModal: React.FC<
       <div className="text-secondary">
         <p>
           Set {pricingModel.name} to default? This will be the default
-          pricingModel for new products.
+          pricing model for new products.
         </p>
       </div>
     </Modal>


### PR DESCRIPTION
## Summary
- Updated all PricingModel labels in the UI to use proper sentence case for consistency
- Changed form labels, modal titles, and button text to follow proper capitalization conventions

## Changes Made
- **PricingModelSelect.tsx**: Changed form label from "PricingModel" to "Pricing model"
- **SetPricingModelAsDefaultModal.tsx**: Updated modal title and description text
- **ClonePricingModelModal.tsx**: Fixed modal title and submit button text

## Test Plan
- [ ] Verify PricingModelSelect component displays "Pricing model" label
- [ ] Check SetPricingModelAsDefault modal shows "Set Default Pricing Model" title
- [ ] Confirm Clone modal displays "Clone Pricing Model" title and button text
- [ ] Ensure all text appears correctly in the UI

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized "Pricing model" labels to sentence case across the UI for consistency and readability. Updated the form label in PricingModelSelect, the title and description in SetPricingModelAsDefaultModal, and the title and submit text in ClonePricingModelModal.

<!-- End of auto-generated description by cubic. -->

