### PR TITLE
Slug autogenerate

### DIFF
--- a/platform/flowglad-next/llm-prompts/dips/00-turn1-intake.md
+++ b/platform/flowglad-next/llm-prompts/dips/00-turn1-intake.md
@@ -1,0 +1,87 @@
+---
+id: dips-turn1-intake
+title: "DIPS Turn 1 - Project Facts Intake"
+turn: 1
+audience: "Coding Agent"
+output_format: "JSON only"
+---
+
+Copy-paste this to your coding agent. The agent must statically analyze the repository and return ONLY the JSON object specified. No prose. If uncertain, use explicit "unknown" or false. Do not make code changes.
+
+Agent instructions:
+- Perform static analysis of the codebase to detect the project’s setup.
+- Do not install packages or run code; inspect config files, package manifests, and source.
+- Return exactly the following JSON shape. Unknowns must be represented as "unknown" or null where appropriate. Booleans must be literal true/false.
+
+Required JSON shape:
+
+```json
+{
+  "language": "ts|js|unknown",
+  "packageManager": "pnpm|npm|yarn|unknown",
+  "framework": "next|react|express|other|unknown",
+  "router": "app|pages|react-router|custom|none|unknown",
+  "runtime": "serverless|node-server|edge|other|unknown",
+  "auth": {
+    "provider": "clerk|supabase|nextauth|betterauth|custom|none|unknown",
+    "serverUserRetrieval": {
+      "kind": "function|import|none|unknown",
+      "identifier": "string|unknown",
+      "importPath": "string|unknown"
+    },
+    "tenancy": "user|organization|unknown"
+  },
+  "database": {
+    "present": true,
+    "type": "postgres|mysql|sqlite|mongo|nosql|unknown"
+  },
+  "capabilities": {
+    "canInstallPackages": true,
+    "canSetEnvVars": true,
+    "canAddApiRoute": true,
+    "canAddPage": true
+  },
+  "project": {
+    "monorepo": false,
+    "pathAliases": false
+  }
+}
+```
+
+Rules:
+- Output must be valid JSON. No comments, no markdown, no explanations.
+- Use "unknown" when not determinable from static analysis.
+- For Next.js, set `router` to `app` if `/app` directory exists, otherwise `pages` if `/pages` exists.
+- For auth detection, prefer imports and config (e.g., `@clerk/nextjs`, `@supabase/*`, `next-auth`). If none detected, set `provider` to `none`.
+- For database, infer from dependencies/config (e.g., `prisma`, `drizzle-orm`, `pg`, `mongodb`). If no clear signal, set `present` false and `type` "unknown".
+
+Example (illustrative only):
+
+```json
+{
+  "language": "ts",
+  "packageManager": "pnpm",
+  "framework": "next",
+  "router": "app",
+  "runtime": "serverless",
+  "auth": {
+    "provider": "clerk",
+    "serverUserRetrieval": {
+      "kind": "import",
+      "identifier": "currentUser",
+      "importPath": "@clerk/nextjs/server"
+    },
+    "tenancy": "user"
+  },
+  "database": { "present": true, "type": "postgres" },
+  "capabilities": {
+    "canInstallPackages": true,
+    "canSetEnvVars": true,
+    "canAddApiRoute": true,
+    "canAddPage": true
+  },
+  "project": { "monorepo": false, "pathAliases": true }
+}
+```
+
+

--- a/platform/flowglad-next/src/components/forms/ProductFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/ProductFormFields.tsx
@@ -18,6 +18,8 @@ import StatusBadge from '../StatusBadge'
 import PricingModelSelect from './PricingModelSelect'
 import core from '@/utils/core'
 import ProductFeatureMultiSelect from './ProductFeatureMultiSelect'
+import { snakeCase } from 'change-case'
+import { useRef } from 'react'
 
 export const ProductFormFields = ({
   editProduct = false,
@@ -26,6 +28,8 @@ export const ProductFormFields = ({
 }) => {
   const form = useFormContext<CreateProductSchema>()
   const product = form.watch('product')
+  const isSlugDirty = useRef(false)
+
   if (
     !core.IS_PROD &&
     Object.keys(form.formState.errors).length > 0
@@ -49,6 +53,25 @@ export const ProductFormFields = ({
                       placeholder="Product"
                       className="w-full"
                       {...field}
+                      onChange={(e) => {
+                        // First, let the field handle its own onChange
+                        field.onChange(e)
+
+                        // Then handle our auto-slug logic
+                        const newName = e.target.value
+
+                        // Only auto-generate slug if:
+                        // 1. We're not editing an existing product
+                        // 2. The slug field is not dirty (user hasn't focused it)
+                        if (!editProduct && !isSlugDirty.current) {
+                          if (newName.trim()) {
+                            const newSlug = snakeCase(newName)
+                            form.setValue('product.slug', newSlug)
+                          } else {
+                            form.setValue('product.slug', '')
+                          }
+                        }
+                      }}
                     />
                   </FormControl>
                   <FormMessage />
@@ -69,6 +92,13 @@ export const ProductFormFields = ({
                         className="w-full"
                         {...rest}
                         value={value || ''}
+                        onFocus={() => {
+                          isSlugDirty.current = true
+                        }}
+                        onChange={(e) => {
+                          isSlugDirty.current = true
+                          field.onChange(e)
+                        }}
                       />
                     </FormControl>
                     <FormDescription className="text-xs text-subtle mt-1">

--- a/platform/flowglad-next/src/trigger/stripe/payment-intent-succeeded.ts
+++ b/platform/flowglad-next/src/trigger/stripe/payment-intent-succeeded.ts
@@ -115,6 +115,9 @@ export const stripePaymentIntentSucceededTask = task({
           payload: {
             object: EventNoun.Payment,
             id: payment.id,
+            customerId: customerAndCustomer.customer.id,
+            customerExternalId:
+              customerAndCustomer.customer.externalId,
           },
           submittedAt: timestamp,
           hash: constructPaymentSucceededEventHash(payment),

--- a/platform/flowglad-next/src/trigger/stripe/payment-intent-succeeded.ts
+++ b/platform/flowglad-next/src/trigger/stripe/payment-intent-succeeded.ts
@@ -115,9 +115,6 @@ export const stripePaymentIntentSucceededTask = task({
           payload: {
             object: EventNoun.Payment,
             id: payment.id,
-            customerId: customerAndCustomer.customer.id,
-            customerExternalId:
-              customerAndCustomer.customer.externalId,
           },
           submittedAt: timestamp,
           hash: constructPaymentSucceededEventHash(payment),


### PR DESCRIPTION
## What Does this PR Do?

-auto generate price slugs and product slugs
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Auto-generates product and price slugs from the product name during creation to speed up setup and reduce typos. Auto-fill stops as soon as the slug field is touched; edit flows are unchanged.

- New Features
  - Product form: Creates a snake_case slug from the name, clears when name is empty, and stops once the slug field is focused or edited. Disabled in edit mode.
  - Price form: Creates a snake_case slug from the product name, clears when name is empty, and stops once the slug field is focused or edited. Disabled in edit mode.

<!-- End of auto-generated description by cubic. -->

