### PR TITLE
Fix migration

### DIFF
--- a/platform/flowglad-next/drizzle-migrations/0236_naive_bloodstorm.sql
+++ b/platform/flowglad-next/drizzle-migrations/0236_naive_bloodstorm.sql
@@ -1,6 +1,7 @@
 ALTER TABLE "subscriptions" ADD COLUMN IF NOT EXISTS "cancellation_reason" text;--> statement-breakpoint
 ALTER TABLE "subscriptions" ADD COLUMN IF NOT EXISTS "replaced_by_subscription_id" text;--> statement-breakpoint
 ALTER TABLE "subscriptions" ADD COLUMN IF NOT EXISTS "is_free_plan" boolean DEFAULT false;--> statement-breakpoint
+ALTER TABLE "subscriptions" ALTER COLUMN "is_free_plan" SET DEFAULT false;--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "subscriptions_replaced_by_subscription_id_idx" ON "subscriptions" USING btree ("replaced_by_subscription_id");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "subscriptions_is_free_plan_idx" ON "subscriptions" USING btree ("is_free_plan");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "subscriptions_cancellation_reason_idx" ON "subscriptions" USING btree ("cancellation_reason") WHERE "cancellation_reason" IS NOT NULL;--> statement-breakpoint

--- a/platform/flowglad-next/drizzle-migrations/0236_naive_bloodstorm.sql
+++ b/platform/flowglad-next/drizzle-migrations/0236_naive_bloodstorm.sql
@@ -1,6 +1,6 @@
-ALTER TABLE "subscriptions" ADD COLUMN "cancellation_reason" text;--> statement-breakpoint
-ALTER TABLE "subscriptions" ADD COLUMN "replaced_by_subscription_id" text;--> statement-breakpoint
-ALTER TABLE "subscriptions" ADD COLUMN "is_free_plan" boolean DEFAULT false;--> statement-breakpoint
+ALTER TABLE "subscriptions" ADD COLUMN IF NOT EXISTS "cancellation_reason" text;--> statement-breakpoint
+ALTER TABLE "subscriptions" ADD COLUMN IF NOT EXISTS "replaced_by_subscription_id" text;--> statement-breakpoint
+ALTER TABLE "subscriptions" ADD COLUMN IF NOT EXISTS "is_free_plan" boolean DEFAULT false;--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "subscriptions_replaced_by_subscription_id_idx" ON "subscriptions" USING btree ("replaced_by_subscription_id");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "subscriptions_is_free_plan_idx" ON "subscriptions" USING btree ("is_free_plan");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "subscriptions_cancellation_reason_idx" ON "subscriptions" USING btree ("cancellation_reason") WHERE "cancellation_reason" IS NOT NULL;--> statement-breakpoint


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Make migration 0236 idempotent by adding IF NOT EXISTS to the three ALTER TABLE statements on subscriptions. Prevents duplicate-column errors when rerunning migrations or applying to databases where these columns already exist.

<!-- End of auto-generated description by cubic. -->

