### PR TITLE
fixed editWebhookModal misalignment with editWebhookInputSchema

### DIFF
--- a/platform/flowglad-next/src/components/forms/EditWebhookModal.tsx
+++ b/platform/flowglad-next/src/components/forms/EditWebhookModal.tsx
@@ -23,10 +23,10 @@ const EditWebhookModal: React.FC<EditWebhookModalProps> = ({
       setIsOpen={setIsOpen}
       title="Edit Webhook"
       formSchema={editWebhookInputSchema}
-      defaultValues={{ webhook }}
+      defaultValues={{ id: webhook.id, webhook }}
       onSubmit={editWebhook.mutateAsync}
     >
-      <WebhookFormFields />
+      <WebhookFormFields edit={true} />
     </FormModal>
   )
 }


### PR DESCRIPTION
## What Does this PR Do?

Fix misalignment of editWebhookModal and editWebhookInputSchema
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Aligns EditWebhookModal with editWebhookInputSchema so edits validate and save correctly, preventing schema errors in the modal.

- **Bug Fixes**
  - Passes id in defaultValues (id: webhook.id) to match the schema.
  - Renders WebhookFormFields in edit mode (edit=true) for correct field/validation behavior.

<!-- End of auto-generated description by cubic. -->

