### PR TITLE
Temporarily disable MCP Server setup in onboarding

### DIFF
--- a/platform/flowglad-next/src/app/onboarding/OnboardingStatusTable.tsx
+++ b/platform/flowglad-next/src/app/onboarding/OnboardingStatusTable.tsx
@@ -266,6 +266,7 @@ const OnboardingStatusTable = ({
           }}
         />
       ))}
+      {/* Temporarily disabled MCP Server setup
       <OnboardingStatusRow
         key={'setup-flowglad-mcp-server'}
         completed={false}
@@ -276,7 +277,7 @@ const OnboardingStatusTable = ({
             href={`https://cursor.com/install-mcp?name=flowglad&config=${encodeURIComponent(JSON.stringify(mcpServerConfig))}`}
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
+            {/* <img
               src="https://cursor.com/deeplink/mcp-install-light.svg"
               alt="Add flowglad MCP server to Cursor"
               height="40"
@@ -285,6 +286,7 @@ const OnboardingStatusTable = ({
           </a>
         }
       />
+      */}
       <NounVerbModal
         isOpen={isNounVerbModalOpen}
         setIsOpen={setIsNounVerbModalOpen}


### PR DESCRIPTION
## Summary
- Commented out the "Setup Flowglad MCP Server" section (item #5) in the onboarding flow
- Code is preserved and can be easily re-enabled by removing the comment markers

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Temporarily hide the “Setup Flowglad MCP Server” step in the onboarding flow by commenting out its row in OnboardingStatusTable. Code remains in place for easy re-enable; other steps render unchanged.

<!-- End of auto-generated description by cubic. -->

