### PR TITLE
Fix failed payment notification emails

### DIFF
--- a/platform/flowglad-next/src/subscriptions/processBillingRunPaymentIntents.ts
+++ b/platform/flowglad-next/src/subscriptions/processBillingRunPaymentIntents.ts
@@ -33,6 +33,7 @@ import { Subscription } from '@/db/schema/subscriptions'
 import { sumNetTotalSettledPaymentsForBillingPeriod } from '@/utils/paymentHelpers'
 import {
   sendAwaitingPaymentConfirmationEmail,
+  sendOrganizationPaymentFailedNotificationEmail,
   sendOrganizationPaymentNotificationEmail,
   sendPaymentFailedEmail,
 } from '@/utils/email'
@@ -149,7 +150,7 @@ const processFailedNotifications = async (
     currency,
   })
 
-  await sendOrganizationPaymentNotificationEmail({
+  await sendOrganizationPaymentFailedNotificationEmail({
     to: params.organizationMemberUsers
       .filter((user) => user.email)
       .map((user) => user.email!),
@@ -157,7 +158,6 @@ const processFailedNotifications = async (
     currency,
     customerId: params.customer.id,
     customerName: params.customer.name,
-    customerEmail: params.customer.email,
     amount: params.invoiceLineItems.reduce((acc, item) => {
       return item.price * item.quantity + acc
     }, 0),


### PR DESCRIPTION
## Summary
- Fixed payment failure notification by using the dedicated `sendOrganizationPaymentFailedNotificationEmail` function
- Removed unnecessary `customerEmail` parameter from the failed notification call

## Test plan
- [ ] Verify that payment failure notifications are sent correctly
- [ ] Confirm organization members receive appropriate failed payment emails
- [ ] Test that the email template renders properly without customerEmail

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed failed payment notifications by switching to sendOrganizationPaymentFailedNotificationEmail. Removed the unnecessary customerEmail parameter so the correct template is sent to organization members.

<!-- End of auto-generated description by cubic. -->

