### PR TITLE
Fix React hooks and Button import issues

### DIFF
--- a/platform/flowglad-next/src/app/logout/page.tsx
+++ b/platform/flowglad-next/src/app/logout/page.tsx
@@ -13,6 +13,6 @@ export default function Logout() {
       redirect('/sign-in')
     }
     performLogout()
-  })
+  }, [])
   return null
 }

--- a/platform/flowglad-next/src/app/sign-in/reset-password/page.tsx
+++ b/platform/flowglad-next/src/app/sign-in/reset-password/page.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import Button from '@/components/ion/Button'
+import { Button } from '@/components/ui/button'
 import { Loader2, CheckCircle, XCircle, Lock } from 'lucide-react'
 import { cn } from '@/utils/core'
 import ErrorLabel from '@/components/ErrorLabel'


### PR DESCRIPTION
## Summary
- Fixed missing dependency array in logout page useEffect to prevent infinite re-renders
- Corrected Button component import path in reset-password page from `@/components/ion/Button` to `@/components/ui/button`

## Test plan
- [x] Verify logout page doesn't trigger infinite re-renders
- [x] Verify reset-password page compiles without TypeScript errors
- [x] All linting and type checks pass

🤖 Generated with Claude Code
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes an infinite re-render on the logout page and corrects the Button import on the reset-password page. This stabilizes logout navigation and resolves TypeScript compile errors.

<!-- End of auto-generated description by cubic. -->

