### PR TITLE
feat: add route config tests for apiKeys and checkoutSessions routers

### DIFF
--- a/platform/flowglad-next/src/server/routers/apiKeysRouter.routeConfigs.test.ts
+++ b/platform/flowglad-next/src/server/routers/apiKeysRouter.routeConfigs.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from 'vitest'
+import { apiKeysRouteConfigs } from './apiKeysRouter'
+
+describe('apiKeysRouteConfigs', () => {
+  // Helper function to find route config in the array
+  const findRouteConfig = (routeKey: string) => {
+    for (const routeConfigObj of apiKeysRouteConfigs) {
+      if (routeConfigObj[routeKey]) {
+        return routeConfigObj[routeKey]
+      }
+    }
+    return undefined
+  }
+
+  // Helper function to get all route keys from the array
+  const getAllRouteKeys = () => {
+    const keys: string[] = []
+    for (const routeConfigObj of apiKeysRouteConfigs) {
+      keys.push(...Object.keys(routeConfigObj))
+    }
+    return keys
+  }
+
+  describe('Route pattern matching and procedure mapping', () => {
+    it('should map POST /api-keys to apiKeys.create procedure', () => {
+      const routeConfig = findRouteConfig('POST /api-keys')
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('apiKeys.create')
+      expect(routeConfig!.pattern.test('api-keys')).toBe(true)
+
+      // Test mapParams with body
+      const testBody = { apiKey: { name: 'Test API Key' } }
+      const result = routeConfig!.mapParams([], testBody)
+      expect(result).toEqual(testBody)
+    })
+
+    it('should map PUT /api-keys/:id to apiKeys.update procedure', () => {
+      const routeConfig = findRouteConfig('PUT /api-keys/:id')
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('apiKeys.update')
+      expect(routeConfig!.pattern.test('api-keys/test-id')).toBe(true)
+
+      // Test mapParams with matches and body (simulate route handler slicing)
+      const testBody = { apiKey: { name: 'Updated API Key' } }
+      const result = routeConfig!.mapParams(['test-id'], testBody)
+      expect(result).toEqual({
+        ...testBody,
+        id: 'test-id',
+      })
+    })
+
+    it('should map GET /api-keys/:id to apiKeys.get procedure', () => {
+      const routeConfig = findRouteConfig('GET /api-keys/:id')
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('apiKeys.get')
+      expect(routeConfig!.pattern.test('api-keys/test-id')).toBe(true)
+
+      // Test mapParams with matches only (simulate route handler slicing)
+      const result = routeConfig!.mapParams(['test-id'])
+      expect(result).toEqual({ id: 'test-id' })
+    })
+
+    it('should map GET /api-keys to apiKeys.list procedure', () => {
+      const routeConfig = findRouteConfig('GET /api-keys')
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('apiKeys.list')
+      expect(routeConfig!.pattern.test('api-keys')).toBe(true)
+
+      // Test mapParams returns undefined for list endpoints
+      const result = routeConfig!.mapParams([])
+      expect(result).toBeUndefined()
+    })
+
+    it('should map DELETE /api-keys/:id to apiKeys.delete procedure', () => {
+      const routeConfig = findRouteConfig('DELETE /api-keys/:id')
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('apiKeys.delete')
+      expect(routeConfig!.pattern.test('api-keys/test-id')).toBe(true)
+
+      // Test mapParams with matches only (simulate route handler slicing)
+      const result = routeConfig!.mapParams(['test-id'])
+      expect(result).toEqual({ id: 'test-id' })
+    })
+  })
+
+  describe('Route pattern RegExp validation', () => {
+    it('should have valid RegExp patterns that match expected paths', () => {
+      // API Keys creation pattern should match 'api-keys'
+      const createConfig = findRouteConfig('POST /api-keys')
+      expect(createConfig!.pattern.test('api-keys')).toBe(true)
+      expect(createConfig!.pattern.test('api-keys/id')).toBe(false)
+
+      // API Keys get pattern should match 'api-keys/abc123'
+      const getConfig = findRouteConfig('GET /api-keys/:id')
+      expect(getConfig!.pattern.test('api-keys/abc123')).toBe(true)
+      expect(getConfig!.pattern.test('api-keys')).toBe(false)
+      expect(getConfig!.pattern.test('api-keys/abc123/extra')).toBe(
+        false
+      )
+
+      // API Keys edit pattern should match 'api-keys/abc123'
+      const updateConfig = findRouteConfig('PUT /api-keys/:id')
+      expect(updateConfig!.pattern.test('api-keys/abc123')).toBe(true)
+      expect(updateConfig!.pattern.test('api-keys')).toBe(false)
+
+      // API Keys delete pattern should match 'api-keys/abc123'
+      const deleteConfig = findRouteConfig('DELETE /api-keys/:id')
+      expect(deleteConfig!.pattern.test('api-keys/abc123')).toBe(true)
+      expect(deleteConfig!.pattern.test('api-keys')).toBe(false)
+
+      // API Keys list pattern should match 'api-keys' only
+      const listConfig = findRouteConfig('GET /api-keys')
+      expect(listConfig!.pattern.test('api-keys')).toBe(true)
+      expect(listConfig!.pattern.test('api-keys/id')).toBe(false)
+    })
+
+    it('should extract correct matches from URL paths', () => {
+      // Test API Keys get pattern extraction
+      const getConfig = findRouteConfig('GET /api-keys/:id')
+      const getMatches = getConfig!.pattern.exec('api-keys/test-id')
+      expect(getMatches).not.toBeNull()
+      expect(getMatches![1]).toBe('test-id') // First capture group
+
+      // Test API Keys update pattern extraction
+      const updateConfig = findRouteConfig('PUT /api-keys/:id')
+      const updateMatches = updateConfig!.pattern.exec(
+        'api-keys/test-id'
+      )
+      expect(updateMatches).not.toBeNull()
+      expect(updateMatches![1]).toBe('test-id') // First capture group
+
+      // Test API Keys delete pattern extraction
+      const deleteConfig = findRouteConfig('DELETE /api-keys/:id')
+      const deleteMatches = deleteConfig!.pattern.exec(
+        'api-keys/test-id'
+      )
+      expect(deleteMatches).not.toBeNull()
+      expect(deleteMatches![1]).toBe('test-id') // First capture group
+
+      // Test API Keys list pattern (no captures)
+      const listConfig = findRouteConfig('GET /api-keys')
+      const listMatches = listConfig!.pattern.exec('api-keys')
+      expect(listMatches).not.toBeNull()
+      expect(listMatches!.length).toBe(1) // Only the full match, no capture groups
+
+      // Test API Keys create pattern (no captures)
+      const createConfig = findRouteConfig('POST /api-keys')
+      const createMatches = createConfig!.pattern.exec('api-keys')
+      expect(createMatches).not.toBeNull()
+      expect(createMatches!.length).toBe(1) // Only the full match, no capture groups
+    })
+  })
+
+  describe('mapParams function behavior', () => {
+    it('should correctly map URL parameters for API Keys get requests', () => {
+      const routeConfig = findRouteConfig('GET /api-keys/:id')
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['api-key-123'])
+
+      expect(result).toEqual({
+        id: 'api-key-123',
+      })
+    })
+
+    it('should correctly map URL parameters and body for API Keys edit requests', () => {
+      const routeConfig = findRouteConfig('PUT /api-keys/:id')
+      const testBody = {
+        apiKey: {
+          name: 'Updated API Key Name',
+          type: 'SECRET',
+        },
+      }
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['api-key-456'], testBody)
+
+      expect(result).toEqual({
+        apiKey: {
+          name: 'Updated API Key Name',
+          type: 'SECRET',
+        },
+        id: 'api-key-456',
+      })
+    })
+
+    it('should correctly map URL parameters for API Keys delete requests', () => {
+      const routeConfig = findRouteConfig('DELETE /api-keys/:id')
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['api-key-789'])
+
+      expect(result).toEqual({
+        id: 'api-key-789',
+      })
+    })
+
+    it('should return body for API Keys create requests', () => {
+      const routeConfig = findRouteConfig('POST /api-keys')
+      const testBody = {
+        apiKey: {
+          name: 'New API Key',
+          type: 'SECRET',
+        },
+      }
+
+      const result = routeConfig!.mapParams([], testBody)
+
+      expect(result).toEqual(testBody)
+    })
+
+    it('should return undefined for API Keys list requests', () => {
+      const routeConfig = findRouteConfig('GET /api-keys')
+
+      const result = routeConfig!.mapParams([])
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should handle special characters and encoded values in id', () => {
+      const routeConfig = findRouteConfig('GET /api-keys/:id')
+
+      // Test with URL-encoded characters (simulate route handler slicing)
+      const result1 = routeConfig!.mapParams(['key%40company.com'])
+      expect(result1).toEqual({
+        id: 'key%40company.com',
+      })
+
+      // Test with hyphens and underscores (simulate route handler slicing)
+      const result2 = routeConfig!.mapParams(['api-key_123-abc'])
+      expect(result2).toEqual({ id: 'api-key_123-abc' })
+    })
+  })
+
+  describe('Route config completeness', () => {
+    it('should have all expected CRUD route configs', () => {
+      const routeKeys = getAllRouteKeys()
+
+      // Check that all expected routes exist
+      expect(routeKeys).toContain('POST /api-keys') // create
+      expect(routeKeys).toContain('PUT /api-keys/:id') // update
+      expect(routeKeys).toContain('GET /api-keys/:id') // get
+      expect(routeKeys).toContain('GET /api-keys') // list
+      expect(routeKeys).toContain('DELETE /api-keys/:id') // delete
+
+      // Check that we have exactly the expected number of routes
+      expect(routeKeys).toHaveLength(5) // Standard CRUD operations
+    })
+
+    it('should have consistent id parameter usage', () => {
+      const idRoutes = [
+        'PUT /api-keys/:id',
+        'GET /api-keys/:id',
+        'DELETE /api-keys/:id',
+      ]
+
+      idRoutes.forEach((routeKey) => {
+        const config = findRouteConfig(routeKey)
+
+        // Test that mapParams consistently uses 'id' (simulate route handler slicing)
+        const result = config!.mapParams(['test-id'], {
+          someData: 'value',
+        })
+        expect(result).toHaveProperty('id', 'test-id')
+      })
+    })
+
+    it('should have valid route config structure for all routes', () => {
+      // Test all route configs from the array
+      apiKeysRouteConfigs.forEach((routeConfigObj) => {
+        Object.entries(routeConfigObj).forEach(
+          ([routeKey, config]) => {
+            // Each config should have required properties
+            expect(config).toHaveProperty('procedure')
+            expect(config).toHaveProperty('pattern')
+            expect(config).toHaveProperty('mapParams')
+
+            // Procedure should be a valid TRPC procedure path
+            expect(config.procedure).toMatch(/^apiKeys\.\w+$/)
+
+            // Pattern should be a RegExp
+            expect(config.pattern).toBeInstanceOf(RegExp)
+
+            // mapParams should be a function
+            expect(typeof config.mapParams).toBe('function')
+          }
+        )
+      })
+    })
+
+    it('should map to correct TRPC procedures', () => {
+      const expectedMappings = {
+        'POST /api-keys': 'apiKeys.create',
+        'PUT /api-keys/:id': 'apiKeys.update',
+        'GET /api-keys/:id': 'apiKeys.get',
+        'GET /api-keys': 'apiKeys.list',
+        'DELETE /api-keys/:id': 'apiKeys.delete',
+      }
+
+      Object.entries(expectedMappings).forEach(
+        ([routeKey, expectedProcedure]) => {
+          const config = findRouteConfig(routeKey)
+          expect(config!.procedure).toBe(expectedProcedure)
+        }
+      )
+    })
+  })
+})

--- a/platform/flowglad-next/src/server/routers/checkoutSessionsRouter.routeConfigs.test.ts
+++ b/platform/flowglad-next/src/server/routers/checkoutSessionsRouter.routeConfigs.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect } from 'vitest'
+import { checkoutSessionsRouteConfigs } from './checkoutSessionsRouter'
+
+describe('checkoutSessionsRouteConfigs', () => {
+  // Helper function to find route config in the array
+  const findRouteConfig = (routeKey: string) => {
+    for (const routeConfigObj of checkoutSessionsRouteConfigs) {
+      if (routeConfigObj[routeKey]) {
+        return routeConfigObj[routeKey]
+      }
+    }
+    return undefined
+  }
+
+  // Helper function to get all route keys from the array
+  const getAllRouteKeys = () => {
+    const keys: string[] = []
+    for (const routeConfigObj of checkoutSessionsRouteConfigs) {
+      keys.push(...Object.keys(routeConfigObj))
+    }
+    return keys
+  }
+
+  describe('Route pattern matching and procedure mapping', () => {
+    it('should map POST /checkout-sessions to checkoutSessions.create procedure', () => {
+      const routeConfig = findRouteConfig('POST /checkout-sessions')
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('checkoutSessions.create')
+      expect(routeConfig!.pattern.test('checkout-sessions')).toBe(
+        true
+      )
+
+      // Test mapParams with body
+      const testBody = {
+        checkoutSession: {
+          type: 'product',
+          customerEmail: 'test@example.com',
+        },
+      }
+      const result = routeConfig!.mapParams([], testBody)
+      expect(result).toEqual(testBody)
+    })
+
+    it('should map PUT /checkout-sessions/:id to checkoutSessions.update procedure', () => {
+      const routeConfig = findRouteConfig(
+        'PUT /checkout-sessions/:id'
+      )
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('checkoutSessions.update')
+      expect(
+        routeConfig!.pattern.test('checkout-sessions/test-id')
+      ).toBe(true)
+
+      // Test mapParams with matches and body (simulate route handler slicing)
+      const testBody = {
+        checkoutSession: {
+          customerEmail: 'updated@example.com',
+        },
+      }
+      const result = routeConfig!.mapParams(['test-id'], testBody)
+      expect(result).toEqual({
+        ...testBody,
+        id: 'test-id',
+      })
+    })
+
+    it('should map GET /checkout-sessions/:id to checkoutSessions.get procedure', () => {
+      const routeConfig = findRouteConfig(
+        'GET /checkout-sessions/:id'
+      )
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('checkoutSessions.get')
+      expect(
+        routeConfig!.pattern.test('checkout-sessions/test-id')
+      ).toBe(true)
+
+      // Test mapParams with matches only (simulate route handler slicing)
+      const result = routeConfig!.mapParams(['test-id'])
+      expect(result).toEqual({ id: 'test-id' })
+    })
+
+    it('should map GET /checkout-sessions to checkoutSessions.list procedure', () => {
+      const routeConfig = findRouteConfig('GET /checkout-sessions')
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('checkoutSessions.list')
+      expect(routeConfig!.pattern.test('checkout-sessions')).toBe(
+        true
+      )
+
+      // Test mapParams returns undefined for list endpoints
+      const result = routeConfig!.mapParams([])
+      expect(result).toBeUndefined()
+    })
+
+    it('should map DELETE /checkout-sessions/:id to checkoutSessions.delete procedure', () => {
+      const routeConfig = findRouteConfig(
+        'DELETE /checkout-sessions/:id'
+      )
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('checkoutSessions.delete')
+      expect(
+        routeConfig!.pattern.test('checkout-sessions/test-id')
+      ).toBe(true)
+
+      // Test mapParams with matches only (simulate route handler slicing)
+      const result = routeConfig!.mapParams(['test-id'])
+      expect(result).toEqual({ id: 'test-id' })
+    })
+  })
+
+  describe('Route pattern RegExp validation', () => {
+    it('should have valid RegExp patterns that match expected paths', () => {
+      // Checkout Sessions creation pattern should match 'checkout-sessions'
+      const createConfig = findRouteConfig('POST /checkout-sessions')
+      expect(createConfig!.pattern.test('checkout-sessions')).toBe(
+        true
+      )
+      expect(createConfig!.pattern.test('checkout-sessions/id')).toBe(
+        false
+      )
+
+      // Checkout Sessions get pattern should match 'checkout-sessions/abc123'
+      const getConfig = findRouteConfig('GET /checkout-sessions/:id')
+      expect(
+        getConfig!.pattern.test('checkout-sessions/abc123')
+      ).toBe(true)
+      expect(getConfig!.pattern.test('checkout-sessions')).toBe(false)
+      expect(
+        getConfig!.pattern.test('checkout-sessions/abc123/extra')
+      ).toBe(false)
+
+      // Checkout Sessions edit pattern should match 'checkout-sessions/abc123'
+      const updateConfig = findRouteConfig(
+        'PUT /checkout-sessions/:id'
+      )
+      expect(
+        updateConfig!.pattern.test('checkout-sessions/abc123')
+      ).toBe(true)
+      expect(updateConfig!.pattern.test('checkout-sessions')).toBe(
+        false
+      )
+
+      // Checkout Sessions delete pattern should match 'checkout-sessions/abc123'
+      const deleteConfig = findRouteConfig(
+        'DELETE /checkout-sessions/:id'
+      )
+      expect(
+        deleteConfig!.pattern.test('checkout-sessions/abc123')
+      ).toBe(true)
+      expect(deleteConfig!.pattern.test('checkout-sessions')).toBe(
+        false
+      )
+
+      // Checkout Sessions list pattern should match 'checkout-sessions' only
+      const listConfig = findRouteConfig('GET /checkout-sessions')
+      expect(listConfig!.pattern.test('checkout-sessions')).toBe(true)
+      expect(listConfig!.pattern.test('checkout-sessions/id')).toBe(
+        false
+      )
+    })
+
+    it('should extract correct matches from URL paths', () => {
+      // Test Checkout Sessions get pattern extraction
+      const getConfig = findRouteConfig('GET /checkout-sessions/:id')
+      const getMatches = getConfig!.pattern.exec(
+        'checkout-sessions/test-id'
+      )
+      expect(getMatches).not.toBeNull()
+      expect(getMatches![1]).toBe('test-id') // First capture group
+
+      // Test Checkout Sessions update pattern extraction
+      const updateConfig = findRouteConfig(
+        'PUT /checkout-sessions/:id'
+      )
+      const updateMatches = updateConfig!.pattern.exec(
+        'checkout-sessions/test-id'
+      )
+      expect(updateMatches).not.toBeNull()
+      expect(updateMatches![1]).toBe('test-id') // First capture group
+
+      // Test Checkout Sessions delete pattern extraction
+      const deleteConfig = findRouteConfig(
+        'DELETE /checkout-sessions/:id'
+      )
+      const deleteMatches = deleteConfig!.pattern.exec(
+        'checkout-sessions/test-id'
+      )
+      expect(deleteMatches).not.toBeNull()
+      expect(deleteMatches![1]).toBe('test-id') // First capture group
+
+      // Test Checkout Sessions list pattern (no captures)
+      const listConfig = findRouteConfig('GET /checkout-sessions')
+      const listMatches = listConfig!.pattern.exec(
+        'checkout-sessions'
+      )
+      expect(listMatches).not.toBeNull()
+      expect(listMatches!.length).toBe(1) // Only the full match, no capture groups
+
+      // Test Checkout Sessions create pattern (no captures)
+      const createConfig = findRouteConfig('POST /checkout-sessions')
+      const createMatches = createConfig!.pattern.exec(
+        'checkout-sessions'
+      )
+      expect(createMatches).not.toBeNull()
+      expect(createMatches!.length).toBe(1) // Only the full match, no capture groups
+    })
+  })
+
+  describe('mapParams function behavior', () => {
+    it('should correctly map URL parameters for checkout sessions get requests', () => {
+      const routeConfig = findRouteConfig(
+        'GET /checkout-sessions/:id'
+      )
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['checkout-session-123'])
+
+      expect(result).toEqual({
+        id: 'checkout-session-123',
+      })
+    })
+
+    it('should correctly map URL parameters and body for checkout sessions edit requests', () => {
+      const routeConfig = findRouteConfig(
+        'PUT /checkout-sessions/:id'
+      )
+      const testBody = {
+        checkoutSession: {
+          customerEmail: 'updated@example.com',
+          automaticallyUpdateSubscriptions: true,
+        },
+      }
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(
+        ['checkout-session-456'],
+        testBody
+      )
+
+      expect(result).toEqual({
+        checkoutSession: {
+          customerEmail: 'updated@example.com',
+          automaticallyUpdateSubscriptions: true,
+        },
+        id: 'checkout-session-456',
+      })
+    })
+
+    it('should correctly map URL parameters for checkout sessions delete requests', () => {
+      const routeConfig = findRouteConfig(
+        'DELETE /checkout-sessions/:id'
+      )
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['checkout-session-789'])
+
+      expect(result).toEqual({
+        id: 'checkout-session-789',
+      })
+    })
+
+    it('should return body for checkout sessions create requests', () => {
+      const routeConfig = findRouteConfig('POST /checkout-sessions')
+      const testBody = {
+        checkoutSession: {
+          type: 'product',
+          customerEmail: 'new@example.com',
+          automaticallyUpdateSubscriptions: false,
+        },
+      }
+
+      const result = routeConfig!.mapParams([], testBody)
+
+      expect(result).toEqual(testBody)
+    })
+
+    it('should return undefined for checkout sessions list requests', () => {
+      const routeConfig = findRouteConfig('GET /checkout-sessions')
+
+      const result = routeConfig!.mapParams([])
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should handle special characters and encoded values in id', () => {
+      const routeConfig = findRouteConfig(
+        'GET /checkout-sessions/:id'
+      )
+
+      // Test with URL-encoded characters (simulate route handler slicing)
+      const result1 = routeConfig!.mapParams([
+        'session%40company.com',
+      ])
+      expect(result1).toEqual({
+        id: 'session%40company.com',
+      })
+
+      // Test with hyphens and underscores (simulate route handler slicing)
+      const result2 = routeConfig!.mapParams([
+        'checkout-session_123-abc',
+      ])
+      expect(result2).toEqual({ id: 'checkout-session_123-abc' })
+    })
+  })
+
+  describe('Route config completeness', () => {
+    it('should have all expected CRUD route configs', () => {
+      const routeKeys = getAllRouteKeys()
+
+      // Check that all expected routes exist
+      expect(routeKeys).toContain('POST /checkout-sessions') // create
+      expect(routeKeys).toContain('PUT /checkout-sessions/:id') // update
+      expect(routeKeys).toContain('GET /checkout-sessions/:id') // get
+      expect(routeKeys).toContain('GET /checkout-sessions') // list
+      expect(routeKeys).toContain('DELETE /checkout-sessions/:id') // delete
+
+      // Check that we have exactly the expected number of routes
+      expect(routeKeys).toHaveLength(5) // Standard CRUD operations
+    })
+
+    it('should have consistent id parameter usage', () => {
+      const idRoutes = [
+        'PUT /checkout-sessions/:id',
+        'GET /checkout-sessions/:id',
+        'DELETE /checkout-sessions/:id',
+      ]
+
+      idRoutes.forEach((routeKey) => {
+        const config = findRouteConfig(routeKey)
+
+        // Test that mapParams consistently uses 'id' (simulate route handler slicing)
+        const result = config!.mapParams(['test-id'], {
+          someData: 'value',
+        })
+        expect(result).toHaveProperty('id', 'test-id')
+      })
+    })
+
+    it('should have valid route config structure for all routes', () => {
+      // Test all route configs from the array
+      checkoutSessionsRouteConfigs.forEach((routeConfigObj) => {
+        Object.entries(routeConfigObj).forEach(
+          ([routeKey, config]) => {
+            // Each config should have required properties
+            expect(config).toHaveProperty('procedure')
+            expect(config).toHaveProperty('pattern')
+            expect(config).toHaveProperty('mapParams')
+
+            // Procedure should be a valid TRPC procedure path
+            expect(config.procedure).toMatch(
+              /^checkoutSessions\.\w+$/
+            )
+
+            // Pattern should be a RegExp
+            expect(config.pattern).toBeInstanceOf(RegExp)
+
+            // mapParams should be a function
+            expect(typeof config.mapParams).toBe('function')
+          }
+        )
+      })
+    })
+
+    it('should map to correct TRPC procedures', () => {
+      const expectedMappings = {
+        'POST /checkout-sessions': 'checkoutSessions.create',
+        'PUT /checkout-sessions/:id': 'checkoutSessions.update',
+        'GET /checkout-sessions/:id': 'checkoutSessions.get',
+        'GET /checkout-sessions': 'checkoutSessions.list',
+        'DELETE /checkout-sessions/:id': 'checkoutSessions.delete',
+      }
+
+      Object.entries(expectedMappings).forEach(
+        ([routeKey, expectedProcedure]) => {
+          const config = findRouteConfig(routeKey)
+          expect(config!.procedure).toBe(expectedProcedure)
+        }
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add comprehensive unit test coverage for `apiKeysRouter` and `checkoutSessionsRouter` route configurations
- Implement tests following established pattern from `customersRouter.routeConfigs.test.ts`
- Validate REST-to-TRPC mapping integrity and prevent regression

## Test Coverage
### apiKeysRouter.routeConfigs.test.ts
- ✅ 17 test cases covering standard CRUD operations (create, read, update, delete, list)
- ✅ Route pattern matching and procedure mapping validation
- ✅ RegExp pattern validation with path matching and parameter extraction
- ✅ mapParams function behavior testing with URL parameters and request bodies
- ✅ Route configuration completeness and consistency verification

### checkoutSessionsRouter.routeConfigs.test.ts  
- ✅ 17 test cases covering standard CRUD operations for checkout sessions
- ✅ Comprehensive validation of `/checkout-sessions` and `/checkout-sessions/:id` patterns
- ✅ Parameter mapping with proper `id` extraction and body handling
- ✅ Edge case testing with special characters and encoded values

## Test Structure
Both test files validate:
- **Route pattern matching**: Verify REST paths map to correct TRPC procedures
- **RegExp pattern validation**: Ensure patterns match intended paths and reject invalid ones  
- **mapParams function behavior**: Validate parameter extraction and payload mapping
- **Route configuration completeness**: Check all expected routes exist with proper structure

## Implementation Details
- Follows the comprehensive test plan outlined in `routeConfigs.test-plan.md`
- Part of effort to add unit test coverage for all 19 router configurations
- Uses helper functions for route discovery and validation consistency
- No database dependencies - focuses purely on route configuration logic

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add unit tests for apiKeysRouter and checkoutSessionsRouter route configs to verify the REST-to-TRPC contract and prevent regressions. Coverage includes CRUD routes, regex path matching and id extraction, mapParams behavior for params and bodies, and edge cases like encoded IDs.

<!-- End of auto-generated description by cubic. -->

