### PR TITLE
test: add route config tests for discounts and features routers

### DIFF
--- a/platform/flowglad-next/src/server/routers/discountsRouter.routeConfigs.test.ts
+++ b/platform/flowglad-next/src/server/routers/discountsRouter.routeConfigs.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest'
+import { discountsRouteConfigs } from './discountsRouter'
+
+describe('discountsRouteConfigs', () => {
+  describe('Route pattern matching and procedure mapping', () => {
+    it('should map POST /discounts to discounts.create procedure', () => {
+      const routeConfig = discountsRouteConfigs['POST /discounts']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig.procedure).toBe('discounts.create')
+      expect(routeConfig.pattern.test('discounts')).toBe(true)
+
+      // Test mapParams with body
+      const testBody = { discount: { code: 'SAVE10', amount: 10 } }
+      const result = routeConfig.mapParams([], testBody)
+      expect(result).toEqual(testBody)
+    })
+
+    it('should map PUT /discounts/:id to discounts.update procedure', () => {
+      const routeConfig = discountsRouteConfigs['PUT /discounts/:id']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig.procedure).toBe('discounts.update')
+      expect(routeConfig.pattern.test('discounts/test-id')).toBe(true)
+
+      // Test mapParams with matches and body
+      const testBody = { discount: { amount: 20 } }
+      const result = routeConfig.mapParams(['test-id'], testBody)
+      expect(result).toEqual({
+        ...testBody,
+        id: 'test-id',
+      })
+    })
+
+    it('should map GET /discounts/:id to discounts.get procedure', () => {
+      const routeConfig = discountsRouteConfigs['GET /discounts/:id']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig.procedure).toBe('discounts.get')
+      expect(routeConfig.pattern.test('discounts/test-id')).toBe(true)
+
+      // Test mapParams with matches only
+      const result = routeConfig.mapParams(['test-id'])
+      expect(result).toEqual({ id: 'test-id' })
+    })
+
+    it('should map GET /discounts to discounts.list procedure', () => {
+      const routeConfig = discountsRouteConfigs['GET /discounts']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig.procedure).toBe('discounts.list')
+      expect(routeConfig.pattern.test('discounts')).toBe(true)
+
+      // Test mapParams returns undefined for list endpoints
+      const result = routeConfig.mapParams([])
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('Route pattern RegExp validation', () => {
+    it('should have valid RegExp patterns that match expected paths', () => {
+      // Discount creation pattern should match 'discounts'
+      const createConfig = discountsRouteConfigs['POST /discounts']
+      expect(createConfig.pattern.test('discounts')).toBe(true)
+      expect(createConfig.pattern.test('discounts/id')).toBe(false)
+
+      // Discount get pattern should match 'discounts/abc123'
+      const getConfig = discountsRouteConfigs['GET /discounts/:id']
+      expect(getConfig.pattern.test('discounts/abc123')).toBe(true)
+      expect(getConfig.pattern.test('discounts')).toBe(false)
+      expect(getConfig.pattern.test('discounts/abc123/extra')).toBe(
+        false
+      )
+
+      // Discount update pattern should match 'discounts/abc123'
+      const updateConfig = discountsRouteConfigs['PUT /discounts/:id']
+      expect(updateConfig.pattern.test('discounts/abc123')).toBe(true)
+      expect(updateConfig.pattern.test('discounts')).toBe(false)
+
+      // Discount list pattern should match 'discounts' only
+      const listConfig = discountsRouteConfigs['GET /discounts']
+      expect(listConfig.pattern.test('discounts')).toBe(true)
+      expect(listConfig.pattern.test('discounts/id')).toBe(false)
+    })
+
+    it('should extract correct matches from URL paths', () => {
+      // Test discount get pattern extraction
+      const getConfig = discountsRouteConfigs['GET /discounts/:id']
+      const getMatches = getConfig.pattern.exec('discounts/test-id')
+      expect(getMatches).not.toBeNull()
+      expect(getMatches![1]).toBe('test-id') // First capture group
+
+      // Test discount update pattern extraction
+      const updateConfig = discountsRouteConfigs['PUT /discounts/:id']
+      const updateMatches = updateConfig.pattern.exec(
+        'discounts/discount-456'
+      )
+      expect(updateMatches).not.toBeNull()
+      expect(updateMatches![1]).toBe('discount-456') // First capture group
+
+      // Test discount list pattern (no captures)
+      const listConfig = discountsRouteConfigs['GET /discounts']
+      const listMatches = listConfig.pattern.exec('discounts')
+      expect(listMatches).not.toBeNull()
+      expect(listMatches!.length).toBe(1) // Only the full match, no capture groups
+
+      // Test discount create pattern (no captures)
+      const createConfig = discountsRouteConfigs['POST /discounts']
+      const createMatches = createConfig.pattern.exec('discounts')
+      expect(createMatches).not.toBeNull()
+      expect(createMatches!.length).toBe(1) // Only the full match, no capture groups
+    })
+  })
+
+  describe('mapParams function behavior', () => {
+    it('should correctly map URL parameters for discount get requests', () => {
+      const routeConfig = discountsRouteConfigs['GET /discounts/:id']
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig.mapParams(['discount-123'])
+
+      expect(result).toEqual({
+        id: 'discount-123',
+      })
+    })
+
+    it('should correctly map URL parameters and body for discount update requests', () => {
+      const routeConfig = discountsRouteConfigs['PUT /discounts/:id']
+      const testBody = {
+        discount: {
+          amount: 25,
+          code: 'UPDATED25',
+        },
+      }
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig.mapParams(['discount-456'], testBody)
+
+      expect(result).toEqual({
+        discount: {
+          amount: 25,
+          code: 'UPDATED25',
+        },
+        id: 'discount-456',
+      })
+    })
+
+    it('should return body for discount create requests', () => {
+      const routeConfig = discountsRouteConfigs['POST /discounts']
+      const testBody = {
+        discount: {
+          code: 'NEWCODE',
+          amount: 15,
+          type: 'percentage',
+        },
+      }
+
+      const result = routeConfig.mapParams([], testBody)
+
+      expect(result).toEqual(testBody)
+    })
+
+    it('should return undefined for discount list requests', () => {
+      const routeConfig = discountsRouteConfigs['GET /discounts']
+
+      const result = routeConfig.mapParams([])
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should handle special characters and encoded values in id', () => {
+      const routeConfig = discountsRouteConfigs['GET /discounts/:id']
+
+      // Test with URL-encoded characters
+      const result1 = routeConfig.mapParams(['discount%2D2024'])
+      expect(result1).toEqual({
+        id: 'discount%2D2024',
+      })
+
+      // Test with hyphens and underscores
+      const result2 = routeConfig.mapParams(['discount_123-abc'])
+      expect(result2).toEqual({ id: 'discount_123-abc' })
+
+      // Test with alphanumeric combinations
+      const result3 = routeConfig.mapParams(['DISCOUNT123'])
+      expect(result3).toEqual({ id: 'DISCOUNT123' })
+    })
+  })
+
+  describe('Route config completeness', () => {
+    it('should have exactly 4 expected route configs', () => {
+      const routeKeys = Object.keys(discountsRouteConfigs)
+
+      // Check that all expected routes exist
+      expect(routeKeys).toContain('POST /discounts') // create
+      expect(routeKeys).toContain('PUT /discounts/:id') // update
+      expect(routeKeys).toContain('GET /discounts/:id') // get
+      expect(routeKeys).toContain('GET /discounts') // list
+
+      // Check that we have exactly the expected number of routes
+      expect(routeKeys).toHaveLength(4) // Only 4 routes (no delete, attempt, or clear)
+
+      // Verify that commented out routes are NOT present
+      expect(routeKeys).not.toContain('DELETE /discounts/:id')
+      expect(routeKeys).not.toContain('POST /discounts/:id/attempt')
+      expect(routeKeys).not.toContain('POST /discounts/:id/clear')
+    })
+
+    it('should have consistent id parameter usage', () => {
+      const idRoutes = ['PUT /discounts/:id', 'GET /discounts/:id']
+
+      idRoutes.forEach((routeKey) => {
+        const config = discountsRouteConfigs[routeKey]
+
+        // Test that mapParams consistently uses 'id'
+        const result = config.mapParams(['test-id'], {
+          someData: 'value',
+        })
+        expect(result).toHaveProperty('id', 'test-id')
+      })
+    })
+
+    it('should have valid route config structure for all routes', () => {
+      Object.entries(discountsRouteConfigs).forEach(
+        ([routeKey, config]) => {
+          // Each config should have required properties
+          expect(config).toHaveProperty('procedure')
+          expect(config).toHaveProperty('pattern')
+          expect(config).toHaveProperty('mapParams')
+
+          // Procedure should be a valid TRPC procedure path
+          expect(config.procedure).toMatch(/^discounts\.\w+$/)
+
+          // Pattern should be a RegExp
+          expect(config.pattern).toBeInstanceOf(RegExp)
+
+          // mapParams should be a function
+          expect(typeof config.mapParams).toBe('function')
+        }
+      )
+    })
+
+    it('should map to correct TRPC procedures', () => {
+      const expectedMappings = {
+        'POST /discounts': 'discounts.create',
+        'PUT /discounts/:id': 'discounts.update',
+        'GET /discounts/:id': 'discounts.get',
+        'GET /discounts': 'discounts.list',
+      }
+
+      Object.entries(expectedMappings).forEach(
+        ([routeKey, expectedProcedure]) => {
+          const config = discountsRouteConfigs[routeKey]
+          expect(config.procedure).toBe(expectedProcedure)
+        }
+      )
+    })
+
+    it('should confirm intentionally omitted routes are missing', () => {
+      // These routes are commented out in the source code
+      // Verify they are intentionally not included
+      const omittedRoutes = [
+        'DELETE /discounts/:id', // delete
+        'POST /discounts/:id/attempt', // attempt
+        'POST /discounts/:id/clear', // clear
+      ]
+
+      omittedRoutes.forEach((routeKey) => {
+        expect(discountsRouteConfigs[routeKey]).toBeUndefined()
+      })
+    })
+  })
+})

--- a/platform/flowglad-next/src/server/routers/featuresRouter.routeConfigs.test.ts
+++ b/platform/flowglad-next/src/server/routers/featuresRouter.routeConfigs.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect } from 'vitest'
+import { featuresRouteConfigs } from './featuresRouter'
+
+describe('featuresRouteConfigs', () => {
+  // Helper function to find route config in the array
+  const findRouteConfig = (routeKey: string) => {
+    for (const routeConfigObj of featuresRouteConfigs) {
+      if (routeConfigObj[routeKey]) {
+        return routeConfigObj[routeKey]
+      }
+    }
+    return undefined
+  }
+
+  // Helper function to get all route keys from the array
+  const getAllRouteKeys = () => {
+    const keys: string[] = []
+    for (const routeConfigObj of featuresRouteConfigs) {
+      keys.push(...Object.keys(routeConfigObj))
+    }
+    return keys
+  }
+
+  describe('Route pattern matching and procedure mapping', () => {
+    it('should map POST /features to features.create procedure', () => {
+      const routeConfig = findRouteConfig('POST /features')
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('features.create')
+      expect(routeConfig!.pattern.test('features')).toBe(true)
+
+      // Test mapParams with body
+      const testBody = {
+        feature: { name: 'Test Feature', value: 'test' },
+      }
+      const result = routeConfig!.mapParams([], testBody)
+      expect(result).toEqual(testBody)
+    })
+
+    it('should map PUT /features/:id to features.update procedure', () => {
+      const routeConfig = findRouteConfig('PUT /features/:id')
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('features.update')
+      expect(routeConfig!.pattern.test('features/test-id')).toBe(true)
+
+      // Test mapParams with matches and body
+      const testBody = { feature: { name: 'Updated Feature' } }
+      const result = routeConfig!.mapParams(['test-id'], testBody)
+      expect(result).toEqual({
+        ...testBody,
+        id: 'test-id',
+      })
+    })
+
+    it('should map GET /features/:id to features.get procedure', () => {
+      const routeConfig = findRouteConfig('GET /features/:id')
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('features.get')
+      expect(routeConfig!.pattern.test('features/test-id')).toBe(true)
+
+      // Test mapParams with matches only
+      const result = routeConfig!.mapParams(['test-id'])
+      expect(result).toEqual({ id: 'test-id' })
+    })
+
+    it('should map DELETE /features/:id to features.delete procedure', () => {
+      const routeConfig = findRouteConfig('DELETE /features/:id')
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('features.delete')
+      expect(routeConfig!.pattern.test('features/test-id')).toBe(true)
+
+      // Test mapParams with matches only
+      const result = routeConfig!.mapParams(['test-id'])
+      expect(result).toEqual({ id: 'test-id' })
+    })
+
+    it('should map GET /features to features.list procedure', () => {
+      const routeConfig = findRouteConfig('GET /features')
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('features.list')
+      expect(routeConfig!.pattern.test('features')).toBe(true)
+
+      // Test mapParams returns undefined for list endpoints
+      const result = routeConfig!.mapParams([])
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('Route pattern RegExp validation', () => {
+    it('should have valid RegExp patterns that match expected paths', () => {
+      // Feature creation pattern should match 'features'
+      const createConfig = findRouteConfig('POST /features')
+      expect(createConfig!.pattern.test('features')).toBe(true)
+      expect(createConfig!.pattern.test('features/id')).toBe(false)
+
+      // Feature get pattern should match 'features/abc123'
+      const getConfig = findRouteConfig('GET /features/:id')
+      expect(getConfig!.pattern.test('features/abc123')).toBe(true)
+      expect(getConfig!.pattern.test('features')).toBe(false)
+      expect(getConfig!.pattern.test('features/abc123/extra')).toBe(
+        false
+      )
+
+      // Feature update pattern should match 'features/abc123'
+      const updateConfig = findRouteConfig('PUT /features/:id')
+      expect(updateConfig!.pattern.test('features/abc123')).toBe(true)
+      expect(updateConfig!.pattern.test('features')).toBe(false)
+
+      // Feature delete pattern should match 'features/abc123'
+      const deleteConfig = findRouteConfig('DELETE /features/:id')
+      expect(deleteConfig!.pattern.test('features/abc123')).toBe(true)
+      expect(deleteConfig!.pattern.test('features')).toBe(false)
+
+      // Feature list pattern should match 'features' only
+      const listConfig = findRouteConfig('GET /features')
+      expect(listConfig!.pattern.test('features')).toBe(true)
+      expect(listConfig!.pattern.test('features/id')).toBe(false)
+    })
+
+    it('should extract correct matches from URL paths', () => {
+      // Test feature get pattern extraction
+      const getConfig = findRouteConfig('GET /features/:id')
+      const getMatches = getConfig!.pattern.exec('features/test-id')
+      expect(getMatches).not.toBeNull()
+      expect(getMatches![1]).toBe('test-id') // First capture group
+
+      // Test feature update pattern extraction
+      const updateConfig = findRouteConfig('PUT /features/:id')
+      const updateMatches = updateConfig!.pattern.exec(
+        'features/feature-456'
+      )
+      expect(updateMatches).not.toBeNull()
+      expect(updateMatches![1]).toBe('feature-456') // First capture group
+
+      // Test feature delete pattern extraction
+      const deleteConfig = findRouteConfig('DELETE /features/:id')
+      const deleteMatches = deleteConfig!.pattern.exec(
+        'features/feature-789'
+      )
+      expect(deleteMatches).not.toBeNull()
+      expect(deleteMatches![1]).toBe('feature-789') // First capture group
+
+      // Test feature list pattern (no captures)
+      const listConfig = findRouteConfig('GET /features')
+      const listMatches = listConfig!.pattern.exec('features')
+      expect(listMatches).not.toBeNull()
+      expect(listMatches!.length).toBe(1) // Only the full match, no capture groups
+
+      // Test feature create pattern (no captures)
+      const createConfig = findRouteConfig('POST /features')
+      const createMatches = createConfig!.pattern.exec('features')
+      expect(createMatches).not.toBeNull()
+      expect(createMatches!.length).toBe(1) // Only the full match, no capture groups
+    })
+  })
+
+  describe('mapParams function behavior', () => {
+    it('should correctly map URL parameters for feature get requests', () => {
+      const routeConfig = findRouteConfig('GET /features/:id')
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['feature-123'])
+
+      expect(result).toEqual({
+        id: 'feature-123',
+      })
+    })
+
+    it('should correctly map URL parameters and body for feature update requests', () => {
+      const routeConfig = findRouteConfig('PUT /features/:id')
+      const testBody = {
+        feature: {
+          name: 'Updated Feature Name',
+          description: 'Updated description',
+        },
+      }
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['feature-456'], testBody)
+
+      expect(result).toEqual({
+        feature: {
+          name: 'Updated Feature Name',
+          description: 'Updated description',
+        },
+        id: 'feature-456',
+      })
+    })
+
+    it('should correctly map URL parameters for feature delete requests', () => {
+      const routeConfig = findRouteConfig('DELETE /features/:id')
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['feature-789'])
+
+      expect(result).toEqual({
+        id: 'feature-789',
+      })
+    })
+
+    it('should return body for feature create requests', () => {
+      const routeConfig = findRouteConfig('POST /features')
+      const testBody = {
+        feature: {
+          name: 'New Feature',
+          key: 'new-feature',
+          value: 'enabled',
+        },
+      }
+
+      const result = routeConfig!.mapParams([], testBody)
+
+      expect(result).toEqual(testBody)
+    })
+
+    it('should return undefined for feature list requests', () => {
+      const routeConfig = findRouteConfig('GET /features')
+
+      const result = routeConfig!.mapParams([])
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should handle special characters and encoded values in id', () => {
+      const routeConfig = findRouteConfig('GET /features/:id')
+
+      // Test with URL-encoded characters
+      const result1 = routeConfig!.mapParams(['feature%2D2024'])
+      expect(result1).toEqual({
+        id: 'feature%2D2024',
+      })
+
+      // Test with hyphens and underscores
+      const result2 = routeConfig!.mapParams(['feature_123-abc'])
+      expect(result2).toEqual({ id: 'feature_123-abc' })
+
+      // Test with alphanumeric combinations
+      const result3 = routeConfig!.mapParams(['FEATURE123'])
+      expect(result3).toEqual({ id: 'FEATURE123' })
+    })
+  })
+
+  describe('Route config completeness', () => {
+    it('should have all expected standard CRUD route configs', () => {
+      const routeKeys = getAllRouteKeys()
+
+      // Check that all expected routes exist
+      expect(routeKeys).toContain('POST /features') // create
+      expect(routeKeys).toContain('PUT /features/:id') // update
+      expect(routeKeys).toContain('GET /features/:id') // get
+      expect(routeKeys).toContain('GET /features') // list
+      expect(routeKeys).toContain('DELETE /features/:id') // delete
+
+      // Check that we have exactly the expected number of routes
+      expect(routeKeys).toHaveLength(5) // Standard CRUD routes
+    })
+
+    it('should have consistent id parameter usage', () => {
+      const idRoutes = [
+        'PUT /features/:id',
+        'GET /features/:id',
+        'DELETE /features/:id',
+      ]
+
+      idRoutes.forEach((routeKey) => {
+        const config = findRouteConfig(routeKey)
+
+        // Test that mapParams consistently uses 'id'
+        const result = config!.mapParams(['test-id'], {
+          someData: 'value',
+        })
+        expect(result).toHaveProperty('id', 'test-id')
+      })
+    })
+
+    it('should have valid route config structure for all routes', () => {
+      // Test all route configs from the array
+      featuresRouteConfigs.forEach((routeConfigObj) => {
+        Object.entries(routeConfigObj).forEach(
+          ([routeKey, config]) => {
+            // Each config should have required properties
+            expect(config).toHaveProperty('procedure')
+            expect(config).toHaveProperty('pattern')
+            expect(config).toHaveProperty('mapParams')
+
+            // Procedure should be a valid TRPC procedure path
+            expect(config.procedure).toMatch(/^features\.\w+$/)
+
+            // Pattern should be a RegExp
+            expect(config.pattern).toBeInstanceOf(RegExp)
+
+            // mapParams should be a function
+            expect(typeof config.mapParams).toBe('function')
+          }
+        )
+      })
+    })
+
+    it('should map to correct TRPC procedures', () => {
+      const expectedMappings = {
+        'POST /features': 'features.create',
+        'PUT /features/:id': 'features.update',
+        'GET /features/:id': 'features.get',
+        'GET /features': 'features.list',
+        'DELETE /features/:id': 'features.delete',
+      }
+
+      Object.entries(expectedMappings).forEach(
+        ([routeKey, expectedProcedure]) => {
+          const config = findRouteConfig(routeKey)
+          expect(config!.procedure).toBe(expectedProcedure)
+        }
+      )
+    })
+
+    it('should match expected standard CRUD pattern', () => {
+      // Features router uses the standard generateOpenApiMetas function
+      // which should produce exactly 5 standard CRUD routes
+      const routeKeys = getAllRouteKeys()
+
+      // Verify we have the standard set of CRUD operations
+      const expectedRoutes = [
+        'POST /features', // create
+        'PUT /features/:id', // update
+        'GET /features/:id', // get
+        'DELETE /features/:id', // delete
+        'GET /features', // list
+      ]
+
+      expectedRoutes.forEach((route) => {
+        expect(routeKeys).toContain(route)
+      })
+
+      // Verify no additional custom routes exist
+      expect(routeKeys.length).toBe(expectedRoutes.length)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Added comprehensive test coverage for `discountsRouter.routeConfigs` (16 tests)
- Added comprehensive test coverage for `featuresRouter.routeConfigs` (18 tests)
- Implements test suites 3 and 4 from the route configs test plan

## Test plan
- [x] Run tests locally: `pnpm test src/server/routers/*.routeConfigs.test.ts`
- [x] All 34 new tests pass
- [x] Tests follow established patterns from existing `customersRouter.routeConfigs.test.ts`
- [x] Validates REST-to-TRPC endpoint mapping
- [x] Verifies parameter extraction and payload mapping

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add route-config tests for the discounts and features routers to verify REST-to-TRPC mapping, param extraction, and regex patterns. 34 tests cover discounts (create, update, get, list; confirms delete/attempt/clear are omitted) and features (full CRUD via generateOpenApiMetas).

<!-- End of auto-generated description by cubic. -->

