### PR TITLE
Add Featurebase messenger integration

### DIFF
--- a/platform/flowglad-next/src/app/FeaturebaseMessenger.tsx
+++ b/platform/flowglad-next/src/app/FeaturebaseMessenger.tsx
@@ -10,7 +10,14 @@ declare global {
 }
 
 export default function FeaturebaseMessenger() {
+  const appId = process.env.NEXT_PUBLIC_FEATUREBASE_APP_ID
+
   useEffect(() => {
+    if (!appId) {
+      // Silently no-op if not configured in this environment
+      return
+    }
+
     const browserWindow = window as Window
 
     if (typeof browserWindow.Featurebase !== 'function') {
@@ -25,12 +32,6 @@ export default function FeaturebaseMessenger() {
       browserWindow.Featurebase = featurebaseShim
     }
 
-    const appId = process.env.NEXT_PUBLIC_FEATUREBASE_APP_ID
-    if (!appId) {
-      // Silently no-op if not configured in this environment
-      return
-    }
-
     browserWindow.Featurebase!('boot', {
       appId,
       // Add additional user context when available. Avoid adding user data
@@ -38,7 +39,11 @@ export default function FeaturebaseMessenger() {
       // theme: 'light',
       // language: 'en',
     })
-  }, [])
+  }, [appId])
+
+  if (!appId) {
+    return null
+  }
 
   return (
     <Script

--- a/platform/flowglad-next/src/app/FeaturebaseMessenger.tsx
+++ b/platform/flowglad-next/src/app/FeaturebaseMessenger.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useEffect } from 'react'
+import Script from 'next/script'
+
+declare global {
+  interface Window {
+    Featurebase?: ((...args: any[]) => void) & { q?: unknown[] }
+  }
+}
+
+export default function FeaturebaseMessenger() {
+  useEffect(() => {
+    const browserWindow = window as Window
+
+    if (typeof browserWindow.Featurebase !== 'function') {
+      type FeaturebaseFunction = ((...args: unknown[]) => void) & {
+        q?: unknown[]
+      }
+      const queuedCalls: unknown[] = []
+      const featurebaseShim = ((...args: unknown[]) => {
+        queuedCalls.push(args)
+      }) as FeaturebaseFunction
+      featurebaseShim.q = queuedCalls
+      browserWindow.Featurebase = featurebaseShim
+    }
+
+    const appId = process.env.NEXT_PUBLIC_FEATUREBASE_APP_ID
+    if (!appId) {
+      // Silently no-op if not configured in this environment
+      return
+    }
+
+    browserWindow.Featurebase!('boot', {
+      appId,
+      // Add additional user context when available. Avoid adding user data
+      // unless Identity Verification (userHash) is configured per docs.
+      // theme: 'light',
+      // language: 'en',
+    })
+  }, [])
+
+  return (
+    <Script
+      src="https://do.featurebase.app/js/sdk.js"
+      id="featurebase-sdk"
+      strategy="afterInteractive"
+    />
+  )
+}
+
+

--- a/platform/flowglad-next/src/app/Providers.tsx
+++ b/platform/flowglad-next/src/app/Providers.tsx
@@ -5,6 +5,7 @@ import type { AuthContextValues } from '../contexts/authContext'
 import AuthProvider from '../contexts/authContext'
 import TrpcProvider from '@/app/_trpc/Provider'
 import PostHogPageView from './PostHogPageview'
+import FeaturebaseMessenger from './FeaturebaseMessenger'
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
@@ -25,6 +26,7 @@ export default function Providers({
       <AuthProvider values={authContext}>
         <PostHogProvider client={posthog}>
           <PostHogPageView user={authContext.user} />
+          <FeaturebaseMessenger />
           {children}
         </PostHogProvider>
       </AuthProvider>


### PR DESCRIPTION
## Summary
- Integrate Featurebase messenger SDK for in-app customer support
- Add FeaturebaseMessenger component that loads SDK and handles initialization
- Environment-configured via NEXT_PUBLIC_FEATUREBASE_APP_ID

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Integrates Featurebase in-app messenger across the app. The SDK loads after interactive and initializes only when NEXT_PUBLIC_FEATUREBASE_APP_ID is set.

- **New Features**
  - FeaturebaseMessenger component loads SDK and boots with appId.
  - Added to Providers for app-wide availability.
  - No-op when env var is missing to avoid errors.

- **Migration**
  - Set NEXT_PUBLIC_FEATUREBASE_APP_ID in environment.
  - Optionally add user context after enabling identity verification.

<!-- End of auto-generated description by cubic. -->

