### PR TITLE
test: add route config tests for invoiceLineItems and invoices routers

### DIFF
--- a/platform/flowglad-next/src/server/routers/invoiceLineItemsRouter.routeConfigs.test.ts
+++ b/platform/flowglad-next/src/server/routers/invoiceLineItemsRouter.routeConfigs.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect } from 'vitest'
+import { invoiceLineItemsRouteConfigs } from './invoiceLineItemsRouter'
+
+describe('invoiceLineItemsRouteConfigs', () => {
+  describe('Route pattern matching and procedure mapping', () => {
+    it('should map POST /invoice-line-items to invoiceLineItems.create procedure', () => {
+      const routeConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'POST /invoice-line-items' in config
+      )?.['POST /invoice-line-items']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('invoiceLineItems.create')
+      expect(routeConfig!.pattern.test('invoice-line-items')).toBe(
+        true
+      )
+
+      // Test mapParams with body
+      const testBody = {
+        lineItem: { amount: 1000, description: 'Test Item' },
+      }
+      const result = routeConfig!.mapParams([], testBody)
+      expect(result).toEqual(testBody)
+    })
+
+    it('should map PUT /invoice-line-items/:id to invoiceLineItems.update procedure', () => {
+      const routeConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'PUT /invoice-line-items/:id' in config
+      )?.['PUT /invoice-line-items/:id']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('invoiceLineItems.update')
+      expect(
+        routeConfig!.pattern.test('invoice-line-items/test-id')
+      ).toBe(true)
+
+      // Test mapParams with matches and body
+      const testBody = { lineItem: { amount: 2000 } }
+      const result = routeConfig!.mapParams(['test-id'], testBody)
+      expect(result).toEqual({
+        ...testBody,
+        id: 'test-id',
+      })
+    })
+
+    it('should map GET /invoice-line-items/:id to invoiceLineItems.get procedure', () => {
+      const routeConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'GET /invoice-line-items/:id' in config
+      )?.['GET /invoice-line-items/:id']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('invoiceLineItems.get')
+      expect(
+        routeConfig!.pattern.test('invoice-line-items/test-id')
+      ).toBe(true)
+
+      // Test mapParams with matches only
+      const result = routeConfig!.mapParams(['test-id'])
+      expect(result).toEqual({ id: 'test-id' })
+    })
+
+    it('should map GET /invoice-line-items to invoiceLineItems.list procedure', () => {
+      const routeConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'GET /invoice-line-items' in config
+      )?.['GET /invoice-line-items']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('invoiceLineItems.list')
+      expect(routeConfig!.pattern.test('invoice-line-items')).toBe(
+        true
+      )
+
+      // Test mapParams returns undefined for list endpoints
+      const result = routeConfig!.mapParams([])
+      expect(result).toBeUndefined()
+    })
+
+    it('should map DELETE /invoice-line-items/:id to invoiceLineItems.delete procedure', () => {
+      const routeConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'DELETE /invoice-line-items/:id' in config
+      )?.['DELETE /invoice-line-items/:id']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('invoiceLineItems.delete')
+      expect(
+        routeConfig!.pattern.test('invoice-line-items/test-id')
+      ).toBe(true)
+
+      // Test mapParams with matches only
+      const result = routeConfig!.mapParams(['test-id'])
+      expect(result).toEqual({ id: 'test-id' })
+    })
+  })
+
+  describe('Route pattern RegExp validation', () => {
+    it('should have valid RegExp patterns that match expected paths', () => {
+      // Invoice line item creation pattern should match 'invoice-line-items'
+      const createConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'POST /invoice-line-items' in config
+      )?.['POST /invoice-line-items']
+      expect(createConfig!.pattern.test('invoice-line-items')).toBe(
+        true
+      )
+      expect(
+        createConfig!.pattern.test('invoice-line-items/id')
+      ).toBe(false)
+
+      // Invoice line item get pattern should match 'invoice-line-items/abc123'
+      const getConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'GET /invoice-line-items/:id' in config
+      )?.['GET /invoice-line-items/:id']
+      expect(
+        getConfig!.pattern.test('invoice-line-items/abc123')
+      ).toBe(true)
+      expect(getConfig!.pattern.test('invoice-line-items')).toBe(
+        false
+      )
+      expect(
+        getConfig!.pattern.test('invoice-line-items/abc123/extra')
+      ).toBe(false)
+
+      // Invoice line item update pattern should match 'invoice-line-items/abc123'
+      const updateConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'PUT /invoice-line-items/:id' in config
+      )?.['PUT /invoice-line-items/:id']
+      expect(
+        updateConfig!.pattern.test('invoice-line-items/abc123')
+      ).toBe(true)
+      expect(updateConfig!.pattern.test('invoice-line-items')).toBe(
+        false
+      )
+
+      // Invoice line item delete pattern should match 'invoice-line-items/abc123'
+      const deleteConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'DELETE /invoice-line-items/:id' in config
+      )?.['DELETE /invoice-line-items/:id']
+      expect(
+        deleteConfig!.pattern.test('invoice-line-items/abc123')
+      ).toBe(true)
+      expect(deleteConfig!.pattern.test('invoice-line-items')).toBe(
+        false
+      )
+
+      // Invoice line item list pattern should match 'invoice-line-items' only
+      const listConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'GET /invoice-line-items' in config
+      )?.['GET /invoice-line-items']
+      expect(listConfig!.pattern.test('invoice-line-items')).toBe(
+        true
+      )
+      expect(listConfig!.pattern.test('invoice-line-items/id')).toBe(
+        false
+      )
+    })
+
+    it('should extract correct matches from URL paths', () => {
+      // Test invoice line item get pattern extraction
+      const getConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'GET /invoice-line-items/:id' in config
+      )?.['GET /invoice-line-items/:id']
+      const getMatches = getConfig!.pattern.exec(
+        'invoice-line-items/test-id'
+      )
+      expect(getMatches).not.toBeNull()
+      expect(getMatches![1]).toBe('test-id') // First capture group
+
+      // Test invoice line item update pattern extraction
+      const updateConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'PUT /invoice-line-items/:id' in config
+      )?.['PUT /invoice-line-items/:id']
+      const updateMatches = updateConfig!.pattern.exec(
+        'invoice-line-items/test-id'
+      )
+      expect(updateMatches).not.toBeNull()
+      expect(updateMatches![1]).toBe('test-id') // First capture group
+
+      // Test invoice line item delete pattern extraction
+      const deleteConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'DELETE /invoice-line-items/:id' in config
+      )?.['DELETE /invoice-line-items/:id']
+      const deleteMatches = deleteConfig!.pattern.exec(
+        'invoice-line-items/test-id'
+      )
+      expect(deleteMatches).not.toBeNull()
+      expect(deleteMatches![1]).toBe('test-id') // First capture group
+
+      // Test invoice line item list pattern (no captures)
+      const listConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'GET /invoice-line-items' in config
+      )?.['GET /invoice-line-items']
+      const listMatches = listConfig!.pattern.exec(
+        'invoice-line-items'
+      )
+      expect(listMatches).not.toBeNull()
+      expect(listMatches!.length).toBe(1) // Only the full match, no capture groups
+
+      // Test invoice line item create pattern (no captures)
+      const createConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'POST /invoice-line-items' in config
+      )?.['POST /invoice-line-items']
+      const createMatches = createConfig!.pattern.exec(
+        'invoice-line-items'
+      )
+      expect(createMatches).not.toBeNull()
+      expect(createMatches!.length).toBe(1) // Only the full match, no capture groups
+    })
+  })
+
+  describe('mapParams function behavior', () => {
+    it('should correctly map URL parameters for invoice line item get requests', () => {
+      const routeConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'GET /invoice-line-items/:id' in config
+      )?.['GET /invoice-line-items/:id']
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['ili_123'])
+
+      expect(result).toEqual({
+        id: 'ili_123',
+      })
+    })
+
+    it('should correctly map URL parameters and body for invoice line item update requests', () => {
+      const routeConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'PUT /invoice-line-items/:id' in config
+      )?.['PUT /invoice-line-items/:id']
+      const testBody = {
+        amount: 3000,
+        description: 'Updated Line Item',
+        quantity: 2,
+      }
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['ili_456'], testBody)
+
+      expect(result).toEqual({
+        amount: 3000,
+        description: 'Updated Line Item',
+        quantity: 2,
+        id: 'ili_456',
+      })
+    })
+
+    it('should correctly map URL parameters for invoice line item delete requests', () => {
+      const routeConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'DELETE /invoice-line-items/:id' in config
+      )?.['DELETE /invoice-line-items/:id']
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['ili_789'])
+
+      expect(result).toEqual({
+        id: 'ili_789',
+      })
+    })
+
+    it('should return body for invoice line item create requests', () => {
+      const routeConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'POST /invoice-line-items' in config
+      )?.['POST /invoice-line-items']
+      const testBody = {
+        invoiceId: 'inv_123',
+        amount: 5000,
+        description: 'New Line Item',
+        quantity: 1,
+      }
+
+      const result = routeConfig!.mapParams([], testBody)
+
+      expect(result).toEqual(testBody)
+    })
+
+    it('should return undefined for invoice line item list requests', () => {
+      const routeConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'GET /invoice-line-items' in config
+      )?.['GET /invoice-line-items']
+
+      const result = routeConfig!.mapParams([])
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should handle special characters and encoded values in id', () => {
+      const routeConfig = invoiceLineItemsRouteConfigs.find(
+        (config) => 'GET /invoice-line-items/:id' in config
+      )?.['GET /invoice-line-items/:id']
+
+      // Test with URL-encoded characters (simulate route handler slicing)
+      const result1 = routeConfig!.mapParams(['ili%40123'])
+      expect(result1).toEqual({
+        id: 'ili%40123',
+      })
+
+      // Test with hyphens and underscores (simulate route handler slicing)
+      const result2 = routeConfig!.mapParams(['ili_123-abc'])
+      expect(result2).toEqual({ id: 'ili_123-abc' })
+    })
+  })
+
+  describe('Route config completeness', () => {
+    it('should have all expected CRUD route configs', () => {
+      const routeKeys: string[] = []
+      invoiceLineItemsRouteConfigs.forEach((config) => {
+        routeKeys.push(...Object.keys(config))
+      })
+
+      // Check that all expected routes exist
+      expect(routeKeys).toContain('POST /invoice-line-items') // create
+      expect(routeKeys).toContain('PUT /invoice-line-items/:id') // update
+      expect(routeKeys).toContain('GET /invoice-line-items/:id') // get
+      expect(routeKeys).toContain('GET /invoice-line-items') // list
+      expect(routeKeys).toContain('DELETE /invoice-line-items/:id') // delete
+
+      // Check that we have exactly the expected number of routes
+      expect(routeKeys).toHaveLength(5) // Standard CRUD operations
+    })
+
+    it('should have consistent id parameter usage', () => {
+      const idRoutes = [
+        'PUT /invoice-line-items/:id',
+        'GET /invoice-line-items/:id',
+        'DELETE /invoice-line-items/:id',
+      ]
+
+      idRoutes.forEach((routeKey) => {
+        const config = invoiceLineItemsRouteConfigs.find(
+          (c) => routeKey in c
+        )?.[routeKey]
+
+        // Test that mapParams consistently uses 'id' (simulate route handler slicing)
+        const result = config!.mapParams(['test-id'], {
+          someData: 'value',
+        })
+        expect(result).toHaveProperty('id', 'test-id')
+      })
+    })
+
+    it('should have valid route config structure for all routes', () => {
+      // Test all route configs from the array
+      invoiceLineItemsRouteConfigs.forEach((routeConfigObj) => {
+        Object.entries(routeConfigObj).forEach(
+          ([routeKey, config]) => {
+            // Each config should have required properties
+            expect(config).toHaveProperty('procedure')
+            expect(config).toHaveProperty('pattern')
+            expect(config).toHaveProperty('mapParams')
+
+            // Procedure should be a valid TRPC procedure path
+            expect(config.procedure).toMatch(
+              /^invoiceLineItems\.\w+$/
+            )
+
+            // Pattern should be a RegExp
+            expect(config.pattern).toBeInstanceOf(RegExp)
+
+            // mapParams should be a function
+            expect(typeof config.mapParams).toBe('function')
+          }
+        )
+      })
+    })
+
+    it('should map to correct TRPC procedures', () => {
+      const expectedMappings = {
+        'POST /invoice-line-items': 'invoiceLineItems.create',
+        'PUT /invoice-line-items/:id': 'invoiceLineItems.update',
+        'GET /invoice-line-items/:id': 'invoiceLineItems.get',
+        'GET /invoice-line-items': 'invoiceLineItems.list',
+        'DELETE /invoice-line-items/:id': 'invoiceLineItems.delete',
+      }
+
+      Object.entries(expectedMappings).forEach(
+        ([routeKey, expectedProcedure]) => {
+          const config = invoiceLineItemsRouteConfigs.find(
+            (c) => routeKey in c
+          )?.[routeKey]
+          expect(config!.procedure).toBe(expectedProcedure)
+        }
+      )
+    })
+  })
+})

--- a/platform/flowglad-next/src/server/routers/invoicesRouter.routeConfigs.test.ts
+++ b/platform/flowglad-next/src/server/routers/invoicesRouter.routeConfigs.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect } from 'vitest'
+import { invoicesRouteConfigs } from './invoicesRouter'
+
+describe('invoicesRouteConfigs', () => {
+  describe('Route pattern matching and procedure mapping', () => {
+    it('should map POST /invoices to invoices.create procedure', () => {
+      const routeConfig = invoicesRouteConfigs.find(
+        (config) => 'POST /invoices' in config
+      )?.['POST /invoices']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('invoices.create')
+      expect(routeConfig!.pattern.test('invoices')).toBe(true)
+
+      // Test mapParams with body
+      const testBody = {
+        invoice: { amount: 10000, dueDate: '2024-12-31' },
+      }
+      const result = routeConfig!.mapParams([], testBody)
+      expect(result).toEqual(testBody)
+    })
+
+    it('should map PUT /invoices/:id to invoices.update procedure', () => {
+      const routeConfig = invoicesRouteConfigs.find(
+        (config) => 'PUT /invoices/:id' in config
+      )?.['PUT /invoices/:id']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('invoices.update')
+      expect(routeConfig!.pattern.test('invoices/test-id')).toBe(true)
+
+      // Test mapParams with matches and body
+      const testBody = { invoice: { amount: 20000 } }
+      const result = routeConfig!.mapParams(['test-id'], testBody)
+      expect(result).toEqual({
+        ...testBody,
+        id: 'test-id',
+      })
+    })
+
+    it('should map GET /invoices/:id to invoices.get procedure', () => {
+      const routeConfig = invoicesRouteConfigs.find(
+        (config) => 'GET /invoices/:id' in config
+      )?.['GET /invoices/:id']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('invoices.get')
+      expect(routeConfig!.pattern.test('invoices/test-id')).toBe(true)
+
+      // Test mapParams with matches only
+      const result = routeConfig!.mapParams(['test-id'])
+      expect(result).toEqual({ id: 'test-id' })
+    })
+
+    it('should map GET /invoices to invoices.list procedure', () => {
+      const routeConfig = invoicesRouteConfigs.find(
+        (config) => 'GET /invoices' in config
+      )?.['GET /invoices']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('invoices.list')
+      expect(routeConfig!.pattern.test('invoices')).toBe(true)
+
+      // Test mapParams returns undefined for list endpoints
+      const result = routeConfig!.mapParams([])
+      expect(result).toBeUndefined()
+    })
+
+    it('should map DELETE /invoices/:id to invoices.delete procedure', () => {
+      const routeConfig = invoicesRouteConfigs.find(
+        (config) => 'DELETE /invoices/:id' in config
+      )?.['DELETE /invoices/:id']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig!.procedure).toBe('invoices.delete')
+      expect(routeConfig!.pattern.test('invoices/test-id')).toBe(true)
+
+      // Test mapParams with matches only
+      const result = routeConfig!.mapParams(['test-id'])
+      expect(result).toEqual({ id: 'test-id' })
+    })
+  })
+
+  describe('Route pattern RegExp validation', () => {
+    it('should have valid RegExp patterns that match expected paths', () => {
+      // Invoice creation pattern should match 'invoices'
+      const createConfig = invoicesRouteConfigs.find(
+        (config) => 'POST /invoices' in config
+      )?.['POST /invoices']
+      expect(createConfig!.pattern.test('invoices')).toBe(true)
+      expect(createConfig!.pattern.test('invoices/id')).toBe(false)
+
+      // Invoice get pattern should match 'invoices/abc123'
+      const getConfig = invoicesRouteConfigs.find(
+        (config) => 'GET /invoices/:id' in config
+      )?.['GET /invoices/:id']
+      expect(getConfig!.pattern.test('invoices/abc123')).toBe(true)
+      expect(getConfig!.pattern.test('invoices')).toBe(false)
+      expect(getConfig!.pattern.test('invoices/abc123/extra')).toBe(
+        false
+      )
+
+      // Invoice update pattern should match 'invoices/abc123'
+      const updateConfig = invoicesRouteConfigs.find(
+        (config) => 'PUT /invoices/:id' in config
+      )?.['PUT /invoices/:id']
+      expect(updateConfig!.pattern.test('invoices/abc123')).toBe(true)
+      expect(updateConfig!.pattern.test('invoices')).toBe(false)
+
+      // Invoice delete pattern should match 'invoices/abc123'
+      const deleteConfig = invoicesRouteConfigs.find(
+        (config) => 'DELETE /invoices/:id' in config
+      )?.['DELETE /invoices/:id']
+      expect(deleteConfig!.pattern.test('invoices/abc123')).toBe(true)
+      expect(deleteConfig!.pattern.test('invoices')).toBe(false)
+
+      // Invoice list pattern should match 'invoices' only
+      const listConfig = invoicesRouteConfigs.find(
+        (config) => 'GET /invoices' in config
+      )?.['GET /invoices']
+      expect(listConfig!.pattern.test('invoices')).toBe(true)
+      expect(listConfig!.pattern.test('invoices/id')).toBe(false)
+    })
+
+    it('should extract correct matches from URL paths', () => {
+      // Test invoice get pattern extraction
+      const getConfig = invoicesRouteConfigs.find(
+        (config) => 'GET /invoices/:id' in config
+      )?.['GET /invoices/:id']
+      const getMatches = getConfig!.pattern.exec('invoices/test-id')
+      expect(getMatches).not.toBeNull()
+      expect(getMatches![1]).toBe('test-id') // First capture group
+
+      // Test invoice update pattern extraction
+      const updateConfig = invoicesRouteConfigs.find(
+        (config) => 'PUT /invoices/:id' in config
+      )?.['PUT /invoices/:id']
+      const updateMatches = updateConfig!.pattern.exec(
+        'invoices/test-id'
+      )
+      expect(updateMatches).not.toBeNull()
+      expect(updateMatches![1]).toBe('test-id') // First capture group
+
+      // Test invoice delete pattern extraction
+      const deleteConfig = invoicesRouteConfigs.find(
+        (config) => 'DELETE /invoices/:id' in config
+      )?.['DELETE /invoices/:id']
+      const deleteMatches = deleteConfig!.pattern.exec(
+        'invoices/test-id'
+      )
+      expect(deleteMatches).not.toBeNull()
+      expect(deleteMatches![1]).toBe('test-id') // First capture group
+
+      // Test invoice list pattern (no captures)
+      const listConfig = invoicesRouteConfigs.find(
+        (config) => 'GET /invoices' in config
+      )?.['GET /invoices']
+      const listMatches = listConfig!.pattern.exec('invoices')
+      expect(listMatches).not.toBeNull()
+      expect(listMatches!.length).toBe(1) // Only the full match, no capture groups
+
+      // Test invoice create pattern (no captures)
+      const createConfig = invoicesRouteConfigs.find(
+        (config) => 'POST /invoices' in config
+      )?.['POST /invoices']
+      const createMatches = createConfig!.pattern.exec('invoices')
+      expect(createMatches).not.toBeNull()
+      expect(createMatches!.length).toBe(1) // Only the full match, no capture groups
+    })
+  })
+
+  describe('mapParams function behavior', () => {
+    it('should correctly map URL parameters for invoice get requests', () => {
+      const routeConfig = invoicesRouteConfigs.find(
+        (config) => 'GET /invoices/:id' in config
+      )?.['GET /invoices/:id']
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['inv_123'])
+
+      expect(result).toEqual({
+        id: 'inv_123',
+      })
+    })
+
+    it('should correctly map URL parameters and body for invoice update requests', () => {
+      const routeConfig = invoicesRouteConfigs.find(
+        (config) => 'PUT /invoices/:id' in config
+      )?.['PUT /invoices/:id']
+      const testBody = {
+        amount: 30000,
+        status: 'paid',
+        paidAt: '2024-01-15',
+      }
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['inv_456'], testBody)
+
+      expect(result).toEqual({
+        amount: 30000,
+        status: 'paid',
+        paidAt: '2024-01-15',
+        id: 'inv_456',
+      })
+    })
+
+    it('should correctly map URL parameters for invoice delete requests', () => {
+      const routeConfig = invoicesRouteConfigs.find(
+        (config) => 'DELETE /invoices/:id' in config
+      )?.['DELETE /invoices/:id']
+
+      // Simulate what route handler does - slices off the full match
+      const result = routeConfig!.mapParams(['inv_789'])
+
+      expect(result).toEqual({
+        id: 'inv_789',
+      })
+    })
+
+    it('should return body for invoice create requests', () => {
+      const routeConfig = invoicesRouteConfigs.find(
+        (config) => 'POST /invoices' in config
+      )?.['POST /invoices']
+      const testBody = {
+        customerId: 'cus_123',
+        amount: 50000,
+        dueDate: '2024-12-31',
+        items: [
+          { description: 'Service A', amount: 30000 },
+          { description: 'Service B', amount: 20000 },
+        ],
+      }
+
+      const result = routeConfig!.mapParams([], testBody)
+
+      expect(result).toEqual(testBody)
+    })
+
+    it('should return undefined for invoice list requests', () => {
+      const routeConfig = invoicesRouteConfigs.find(
+        (config) => 'GET /invoices' in config
+      )?.['GET /invoices']
+
+      const result = routeConfig!.mapParams([])
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should handle special characters and encoded values in id', () => {
+      const routeConfig = invoicesRouteConfigs.find(
+        (config) => 'GET /invoices/:id' in config
+      )?.['GET /invoices/:id']
+
+      // Test with URL-encoded characters (simulate route handler slicing)
+      const result1 = routeConfig!.mapParams(['inv%40123'])
+      expect(result1).toEqual({
+        id: 'inv%40123',
+      })
+
+      // Test with hyphens and underscores (simulate route handler slicing)
+      const result2 = routeConfig!.mapParams(['inv_123-abc'])
+      expect(result2).toEqual({ id: 'inv_123-abc' })
+
+      // Test with alphanumeric IDs
+      const result3 = routeConfig!.mapParams(['INV2024001'])
+      expect(result3).toEqual({ id: 'INV2024001' })
+    })
+  })
+
+  describe('Route config completeness', () => {
+    it('should have all expected CRUD route configs', () => {
+      const routeKeys: string[] = []
+      invoicesRouteConfigs.forEach((config) => {
+        routeKeys.push(...Object.keys(config))
+      })
+
+      // Check that all expected routes exist
+      expect(routeKeys).toContain('POST /invoices') // create
+      expect(routeKeys).toContain('PUT /invoices/:id') // update
+      expect(routeKeys).toContain('GET /invoices/:id') // get
+      expect(routeKeys).toContain('GET /invoices') // list
+      expect(routeKeys).toContain('DELETE /invoices/:id') // delete
+
+      // Check that we have exactly the expected number of routes
+      expect(routeKeys).toHaveLength(5) // Standard CRUD operations
+    })
+
+    it('should have consistent id parameter usage', () => {
+      const idRoutes = [
+        'PUT /invoices/:id',
+        'GET /invoices/:id',
+        'DELETE /invoices/:id',
+      ]
+
+      idRoutes.forEach((routeKey) => {
+        const config = invoicesRouteConfigs.find(
+          (c) => routeKey in c
+        )?.[routeKey]
+
+        // Test that mapParams consistently uses 'id' (simulate route handler slicing)
+        const result = config!.mapParams(['test-id'], {
+          someData: 'value',
+        })
+        expect(result).toHaveProperty('id', 'test-id')
+      })
+    })
+
+    it('should have valid route config structure for all routes', () => {
+      // Test all route configs from the array
+      invoicesRouteConfigs.forEach((routeConfigObj) => {
+        Object.entries(routeConfigObj).forEach(
+          ([routeKey, config]) => {
+            // Each config should have required properties
+            expect(config).toHaveProperty('procedure')
+            expect(config).toHaveProperty('pattern')
+            expect(config).toHaveProperty('mapParams')
+
+            // Procedure should be a valid TRPC procedure path
+            expect(config.procedure).toMatch(/^invoices\.\w+$/)
+
+            // Pattern should be a RegExp
+            expect(config.pattern).toBeInstanceOf(RegExp)
+
+            // mapParams should be a function
+            expect(typeof config.mapParams).toBe('function')
+          }
+        )
+      })
+    })
+
+    it('should map to correct TRPC procedures', () => {
+      const expectedMappings = {
+        'POST /invoices': 'invoices.create',
+        'PUT /invoices/:id': 'invoices.update',
+        'GET /invoices/:id': 'invoices.get',
+        'GET /invoices': 'invoices.list',
+        'DELETE /invoices/:id': 'invoices.delete',
+      }
+
+      Object.entries(expectedMappings).forEach(
+        ([routeKey, expectedProcedure]) => {
+          const config = invoicesRouteConfigs.find(
+            (c) => routeKey in c
+          )?.[routeKey]
+          expect(config!.procedure).toBe(expectedProcedure)
+        }
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Added comprehensive test coverage for `invoiceLineItemsRouter` route configurations
- Added comprehensive test coverage for `invoicesRouter` route configurations  
- Both test suites follow the established pattern from existing route config tests

## Changes
- Created `invoiceLineItemsRouter.routeConfigs.test.ts` with 17 test cases
- Created `invoicesRouter.routeConfigs.test.ts` with 17 test cases
- Tests verify route pattern matching, RegExp validation, parameter mapping, and completeness
- All 34 tests are passing successfully

## Test Coverage
Each test suite covers:
- Route pattern matching and procedure mapping
- RegExp validation for URL patterns
- mapParams function behavior
- Route config completeness and structure validation

These tests ensure that the REST-to-TRPC mapping integrity is maintained for both routers.

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add comprehensive tests for invoices and invoice line items route configs to validate REST-to-TRPC mapping and procedure wiring. 34 tests (17 per router) cover route pattern matching, RegExp correctness, mapParams behavior, and config completeness; all passing to guard against regressions.

<!-- End of auto-generated description by cubic. -->

