### PR TITLE
Rm Grant Role

### DIFF
--- a/platform/flowglad-next/drizzle-migrations/0235_fresh_wraith.sql
+++ b/platform/flowglad-next/drizzle-migrations/0235_fresh_wraith.sql
@@ -1,5 +1,5 @@
 DO $$ BEGIN
-    CREATE ROLE "authenticated";
+    CREATE ROLE "customer";
 EXCEPTION
     WHEN duplicate_object THEN null;
 END $$;
@@ -50,8 +50,6 @@ BEGIN
     END LOOP;
 END
 $$;
-
-GRANT customer TO postgres;
 
 CREATE INDEX IF NOT EXISTS "memberships_user_id_focused_idx" ON "memberships" USING btree ("user_id","focused");--> statement-breakpoint
 DO $$


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switch the migration to create a "customer" role (replacing "authenticated") and remove the GRANT to postgres. This aligns with our role model and avoids unnecessary privileges for the postgres user.

<!-- End of auto-generated description by cubic. -->

