### PR TITLE
feat: add cookie cleanup to logout flow

### DIFF
--- a/platform/flowglad-next/public/preview/manifest.json
+++ b/platform/flowglad-next/public/preview/manifest.json
@@ -1,6 +1,6 @@
 {
-  "hash": "1aa13533",
+  "hash": "37463f49",
   "path": "/preview/preview.css",
-  "size": 57075,
-  "generatedAt": "2025-08-29T23:19:21.715Z"
+  "size": 56282,
+  "generatedAt": "2025-09-01T04:27:01.143Z"
 }

--- a/platform/flowglad-next/src/app/billing-portal/[organizationId]/page.tsx
+++ b/platform/flowglad-next/src/app/billing-portal/[organizationId]/page.tsx
@@ -4,11 +4,14 @@ import { useRouter } from 'next/navigation'
 import { signOut } from '@/utils/authClient'
 import Button from '@/components/ion/Button'
 import { LogOut } from 'lucide-react'
+import { trpc } from '@/app/_trpc/client'
 
 const BillingPortalPage = () => {
   const router = useRouter()
+  const logoutMutation = trpc.utils.logout.useMutation()
 
   const handleLogout = async () => {
+    await logoutMutation.mutateAsync()
     await signOut()
     router.push('/sign-in')
   }

--- a/platform/flowglad-next/src/app/logout/page.tsx
+++ b/platform/flowglad-next/src/app/logout/page.tsx
@@ -10,10 +10,9 @@ export default function Logout() {
   useEffect(() => {
     const performLogout = async () => {
       await logoutMutation.mutateAsync()
-      await authClient.signOut()
       redirect('/sign-in')
     }
     performLogout()
-  }, [logoutMutation])
+  }, [])
   return null
 }

--- a/platform/flowglad-next/src/app/logout/page.tsx
+++ b/platform/flowglad-next/src/app/logout/page.tsx
@@ -2,11 +2,18 @@
 import { authClient } from '@/utils/authClient'
 import { redirect } from 'next/navigation'
 import { useEffect } from 'react'
+import { trpc } from '@/app/_trpc/client'
 
 export default function Logout() {
+  const logoutMutation = trpc.utils.logout.useMutation()
+  
   useEffect(() => {
-    authClient.signOut()
-    redirect('/sign-in')
-  }, [])
+    const performLogout = async () => {
+      await logoutMutation.mutateAsync()
+      await authClient.signOut()
+      redirect('/sign-in')
+    }
+    performLogout()
+  }, [logoutMutation])
   return null
 }

--- a/platform/flowglad-next/src/server/index.ts
+++ b/platform/flowglad-next/src/server/index.ts
@@ -37,6 +37,7 @@ import { featuresRouter } from './routers/featuresRouter'
 import { productFeaturesRouter } from './routers/productFeaturesRouter'
 import { subscriptionItemFeaturesRouter } from './routers/subscriptionItemFeaturesRouter'
 import { customerBillingPortalRouter } from './routers/customerBillingPortalRouter'
+import { logout } from './mutations/logout'
 
 const filesRouter = router({
   create: createFile,
@@ -76,6 +77,7 @@ export const appRouter = router({
     toggleTestMode,
     inviteUserToOrganization,
     requestBillingPortalLink,
+    logout,
   }),
   apiKeys: apiKeysRouter,
   subscriptions: subscriptionsRouter,

--- a/platform/flowglad-next/src/server/mutations/logout.ts
+++ b/platform/flowglad-next/src/server/mutations/logout.ts
@@ -1,0 +1,7 @@
+import { publicProcedure } from '../trpc'
+import { clearCustomerBillingPortalOrganizationId } from '@/utils/customerBillingPortalState'
+
+export const logout = publicProcedure.mutation(async () => {
+  await clearCustomerBillingPortalOrganizationId()
+  return { success: true }
+})

--- a/platform/flowglad-next/src/server/mutations/logout.ts
+++ b/platform/flowglad-next/src/server/mutations/logout.ts
@@ -1,7 +1,12 @@
+import { auth } from '@/utils/auth'
 import { publicProcedure } from '../trpc'
 import { clearCustomerBillingPortalOrganizationId } from '@/utils/customerBillingPortalState'
+import { headers } from 'next/headers'
 
 export const logout = publicProcedure.mutation(async () => {
   await clearCustomerBillingPortalOrganizationId()
+  await auth.api.signOut({
+    headers: await headers(),
+  })
   return { success: true }
 })

--- a/platform/flowglad-next/src/utils/customerBillingPortalState.ts
+++ b/platform/flowglad-next/src/utils/customerBillingPortalState.ts
@@ -11,7 +11,12 @@ export const setCustomerBillingPortalOrganizationId = async (
   organizationId: string
 ) => {
   const cookieStore = await cookies()
-  await cookieStore.set(cookieName, organizationId)
+  await cookieStore.set(cookieName, organizationId, {
+    maxAge: 60 * 60 * 24, // 24 hours in seconds
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+  })
 }
 
 export const getCustomerBillingPortalOrganizationId =


### PR DESCRIPTION
## Summary
- Added a public TRPC logout procedure to clear the customer-organization-id cookie
- Configured customer billing portal cookie with 24-hour expiry and proper security settings
- Updated all logout paths to consistently use the new logout procedure

## Changes
1. **Created logout TRPC procedure** (`platform/flowglad-next/src/server/mutations/logout.ts`)
   - Public procedure that clears the customer-organization-id cookie
   - Added to utils router for easy access

2. **Enhanced cookie security** (`platform/flowglad-next/src/utils/customerBillingPortalState.ts`)
   - Set 24-hour expiry (maxAge: 86400 seconds)
   - Added httpOnly flag for security
   - Configured secure flag for production environments
   - Set sameSite: 'lax' for CSRF protection

3. **Updated logout implementations**
   - Main app logout page now calls the logout procedure before signing out
   - Billing portal logout button also calls the logout procedure
   - Ensures consistent cookie cleanup across all logout paths

## Test plan
- [ ] Navigate to the main app and click logout - verify cookie is cleared
- [ ] Navigate to billing portal and click logout - verify cookie is cleared
- [ ] Check that customer-organization-id cookie expires after 24 hours
- [ ] Verify logout redirects to sign-in page correctly

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a TRPC logout procedure to clear organization context and wires it into all logout paths. Improves session safety by enforcing stricter billing portal cookie settings.

- **New Features**
  - Public utils.logout mutation now called by main app and billing portal logout to clear the customer-organization-id cookie.
  - Billing portal cookie hardened: 24h expiry, httpOnly, sameSite=lax, secure in production.

<!-- End of auto-generated description by cubic. -->

