### PR TITLE
temp disable featurebase

### DIFF
--- a/platform/flowglad-next/src/app/Providers.tsx
+++ b/platform/flowglad-next/src/app/Providers.tsx
@@ -31,7 +31,7 @@ export default function Providers({
       <AuthProvider values={authContext}>
         <PostHogProvider client={posthog}>
           <PostHogPageView user={authContext.user} />
-          {!isPublicRoute && !isBillingPortal && <FeaturebaseMessenger />}
+          {/* {!isPublicRoute && !isBillingPortal && <FeaturebaseMessenger />} */}
           {children}
         </PostHogProvider>
       </AuthProvider>


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Temporarily disable the Featurebase Messenger so the widget no longer loads on non-public, non-billing routes by commenting out its render in Providers.tsx. No other behavior or providers are affected.

<!-- End of auto-generated description by cubic. -->

