### PR TITLE
enforce default plan creation when creating an org

### DIFF
--- a/platform/flowglad-next/src/utils/organizationHelpers.test.ts
+++ b/platform/flowglad-next/src/utils/organizationHelpers.test.ts
@@ -7,6 +7,9 @@ import core from './core'
 import { selectOrganizations } from '@/db/tableMethods/organizationMethods'
 import { selectApiKeys } from '@/db/tableMethods/apiKeyMethods'
 import { FlowgladApiKeyType } from '@/types'
+import { selectPricingModels } from '@/db/tableMethods/pricingModelMethods'
+import { selectProducts } from '@/db/tableMethods/productMethods'
+import { selectPricesAndProductByProductId } from '@/db/tableMethods/priceMethods'
 
 describe('createOrganizationTransaction', () => {
   it('should create an organization', async () => {
@@ -74,6 +77,106 @@ describe('createOrganizationTransaction', () => {
        * they can only be created once the organization has payouts enabled.
        */
       expect(livemodeKeys.length).toBe(0)
+    })
+  })
+
+  it('should create default Free Plan products and prices for live and testmode', async () => {
+    const organizationName = `org_${core.nanoid()}`
+    await adminTransaction(async ({ transaction }) => {
+      const [country] = await selectCountries({}, transaction)
+      const input: CreateOrganizationInput = {
+        organization: {
+          name: organizationName,
+          countryId: country.id,
+        },
+      }
+      return createOrganizationTransaction(
+        input,
+        {
+          id: core.nanoid(),
+          email: `test+${core.nanoid()}@test.com`,
+          fullName: 'Test User',
+        },
+        transaction
+      )
+    })
+
+    await adminTransaction(async ({ transaction }) => {
+      const [organization] = await selectOrganizations(
+        { name: organizationName },
+        transaction
+      )
+      expect(organization).toBeDefined()
+
+      // Live default pricing model and Free Plan
+      const [liveDefaultPricingModel] = await selectPricingModels(
+        {
+          organizationId: organization.id,
+          livemode: true,
+          isDefault: true,
+        },
+        transaction
+      )
+      expect(liveDefaultPricingModel?.id).toBeDefined()
+
+      const [liveDefaultProduct] = await selectProducts(
+        {
+          pricingModelId: liveDefaultPricingModel.id,
+          default: true,
+        },
+        transaction
+      )
+      expect(liveDefaultProduct?.id).toBeDefined()
+      expect(liveDefaultProduct.name).toBe('Free Plan')
+      expect(liveDefaultProduct.organizationId).toBe(organization.id)
+      expect(liveDefaultProduct.livemode).toBe(true)
+
+      const liveProductWithPrices = await selectPricesAndProductByProductId(
+        liveDefaultProduct.id,
+        transaction
+      )
+      expect(liveProductWithPrices.defaultPrice?.id).toBeDefined()
+      expect(liveProductWithPrices.defaultPrice.name).toBe('Free Plan')
+      expect(liveProductWithPrices.defaultPrice.unitPrice).toBe(0)
+      expect(liveProductWithPrices.defaultPrice.livemode).toBe(true)
+      expect(liveProductWithPrices.defaultPrice.currency).toBe(
+        organization.defaultCurrency
+      )
+
+      // Testmode default pricing model and Free Plan
+      const [testDefaultPricingModel] = await selectPricingModels(
+        {
+          organizationId: organization.id,
+          livemode: false,
+          isDefault: true,
+        },
+        transaction
+      )
+      expect(testDefaultPricingModel?.id).toBeDefined()
+
+      const [testDefaultProduct] = await selectProducts(
+        {
+          pricingModelId: testDefaultPricingModel.id,
+          default: true,
+        },
+        transaction
+      )
+      expect(testDefaultProduct?.id).toBeDefined()
+      expect(testDefaultProduct.name).toBe('Free Plan')
+      expect(testDefaultProduct.organizationId).toBe(organization.id)
+      expect(testDefaultProduct.livemode).toBe(false)
+
+      const testProductWithPrices = await selectPricesAndProductByProductId(
+        testDefaultProduct.id,
+        transaction
+      )
+      expect(testProductWithPrices.defaultPrice?.id).toBeDefined()
+      expect(testProductWithPrices.defaultPrice.name).toBe('Free Plan')
+      expect(testProductWithPrices.defaultPrice.unitPrice).toBe(0)
+      expect(testProductWithPrices.defaultPrice.livemode).toBe(false)
+      expect(testProductWithPrices.defaultPrice.currency).toBe(
+        organization.defaultCurrency
+      )
     })
   })
 })


### PR DESCRIPTION
## What Does this PR Do?

- enforce default plan creation when creating an org
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Automatically creates a default pricing model and a Free Plan (product + price) for both live and test mode when a new organization is created, so every org starts with a usable plan. Replaces ad-hoc inserts with a single bookkeeping flow.

- **New Features**
  - Uses createPricingModelBookkeeping to create default live and testmode pricing models with a “Free Plan” product and a 0-price default price in the org’s currency.
  - Adds tests to verify default pricing models, products, and prices are created for both modes.

<!-- End of auto-generated description by cubic. -->

