### PR TITLE
Restore Original Docs Structure

### DIFF
--- a/platform/docs/docs.json
+++ b/platform/docs/docs.json
@@ -9,55 +9,71 @@
   },
   "integrations": {
     "posthog": {
-      "apiKey": "phc_NDDBDoAw8gMHPIhSfAvlBF6TdnRP2uqSAQ0eBSNXAKk"
+        "apiKey": "phc_NDDBDoAw8gMHPIhSfAvlBF6TdnRP2uqSAQ0eBSNXAKk"
     }
   },
   "favicon": "/favicon.svg",
   "navigation": {
-    "groups": [
+    "tabs": [
       {
-        "group": "Get Started",
-        "pages": [
-          "quickstart",
-          "setup-by-prompt"
+        "tab": "Documentation",
+        "groups": [
+          {
+            "group": "Get Started",
+            "pages": [
+              "quickstart",
+              "setup-by-prompt"
+            ]
+          },
+          {
+            "group": "Features",
+            "pages": [
+              "features/products",
+              "features/prices",
+              "features/discounts",
+              "features/pricing-models",
+              "features/subscriptions",
+              "features/checkout-sessions",
+              "features/billing-ui",
+              "features/invoices",
+              "features/usage",
+              "features/webhooks"
+            ]
+          },
+          {
+            "group": "Concepts",
+            "pages": [
+              "principles",
+              "countries"
+            ]
+          }
         ]
       },
       {
-        "group": "Features",
-        "pages": [
-          "features/products",
-          "features/prices",
-          "features/discounts",
-          "features/pricing-models",
-          "features/subscriptions",
-          "features/checkout-sessions",
-          "features/billing-ui",
-          "features/invoices",
-          "features/usage",
-          "features/webhooks"
-        ]
-      },
-      {
-        "group": "Concepts",
-        "pages": [
-          "principles",
-          "countries"
-        ]
-      },
-      {
-        "group": "API Reference",
-        "pages": [
-          "api-reference/introduction"
+        "tab": "API Reference",
+        "openapi": {
+          "source": "https://app.flowglad.com/api/openapi",
+          "directory": "api-reference"
+        },
+        "groups": [
+          {
+            "group": "API Documentation",
+            "pages": [
+              "api-reference/introduction"
+            ]
+          }
         ]
       }
     ],
-    "anchors": [
-      {
-        "anchor": "Community",
-        "href": "https://app.flowglad.com/invite-discord",
-        "icon": "discord"
-      }
-    ]
+    "global": {
+      "anchors": [
+        {
+          "anchor": "Community",
+          "href": "https://app.flowglad.com/invite-discord",
+          "icon": "discord"
+        }
+      ]
+    }
   },
   "logo": {
     "light": "/logo/light.svg",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Restored the original docs structure by switching to tabbed navigation with separate Documentation and API Reference. API Reference now uses the OpenAPI source and keeps existing content organized without changing page slugs.

- **Refactors**
  - Replaced navigation.groups with navigation.tabs (Documentation, API Reference).
  - Added OpenAPI config for API Reference (source https://app.flowglad.com/api/openapi, directory api-reference).
  - Preserved Get Started, Features, and Concepts under the Documentation tab.
  - Moved anchors to navigation.global.anchors; minor formatting cleanup.

<!-- End of auto-generated description by cubic. -->

