### PR TITLE
fixed edit pricing model modal not submitting by matching editPricing…

### DIFF
--- a/platform/flowglad-next/src/components/forms/EditPricingModelModal.tsx
+++ b/platform/flowglad-next/src/components/forms/EditPricingModelModal.tsx
@@ -26,7 +26,13 @@ const EditPricingModelModal: React.FC<EditPricingModelModalProps> = ({
       setIsOpen={setIsOpen}
       title="Edit Pricing Model"
       formSchema={editPricingModelSchema}
-      defaultValues={{ pricingModel }}
+      defaultValues={{
+        id: pricingModel.id,
+        pricingModel: {
+          ...pricingModel,
+          id: pricingModel.id,
+        },
+      }}
       onSubmit={editPricingModel.mutateAsync}
     >
       <PricingModelFormFields />


### PR DESCRIPTION
## What Does this PR Do?

- fixed edit pricing model modal not submitting by matching editPricingModelSchema correctly

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the Edit Pricing Model modal so it submits correctly by matching the form data to editPricingModelSchema. defaultValues now include a root id and a nested pricingModel object with its id.

<!-- End of auto-generated description by cubic. -->

