### PR TITLE
disallow editing intervalUnit on default plan prices

### DIFF
--- a/platform/flowglad-next/src/components/forms/PriceFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/PriceFormFields.tsx
@@ -94,6 +94,7 @@ const SubscriptionFields = ({
                 <Select
                   value={field.value ?? ''}
                   onValueChange={field.onChange}
+                  disabled={disableAmountAndTrials}
                 >
                   <SelectTrigger className="flex-1">
                     <SelectValue placeholder="Select interval" />

--- a/platform/flowglad-next/src/server/routers/pricesRouter.test.ts
+++ b/platform/flowglad-next/src/server/routers/pricesRouter.test.ts
@@ -151,8 +151,6 @@ describe('pricesRouter - Default Price Constraints', () => {
               unitPrice: 0,
               type: PriceType.Subscription,
               name: 'Updated Base Plan Price',
-              intervalUnit: IntervalUnit.Month,
-              intervalCount: 1,
             },
             existingPrice,
             product
@@ -201,6 +199,30 @@ describe('pricesRouter - Default Price Constraints', () => {
         })
       ).rejects.toThrow(
         'Cannot change the default status of a default price on a default product'
+      )
+    })
+
+    it('should throw error when attempting to change intervalUnit of default price on default product', async () => {
+      await expect(
+        adminTransaction(async ({ transaction }) => {
+          const existingPrice = await selectPriceById(
+            defaultPriceId,
+            transaction
+          )
+          const product = await selectProductById(
+            existingPrice.productId,
+            transaction
+          )
+
+          // This should throw an error
+          validateDefaultPriceUpdate(
+            { intervalUnit: IntervalUnit.Year, type: PriceType.Subscription },
+            existingPrice,
+            product
+          )
+        })
+      ).rejects.toThrow(
+        'Cannot change the billing interval of the default price for a default product'
       )
     })
 

--- a/platform/flowglad-next/src/utils/defaultProductValidation.ts
+++ b/platform/flowglad-next/src/utils/defaultProductValidation.ts
@@ -125,6 +125,18 @@ export const validateDefaultPriceUpdate = (
     })
   }
 
+  // Prevent changing the billing interval for default prices on default products
+  if (
+    update.intervalUnit !== undefined &&
+    update.intervalUnit !== existingPrice.intervalUnit
+  ) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message:
+        'Cannot change the billing interval of the default price for a default product',
+    })
+  }
+
   // Prevent changing the isDefault status
   if (
     'isDefault' in update &&


### PR DESCRIPTION
## What Does this PR Do?

- disallow editing intervalUnit on default plan prices
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevent changing the billing interval (intervalUnit) for the default price on default products to keep default plan billing periods consistent and safe.

- **Bug Fixes**
  - Enforce server-side validation to reject intervalUnit changes on default prices (FORBIDDEN error with clear message).
  - Disable the interval Select in the price form when default plan fields are locked.
  - Update tests to cover the restriction and allowed updates.

<!-- End of auto-generated description by cubic. -->

