### PR TITLE
feat: add scheduled API contract verification task

### DIFF
--- a/platform/flowglad-next/src/__mocks__/@trigger/index.ts
+++ b/platform/flowglad-next/src/__mocks__/@trigger/index.ts
@@ -74,6 +74,9 @@ export const invoiceUpdatedTask = createTaskMock(
 // Cron tasks
 export const dailyCron = createTaskMock('daily-cron')
 export const hourlyCron = createTaskMock('hourly-cron')
+export const verifyApiContractTask = createTaskMock(
+  'verify-api-contract'
+)
 
 // Example task
 export const helloWorldTask = createTaskMock('example')

--- a/platform/flowglad-next/src/trigger/verify-api-contract.ts
+++ b/platform/flowglad-next/src/trigger/verify-api-contract.ts
@@ -1,0 +1,35 @@
+import { logger, schedules } from '@trigger.dev/sdk'
+import { StandardLogger } from '@/types'
+import verifyApiContract from '@/api-contract/verify'
+
+export const verifyApiContractTask = schedules.task({
+  id: 'verify-api-contract',
+  cron: '*/10 * * * *', // Every 10 minutes
+  run: async ({ timestamp }) => {
+    // Create a StandardLogger that wraps trigger.dev's logger
+    const standardLogger: StandardLogger = {
+      info: (message: string) => logger.log(message),
+      warn: (message: string) => logger.warn(message),
+      error: (message: string) => logger.error(message),
+    }
+
+    logger.log('Starting API contract verification', { timestamp })
+
+    try {
+      await verifyApiContract(standardLogger)
+      logger.log('API contract verification completed successfully', {
+        timestamp,
+      })
+      return {
+        success: true,
+        timestamp: timestamp.toISOString(),
+      }
+    } catch (error) {
+      logger.error('API contract verification failed', {
+        error: error instanceof Error ? error.message : String(error),
+        timestamp,
+      })
+      throw error
+    }
+  },
+})


### PR DESCRIPTION
## Summary
- Implemented a scheduled trigger.dev task that runs every 10 minutes to verify API contracts
- Created StandardLogger wrapper to adapt trigger.dev's logger to the expected interface
- Added test mock for the new scheduled task

## Test plan
- [ ] Verify the task appears in trigger.dev dashboard
- [ ] Confirm the task runs every 10 minutes as scheduled
- [ ] Check that API contract verification logs are properly captured
- [ ] Ensure error handling works correctly when verification fails

🤖 Generated with [Claude Code](https://claude.ai/code)