### PR TITLE
Remove usage feature flag gate - make usage meters available to all users

### DIFF
--- a/platform/flowglad-next/src/components/forms/PriceFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/PriceFormFields.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useState, useRef } from 'react'
 import { CurrencyInput } from '@/components/ui/currency-input'
-import { FeatureFlag, IntervalUnit, PriceType } from '@/types'
+import { IntervalUnit, PriceType } from '@/types'
 import { snakeCase } from 'change-case'
 import { Switch } from '@/components/ui/switch'
 import {
@@ -26,7 +26,6 @@ import {
   FormMessage,
   FormDescription,
 } from '@/components/ui/form'
-import { hasFeatureFlag } from '@/utils/organizationHelpers'
 import { useAuthenticatedContext } from '@/contexts/authContext'
 import UsageMetersSelect from './UsageMetersSelect'
 import { cn, core } from '@/utils/core'
@@ -245,7 +244,6 @@ const PriceFormFields = ({
 
   let typeFields = <></>
   const { organization } = useAuthenticatedContext()
-  const hasUsage = hasFeatureFlag(organization, FeatureFlag.Usage)
   if (!core.IS_PROD) {
     const price = watch('price')
     console.log('===price', price)
@@ -368,11 +366,9 @@ const PriceFormFields = ({
                   <SelectItem value={PriceType.Subscription}>
                     Subscription
                   </SelectItem>
-                  {hasUsage && (
-                    <SelectItem value={PriceType.Usage}>
-                      Usage
-                    </SelectItem>
-                  )}
+                  <SelectItem value={PriceType.Usage}>
+                    Usage
+                  </SelectItem>
                 </SelectContent>
               </Select>
             </FormControl>

--- a/platform/flowglad-next/src/components/navigation/SideNavigation.tsx
+++ b/platform/flowglad-next/src/components/navigation/SideNavigation.tsx
@@ -20,7 +20,6 @@ import { trpc } from '@/app/_trpc/client'
 import { cn } from '@/utils/core'
 import { useEffect, useState } from 'react'
 import { FallbackSkeleton } from '../ui/skeleton'
-import { FeatureFlag } from '@/types'
 import { RiDiscordFill } from '@remixicon/react'
 import {
   SidebarHeader,
@@ -92,16 +91,11 @@ export const SideNavigation = () => {
       label: 'Purchases',
       href: '/store/purchases',
     },
-  ]
-  if (
-    organization &&
-    organization.featureFlags?.[FeatureFlag.Usage]
-  ) {
-    storeChildItems.push({
+    {
       label: 'Usage Meters',
       href: '/store/usage-meters',
-    })
-  }
+    },
+  ]
 
   return (
     <>

--- a/platform/flowglad-next/src/server/routers/usageEventsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/usageEventsRouter.ts
@@ -11,7 +11,7 @@ import {
 import { generateOpenApiMetas } from '@/utils/openapi'
 import { usageEventsClientSelectSchema } from '@/db/schema/usageEvents'
 
-import { usageProcedure } from '@/server/trpc'
+import { protectedProcedure } from '@/server/trpc'
 import {
   authenticatedProcedureComprehensiveTransaction,
   authenticatedTransaction,
@@ -31,7 +31,7 @@ const { openApiMetas, routeConfigs } = generateOpenApiMetas({
 
 export const usageEventsRouteConfigs = routeConfigs
 
-export const createUsageEvent = usageProcedure
+export const createUsageEvent = protectedProcedure
   .meta(openApiMetas.POST)
   .input(createUsageEventSchema)
   .output(z.object({ usageEvent: usageEventsClientSelectSchema }))
@@ -46,7 +46,7 @@ export const createUsageEvent = usageProcedure
     )
   )
 
-export const getUsageEvent = usageProcedure
+export const getUsageEvent = protectedProcedure
   .meta(openApiMetas.GET)
   .input(idInputSchema)
   .output(z.object({ usageEvent: usageEventsClientSelectSchema }))
@@ -60,7 +60,7 @@ export const getUsageEvent = usageProcedure
     return { usageEvent }
   })
 
-export const bulkInsertUsageEventsProcedure = usageProcedure
+export const bulkInsertUsageEventsProcedure = protectedProcedure
   .input(bulkInsertUsageEventsSchema)
   .output(
     z.object({ usageEvents: z.array(usageEventsClientSelectSchema) })

--- a/platform/flowglad-next/src/server/routers/usageMetersRouter.ts
+++ b/platform/flowglad-next/src/server/routers/usageMetersRouter.ts
@@ -1,4 +1,4 @@
-import { router, usageProcedure } from '../trpc'
+import { router, protectedProcedure } from '../trpc'
 import {
   editUsageMeterSchema,
   usageMeterPaginatedListSchema,
@@ -24,8 +24,6 @@ import {
 } from '@/db/tableUtils'
 import { selectMembershipAndOrganizations } from '@/db/tableMethods/membershipMethods'
 import { z } from 'zod'
-import { FeatureFlag } from '@/types'
-import { hasFeatureFlag } from '@/utils/organizationHelpers'
 
 const { openApiMetas, routeConfigs } = generateOpenApiMetas({
   resource: 'usageMeter',
@@ -34,7 +32,7 @@ const { openApiMetas, routeConfigs } = generateOpenApiMetas({
 
 export const usageMetersRouteConfigs = routeConfigs
 
-export const createUsageMeter = usageProcedure
+export const createUsageMeter = protectedProcedure
   .meta(openApiMetas.POST)
   .input(createUsageMeterSchema)
   .output(z.object({ usageMeter: usageMetersClientSelectSchema }))
@@ -49,11 +47,6 @@ export const createUsageMeter = usageProcedure
             },
             transaction
           )
-        if (!hasFeatureFlag(organization, FeatureFlag.Usage)) {
-          throw new Error(
-            `Organization ${organization.id} does not have feature flag ${FeatureFlag.Usage} enabled`
-          )
-        }
         const usageMeter = await insertUsageMeter(
           {
             ...input.usageMeter,
@@ -67,7 +60,7 @@ export const createUsageMeter = usageProcedure
     )
   )
 
-const listUsageMetersProcedure = usageProcedure
+const listUsageMetersProcedure = protectedProcedure
   .meta(openApiMetas.LIST)
   .input(usageMeterPaginatedSelectSchema)
   .output(usageMeterPaginatedListSchema)
@@ -79,7 +72,7 @@ const listUsageMetersProcedure = usageProcedure
     )
   )
 
-const editUsageMeter = usageProcedure
+const editUsageMeter = protectedProcedure
   .meta(openApiMetas.PUT)
   .input(editUsageMeterSchema)
   .output(z.object({ usageMeter: usageMetersClientSelectSchema }))
@@ -98,7 +91,7 @@ const editUsageMeter = usageProcedure
     )
   )
 
-const getUsageMeter = usageProcedure
+const getUsageMeter = protectedProcedure
   .meta(openApiMetas.GET)
   .input(idInputSchema)
   .output(z.object({ usageMeter: usageMetersClientSelectSchema }))
@@ -114,7 +107,7 @@ const getUsageMeter = usageProcedure
     )
   )
 
-const getTableRowsProcedure = usageProcedure
+const getTableRowsProcedure = protectedProcedure
   .input(
     createPaginatedTableRowInputSchema(
       z.object({

--- a/platform/flowglad-next/src/server/trpc.ts
+++ b/platform/flowglad-next/src/server/trpc.ts
@@ -159,7 +159,3 @@ export const featureFlaggedProcedure = (featureFlag: FeatureFlag) => {
     return next({ ctx })
   })
 }
-
-export const usageProcedure = featureFlaggedProcedure(
-  FeatureFlag.Usage
-)


### PR DESCRIPTION
## Summary
- Removed the `FeatureFlag.Usage` gate that was restricting access to usage meters functionality
- Made usage meters available to all authenticated users by default
- Cleaned up related code and unused imports

## Changes
- **SideNavigation.tsx**: Removed conditional check for usage feature flag - "Usage Meters" menu item now always appears
- **API Routes**: Replaced `usageProcedure` with `protectedProcedure` in both usageMetersRouter and usageEventsRouter
- **PriceFormFields.tsx**: Usage price type option is now always available when creating/editing prices
- **Cleanup**: Removed unused `usageProcedure` export and all unused feature flag imports

## Test Plan
- [ ] Verify that "Usage Meters" appears in the sidebar for all authenticated users
- [ ] Test creating and managing usage meters
- [ ] Verify that Usage price type is available when creating new prices
- [ ] Test usage events API endpoints work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Opened up usage meters for all authenticated users by removing the Usage feature flag gate. The sidebar always shows Usage Meters, and the Usage price type is always available.

- **Refactors**
  - Replaced usageProcedure with protectedProcedure in usageMetersRouter and usageEventsRouter.
  - Removed FeatureFlag.Usage checks and related helpers/imports.
  - Always show "Usage Meters" in the sidebar and the "Usage" price type in PriceFormFields.
  - Deleted usageProcedure export from trpc.ts.

<!-- End of auto-generated description by cubic. -->

