### PR TITLE
display featurebase

### DIFF
--- a/platform/flowglad-next/src/app/Providers.tsx
+++ b/platform/flowglad-next/src/app/Providers.tsx
@@ -31,7 +31,7 @@ export default function Providers({
       <AuthProvider values={authContext}>
         <PostHogProvider client={posthog}>
           <PostHogPageView user={authContext.user} />
-          {/* {!isPublicRoute && !isBillingPortal && <FeaturebaseMessenger />} */}
+          {!isPublicRoute && !isBillingPortal && <FeaturebaseMessenger />}
           {children}
         </PostHogProvider>
       </AuthProvider>


### PR DESCRIPTION
## What Does this PR Do?

-render featurebase
-identity keyed rebooting
-no caching userHash
-logging for DEV enviornment
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable Featurebase messenger in the app and fix boot logic to track user identity. Prevents duplicate boots and ensures the widget updates when the user changes.

- **New Features**
  - Render FeaturebaseMessenger on non-public, non-billing pages.
  - Key boot by user.id + userHash to allow reboots on identity change and avoid repeat boots.
  - Fetch userHash with cache: 'no-store' to avoid stale hashes.
  - Add dev warnings when disabled and SDK load error logging.

<!-- End of auto-generated description by cubic. -->

