### PR TITLE
fix: trial input

### DIFF
--- a/platform/flowglad-next/src/components/forms/PriceFormTrialFields.tsx
+++ b/platform/flowglad-next/src/components/forms/PriceFormTrialFields.tsx
@@ -108,8 +108,9 @@ const TrialFields = () => {
                   <FormControl>
                     <NumberInput
                       {...field}
-                      onChange={(e) => {
-                        field.onChange(Number(e.target.value))
+                      onChange={undefined}
+                      onValueChange={({ floatValue }) => {
+                        field.onChange(floatValue ?? undefined)
                       }}
                       min={1}
                       max={365}


### PR DESCRIPTION
## What Does this PR Do?

- fixed trial input in create product modal by switching from onChange to onValueChange to align with NumberInput 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the trial duration field in the Create Product modal by using NumberInput’s onValueChange so the form receives a proper numeric value. Prevents invalid or missed updates and aligns with the NumberInput API.

<!-- End of auto-generated description by cubic. -->

