### PR TITLE
Trpc invalidate create feature modal

### DIFF
--- a/platform/flowglad-next/src/components/forms/CreateFeatureModal.tsx
+++ b/platform/flowglad-next/src/components/forms/CreateFeatureModal.tsx
@@ -48,10 +48,13 @@ const CreateFeatureModal: React.FC<CreateFeatureModalProps> = ({
         await createFeatureMutation.mutateAsync(data)
       }}
       onSuccess={() => {
-        // Invalidate the specific query the dropdown uses
-        trpcContext.features.getFeaturesForPricingModel.invalidate({
-          pricingModelId: defaultPricingModelId,
-        })
+        // Invalidate all queries that might contain features for this pricing model
+        // This ensures the dropdown gets fresh data regardless of context
+        trpcContext.features.getFeaturesForPricingModel.invalidate()
+
+        // CRITICAL: Invalidate productFeatures.list since EditProductModal uses this
+        // to populate the features dropdown, not features.getFeaturesForPricingModel
+        trpcContext.productFeatures.list.invalidate()
 
         // Invalidate the general list for other components
         trpcContext.features.list.invalidate()

--- a/platform/flowglad-next/src/components/forms/CreateFeatureModal.tsx
+++ b/platform/flowglad-next/src/components/forms/CreateFeatureModal.tsx
@@ -22,6 +22,7 @@ const CreateFeatureModal: React.FC<CreateFeatureModalProps> = ({
   defaultPricingModelId,
 }) => {
   const createFeatureMutation = trpc.features.create.useMutation() // Adjusted endpoint
+  const trpcContext = trpc.useContext()
   const { livemode } = useAuthenticatedContext()
   return (
     <FormModal<CreateFeatureInput>
@@ -45,6 +46,18 @@ const CreateFeatureModal: React.FC<CreateFeatureModalProps> = ({
       }}
       onSubmit={async (data) => {
         await createFeatureMutation.mutateAsync(data)
+      }}
+      onSuccess={() => {
+        // Invalidate the specific query the dropdown uses
+        trpcContext.features.getFeaturesForPricingModel.invalidate({
+          pricingModelId: defaultPricingModelId,
+        })
+
+        // Invalidate the general list for other components
+        trpcContext.features.list.invalidate()
+
+        // Invalidate table data
+        trpcContext.features.getTableRows.invalidate()
       }}
     >
       <FeatureFormFields />

--- a/platform/flowglad-next/src/components/forms/CreateFeatureModal.tsx
+++ b/platform/flowglad-next/src/components/forms/CreateFeatureModal.tsx
@@ -48,18 +48,9 @@ const CreateFeatureModal: React.FC<CreateFeatureModalProps> = ({
         await createFeatureMutation.mutateAsync(data)
       }}
       onSuccess={() => {
-        // Invalidate all queries that might contain features for this pricing model
-        // This ensures the dropdown gets fresh data regardless of context
         trpcContext.features.getFeaturesForPricingModel.invalidate()
-
-        // CRITICAL: Invalidate productFeatures.list since EditProductModal uses this
-        // to populate the features dropdown, not features.getFeaturesForPricingModel
         trpcContext.productFeatures.list.invalidate()
-
-        // Invalidate the general list for other components
         trpcContext.features.list.invalidate()
-
-        // Invalidate table data
         trpcContext.features.getTableRows.invalidate()
       }}
     >

--- a/platform/flowglad-next/src/components/forms/EditProductModal.tsx
+++ b/platform/flowglad-next/src/components/forms/EditProductModal.tsx
@@ -35,7 +35,7 @@ const EditProductModal: React.FC<EditProductModalProps> = ({
           createdAt: new Date(0),
           direction: 'forward',
         }),
-        limit: 100,
+        limit: '100',
       },
       {
         enabled: isOpen, // Only fetch when modal is open

--- a/platform/flowglad-next/src/components/forms/ProductFeatureMultiSelect.tsx
+++ b/platform/flowglad-next/src/components/forms/ProductFeatureMultiSelect.tsx
@@ -11,9 +11,16 @@ export const ProductFeatureMultiSelect = ({
   pricingModelId: string
 }) => {
   const { data: features } =
-    trpc.features.getFeaturesForPricingModel.useQuery({
-      pricingModelId,
-    })
+    trpc.features.getFeaturesForPricingModel.useQuery(
+      {
+        pricingModelId,
+      },
+      {
+        refetchOnMount: 'always', // Force refetch every time component mounts
+        staleTime: 0, // Consider data stale immediately
+      }
+    )
+
   const {
     formState: { errors },
     control,

--- a/platform/flowglad-next/src/components/forms/ProductFeatureMultiSelect.tsx
+++ b/platform/flowglad-next/src/components/forms/ProductFeatureMultiSelect.tsx
@@ -11,15 +11,9 @@ export const ProductFeatureMultiSelect = ({
   pricingModelId: string
 }) => {
   const { data: features } =
-    trpc.features.getFeaturesForPricingModel.useQuery(
-      {
-        pricingModelId,
-      },
-      {
-        refetchOnMount: 'always', // Force refetch every time component mounts
-        staleTime: 0, // Consider data stale immediately
-      }
-    )
+    trpc.features.getFeaturesForPricingModel.useQuery({
+      pricingModelId,
+    })
 
   const {
     formState: { errors },


### PR DESCRIPTION
## What Does this PR Do?

- trpc invalidate CreateFeatureModal
- fix typing of pagination for EditProductModal
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds TRPC cache invalidation to CreateFeatureModal so feature lists refresh immediately after creating a feature. Also fixes the pagination limit type in EditProductModal to match the query.

- **Bug Fixes**
  - Invalidate on success: features.getFeaturesForPricingModel, productFeatures.list, features.list, features.getTableRows.
  - Set pagination limit to "100" (string) in EditProductModal.

<!-- End of auto-generated description by cubic. -->

