### PR TITLE
create purchase api endpoint

### DIFF
--- a/platform/flowglad-next/public/preview/manifest.json
+++ b/platform/flowglad-next/public/preview/manifest.json
@@ -2,5 +2,5 @@
   "hash": "1c6121af",
   "path": "/preview/preview.css",
   "size": 63315,
-  "generatedAt": "2025-09-08T14:14:15.186Z"
+  "generatedAt": "2025-09-09T21:24:25.418Z"
 }

--- a/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
+++ b/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
@@ -16,6 +16,7 @@ import { discountsRouteConfigs } from '@/server/routers/discountsRouter'
 import { pricesRouteConfigs } from '@/server/routers/pricesRouter'
 import { invoicesRouteConfigs } from '@/server/routers/invoicesRouter'
 import { paymentMethodsRouteConfigs } from '@/server/routers/paymentMethodsRouter'
+import { purchasesRouteConfigs } from '@/server/routers/purchasesRouter'
 import { usageEventsRouteConfigs } from '@/server/routers/usageEventsRouter'
 import { usageMetersRouteConfigs } from '@/server/routers/usageMetersRouter'
 import { webhooksRouteConfigs } from '@/server/routers/webhooksRouter'
@@ -52,6 +53,7 @@ const routeConfigs = [
   ...invoicesRouteConfigs,
   ...paymentMethodsRouteConfigs,
   ...paymentsRouteConfigs,
+  ...purchasesRouteConfigs,
   ...pricingModelsRouteConfigs,
   ...usageMetersRouteConfigs,
   ...usageEventsRouteConfigs,

--- a/platform/flowglad-next/src/server/routers/purchasesRouter.ts
+++ b/platform/flowglad-next/src/server/routers/purchasesRouter.ts
@@ -3,8 +3,14 @@ import {
   authenticatedProcedureTransaction,
   authenticatedTransaction,
 } from '@/db/authenticatedTransaction'
-import { selectPurchasesTableRowData } from '@/db/tableMethods/purchaseMethods'
-import { purchasesTableRowDataSchema } from '@/db/schema/purchases'
+import {
+  selectPurchasesTableRowData,
+  selectPurchaseById,
+} from '@/db/tableMethods/purchaseMethods'
+import {
+  purchasesTableRowDataSchema,
+  purchaseClientSelectSchema,
+} from '@/db/schema/purchases'
 import { protectedProcedure, router } from '@/server/trpc'
 import { createPurchase } from '@/server/mutations/createPurchase'
 import { setCheckoutSessionCookie } from '@/server/mutations/setCheckoutSessionCookie'
@@ -15,7 +21,32 @@ import { PurchaseStatus } from '@/types'
 import {
   createPaginatedTableRowInputSchema,
   createPaginatedTableRowOutputSchema,
+  idInputSchema,
 } from '@/db/tableUtils'
+import { generateOpenApiMetas } from '@/utils/openapi'
+
+const { openApiMetas, routeConfigs } = generateOpenApiMetas({
+  resource: 'Purchase',
+  tags: ['Purchases'],
+})
+
+export const purchasesRouteConfigs = routeConfigs
+
+const getPurchaseProcedure = protectedProcedure
+  .meta(openApiMetas.GET)
+  .input(idInputSchema)
+  .output(z.object({ purchase: purchaseClientSelectSchema }))
+  .query(async ({ ctx, input }) => {
+    const purchase = await authenticatedTransaction(
+      async ({ transaction }) => {
+        return selectPurchaseById(input.id, transaction)
+      },
+      {
+        apiKey: ctx.apiKey,
+      }
+    )
+    return { purchase }
+  })
 
 const getTableRows = protectedProcedure
   .input(
@@ -35,11 +66,15 @@ const getTableRows = protectedProcedure
   )
 
 export const purchasesRouter = router({
+  // Get single purchase
+  get: getPurchaseProcedure,
+  // Create purchase
   create: createPurchase,
   // Purchase session management
   createSession: setCheckoutSessionCookie,
   updateSession: editCheckoutSession,
   confirmSession: confirmCheckoutSession,
   requestAccess: requestPurchaseAccessSession,
+  // Table rows for internal UI
   getTableRows,
 })


### PR DESCRIPTION
## What Does this PR Do?

- create /api/v1/purchases/{id} endpoint
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a protected GET /api/v1/purchases/{id} endpoint to fetch a single purchase by ID. Wires it into the v1 router and OpenAPI docs.

- **New Features**
  - New GET /api/v1/purchases/{id} returns { purchase } shaped by purchaseClientSelectSchema.
  - Validates id with idInputSchema and authorizes via API key via authenticatedTransaction.
  - Registers purchasesRouteConfigs and adds it to the v1 route aggregator for routing and docs.

<!-- End of auto-generated description by cubic. -->

