### PR TITLE
disallow creating checkout sessions on default products

### DIFF
--- a/packages/react/src/components/billing-page.tsx
+++ b/packages/react/src/components/billing-page.tsx
@@ -84,7 +84,11 @@ const CurrentSubscriptionOrPricingTable = ({
         description: product.description,
         displayFeatures: product.displayFeatures,
         primaryButtonText: 'Subscribe',
+        disabled: product.default,
         onClickPrimaryButton: () => {
+          if (product.default) {
+            return // Do nothing for default products
+          }
           return createCheckoutSession({
             priceId: product.defaultPrice.id,
             successUrl: window.location.href,

--- a/platform/flowglad-next/src/app/store/products/ProductsTable.tsx
+++ b/platform/flowglad-next/src/app/store/products/ProductsTable.tsx
@@ -73,6 +73,10 @@ const MoreMenuCell = ({
       label: 'Copy purchase link',
       icon: <Copy />,
       handler: copyPurchaseLinkHandler,
+      disabled: product.default,
+      helperText: product.default
+        ? 'Cannot copy checkout link for default products. Default products are automatically assigned to customers.'
+        : undefined,
     },
     {
       label: product.active

--- a/platform/flowglad-next/src/app/store/products/[id]/InternalProductDetailsPage.tsx
+++ b/platform/flowglad-next/src/app/store/products/[id]/InternalProductDetailsPage.tsx
@@ -54,10 +54,18 @@ function InternalProductDetailsPage(
     {
       label: 'Copy Link',
       handler: () => copyPurchaseLinkHandler(),
+      disabled: product.default,
+      helperText: product.default
+        ? 'Cannot copy checkout link for default products. Default products are automatically assigned to customers.'
+        : undefined,
     },
     {
       label: 'Preview',
       handler: () => previewProductHandler(),
+      disabled: product.default,
+      helperText: product.default
+        ? 'Cannot preview checkout for default products. Default products are automatically assigned to customers.'
+        : undefined,
     },
   ]
 

--- a/platform/flowglad-next/src/components/PopoverMenu.tsx
+++ b/platform/flowglad-next/src/components/PopoverMenu.tsx
@@ -39,41 +39,43 @@ const PopoverMenuItem = ({
   helperText,
   icon,
 }: PopoverMenuItemProps) => {
-  return (
-    <PopoverPrimitive.Close asChild>
-      <div
-        className={cn(
-          'relative flex cursor-default select-none items-start rounded-lg px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
-          helperText ? 'flex-col gap-1' : 'items-center gap-2',
-          className,
-          disabled
-            ? 'opacity-50 cursor-not-allowed'
-            : 'cursor-pointer'
-        )}
-        onClick={disabled ? undefined : onClick}
-      >
-        {icon && <span className="flex-shrink-0">{icon}</span>}
+  const content = (
+    <div
+      className={cn(
+        'relative flex cursor-default select-none items-start rounded-lg px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+        helperText ? 'flex-col gap-1' : 'items-center gap-2',
+        className,
+        disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+      )}
+      onClick={disabled ? undefined : onClick}
+      aria-disabled={disabled}
+    >
+      {icon && <span className="flex-shrink-0">{icon}</span>}
+      <div className={cn('flex flex-col', helperText ? 'gap-1' : '')}>
         <div
-          className={cn('flex flex-col', helperText ? 'gap-1' : '')}
-        >
-          <div
-            className={cn(
-              'whitespace-normal break-words',
-              state === PopoverMenuItemState.Danger
-                ? 'text-destructive'
-                : ''
-            )}
-          >
-            {children}
-          </div>
-          {helperText && (
-            <p className="text-xs text-muted-foreground whitespace-normal break-words">
-              {helperText}
-            </p>
+          className={cn(
+            'whitespace-normal break-words',
+            state === PopoverMenuItemState.Danger
+              ? 'text-destructive'
+              : ''
           )}
+        >
+          {children}
         </div>
+        {helperText && (
+          <p className="text-xs text-muted-foreground whitespace-normal break-words">
+            {helperText}
+          </p>
+        )}
       </div>
-    </PopoverPrimitive.Close>
+    </div>
+  )
+
+  // Only wrap with PopoverPrimitive.Close if the item is enabled
+  return disabled ? (
+    content
+  ) : (
+    <PopoverPrimitive.Close asChild>{content}</PopoverPrimitive.Close>
   )
 }
 

--- a/platform/flowglad-next/src/utils/bookkeeping/createCheckoutSession.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/createCheckoutSession.ts
@@ -165,6 +165,13 @@ export const createCheckoutSessionTransaction = async (
     price = result.price
     product = result.product
     organization = result.organization
+
+    // Validate that checkout sessions cannot be created for default products
+    if (product.default) {
+      throw new Error(
+        'Checkout sessions cannot be created for default products. Default products are automatically assigned to customers and do not require manual checkout.'
+      )
+    }
   } else {
     organization = await selectOrganizationById(
       checkoutSession.organizationId,

--- a/platform/flowglad-next/src/utils/bookkeeping/createCheckoutSession.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/createCheckoutSession.ts
@@ -142,8 +142,32 @@ export const createCheckoutSessionTransaction = async (
     )
   }
   // Anonymous sessions can omit customerExternalId; in that case customer will be null
-  // NOTE: invoice and purchase checkout sessions
-  // are not supported by API yet.
+  // NOTE: invoice and purchase checkout sessions are not supported by API yet.
+  let price: Price.Record | null = null
+  let product: Product.Record | null = null
+  let organization: Organization.Record | null = null
+  if (checkoutSessionInput.type === CheckoutSessionType.Product) {
+    const [result] =
+      await selectPriceProductAndOrganizationByPriceWhere(
+        { id: checkoutSessionInput.priceId },
+        transaction
+      )
+    price = result.price
+    product = result.product
+    organization = result.organization
+
+    if (product.default) {
+      throw new Error(
+        'Checkout sessions cannot be created for default products. Default products are automatically assigned to customers and do not require manual checkout.'
+      )
+    }
+  } else {
+    organization = await selectOrganizationById(
+      organizationId,
+      transaction
+    )
+  }
+
   const checkoutSession = await insertCheckoutSession(
     checkoutSessionInsertFromInput({
       checkoutSessionInput,
@@ -153,31 +177,6 @@ export const createCheckoutSessionTransaction = async (
     }),
     transaction
   )
-  let price: Price.Record | null = null
-  let product: Product.Record | null = null
-  let organization: Organization.Record | null = null
-  if (checkoutSession.type === CheckoutSessionType.Product) {
-    const [result] =
-      await selectPriceProductAndOrganizationByPriceWhere(
-        { id: checkoutSession.priceId },
-        transaction
-      )
-    price = result.price
-    product = result.product
-    organization = result.organization
-
-    // Validate that checkout sessions cannot be created for default products
-    if (product.default) {
-      throw new Error(
-        'Checkout sessions cannot be created for default products. Default products are automatically assigned to customers and do not require manual checkout.'
-      )
-    }
-  } else {
-    organization = await selectOrganizationById(
-      checkoutSession.organizationId,
-      transaction
-    )
-  }
 
   let stripeSetupIntentId: string | null = null
   let stripePaymentIntentId: string | null = null

--- a/platform/flowglad-next/src/utils/checkoutSessionState.test.ts
+++ b/platform/flowglad-next/src/utils/checkoutSessionState.test.ts
@@ -101,30 +101,34 @@ describe('createNonInvoiceCheckoutSession', () => {
       // Create a default product and price
       const { organization: defaultOrg, product: defaultProduct } =
         await setupOrg()
-      const defaultPrice = await setupPrice({
-        productId: defaultProduct.id,
-        type: PriceType.SinglePayment,
-        name: 'Default Product Price',
-        unitPrice: 0,
-        intervalUnit: IntervalUnit.Day,
-        intervalCount: 1,
-        livemode: true,
-        isDefault: true,
-      })
+      try {
+        const defaultPrice = await setupPrice({
+          productId: defaultProduct.id,
+          type: PriceType.SinglePayment,
+          name: 'Default Product Price',
+          unitPrice: 0,
+          intervalUnit: IntervalUnit.Day,
+          intervalCount: 1,
+          livemode: true,
+          isDefault: true,
+        })
 
-      await expect(
-        adminTransaction(async ({ transaction }) =>
-          createNonInvoiceCheckoutSession(
-            {
-              price: defaultPrice,
-              organizationId: defaultOrg.id,
-            },
-            transaction
+        await expect(
+          adminTransaction(async ({ transaction }) =>
+            createNonInvoiceCheckoutSession(
+              {
+                price: defaultPrice,
+                organizationId: defaultOrg.id,
+              },
+              transaction
+            )
           )
+        ).rejects.toThrow(
+          'Checkout sessions cannot be created for default products. Default products are automatically assigned to customers and do not require manual checkout.'
         )
-      ).rejects.toThrow(
-        'Checkout sessions cannot be created for default products. Default products are automatically assigned to customers and do not require manual checkout.'
-      )
+      } finally {
+        await teardownOrg({ organizationId: defaultOrg.id })
+      }
     })
 
     it('should allow creating checkout sessions for non-default products', async () => {

--- a/platform/flowglad-next/src/utils/checkoutSessionState.test.ts
+++ b/platform/flowglad-next/src/utils/checkoutSessionState.test.ts
@@ -1,0 +1,226 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  beforeAll,
+} from 'vitest'
+import { createNonInvoiceCheckoutSession } from './checkoutSessionState'
+import {
+  setupOrg,
+  setupCustomer,
+  teardownOrg,
+  setupPrice,
+  setupUsageMeter,
+  setupProduct,
+} from '@/../seedDatabase'
+import { adminTransaction } from '@/db/adminTransaction'
+import { Organization } from '@/db/schema/organizations'
+import { Price } from '@/db/schema/prices'
+import { Customer } from '@/db/schema/customers'
+import { CheckoutSessionType, PriceType } from '@/types'
+import { IntervalUnit } from '@/types'
+import { UsageMeter } from '@/db/schema/usageMeters'
+import { core } from '@/utils/core'
+
+describe('createNonInvoiceCheckoutSession', () => {
+  let organization: Organization.Record
+  let customer: Customer.Record
+  let singlePaymentPrice: Price.Record
+  let subscriptionPrice: Price.Record
+  let usagePrice: Price.Record
+  let usageMeter: UsageMeter.Record
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
+  })
+
+  beforeEach(async () => {
+    const { organization: org, pricingModel } = await setupOrg()
+    organization = org
+    customer = await setupCustomer({
+      organizationId: organization.id,
+      stripeCustomerId: `cus_${core.nanoid()}`,
+    })
+    usageMeter = await setupUsageMeter({
+      organizationId: organization.id,
+      name: 'Usage Meter',
+      pricingModelId: pricingModel.id,
+      livemode: false,
+    })
+
+    // Create a non-default product for testing
+    const nonDefaultProduct = await setupProduct({
+      organizationId: organization.id,
+      name: 'Test Product',
+      livemode: false,
+      pricingModelId: pricingModel.id,
+      active: true,
+      default: false,
+    })
+
+    singlePaymentPrice = await setupPrice({
+      productId: nonDefaultProduct.id,
+      type: PriceType.SinglePayment,
+      name: 'Single Payment Price',
+      unitPrice: 1000,
+      intervalUnit: IntervalUnit.Day,
+      intervalCount: 1,
+      livemode: false,
+      isDefault: false,
+    })
+    subscriptionPrice = await setupPrice({
+      productId: nonDefaultProduct.id,
+      type: PriceType.Subscription,
+      name: 'Subscription Price',
+      unitPrice: 500,
+      intervalUnit: IntervalUnit.Month,
+      intervalCount: 1,
+      livemode: false,
+      isDefault: false,
+    })
+    usagePrice = await setupPrice({
+      productId: nonDefaultProduct.id,
+      type: PriceType.Usage,
+      name: 'Usage Price',
+      unitPrice: 100,
+      intervalUnit: IntervalUnit.Day,
+      intervalCount: 1,
+      livemode: false,
+      isDefault: false,
+      usageMeterId: usageMeter.id,
+    })
+  })
+
+  afterEach(async () => {
+    await teardownOrg({ organizationId: organization.id })
+  })
+
+  describe('Default product validation', () => {
+    it('should throw an error when trying to create a checkout session for a default product', async () => {
+      // Create a default product and price
+      const { organization: defaultOrg, product: defaultProduct } =
+        await setupOrg()
+      const defaultPrice = await setupPrice({
+        productId: defaultProduct.id,
+        type: PriceType.SinglePayment,
+        name: 'Default Product Price',
+        unitPrice: 0,
+        intervalUnit: IntervalUnit.Day,
+        intervalCount: 1,
+        livemode: true,
+        isDefault: true,
+      })
+
+      await expect(
+        adminTransaction(async ({ transaction }) =>
+          createNonInvoiceCheckoutSession(
+            {
+              price: defaultPrice,
+              organizationId: defaultOrg.id,
+            },
+            transaction
+          )
+        )
+      ).rejects.toThrow(
+        'Checkout sessions cannot be created for default products. Default products are automatically assigned to customers and do not require manual checkout.'
+      )
+    })
+
+    it('should allow creating checkout sessions for non-default products', async () => {
+      // This test verifies that the existing functionality still works for non-default products
+      const checkoutSession = await adminTransaction(
+        async ({ transaction }) =>
+          createNonInvoiceCheckoutSession(
+            {
+              price: singlePaymentPrice,
+              organizationId: organization.id,
+            },
+            transaction
+          )
+      )
+
+      expect(checkoutSession.stripePaymentIntentId).not.toBeNull()
+      expect(checkoutSession.stripeSetupIntentId).toBeNull()
+    })
+  })
+
+  describe('Product checkout sessions', () => {
+    it('should create a checkout session for a SinglePayment product', async () => {
+      const checkoutSession = await adminTransaction(
+        async ({ transaction }) =>
+          createNonInvoiceCheckoutSession(
+            {
+              price: singlePaymentPrice,
+              organizationId: organization.id,
+            },
+            transaction
+          )
+      )
+
+      expect(checkoutSession.stripePaymentIntentId).not.toBeNull()
+      expect(checkoutSession.stripeSetupIntentId).toBeNull()
+      expect(checkoutSession.type).toBe(CheckoutSessionType.Product)
+      expect(checkoutSession.priceId).toBe(singlePaymentPrice.id)
+    })
+
+    it('should create a checkout session for a Subscription product', async () => {
+      const checkoutSession = await adminTransaction(
+        async ({ transaction }) =>
+          createNonInvoiceCheckoutSession(
+            {
+              price: subscriptionPrice,
+              organizationId: organization.id,
+            },
+            transaction
+          )
+      )
+
+      expect(checkoutSession.stripePaymentIntentId).toBeNull()
+      expect(checkoutSession.stripeSetupIntentId).not.toBeNull()
+      expect(checkoutSession.type).toBe(CheckoutSessionType.Product)
+      expect(checkoutSession.priceId).toBe(subscriptionPrice.id)
+    })
+
+    it('should create a checkout session for a Usage-based product', async () => {
+      const checkoutSession = await adminTransaction(
+        async ({ transaction }) =>
+          createNonInvoiceCheckoutSession(
+            {
+              price: usagePrice,
+              organizationId: organization.id,
+            },
+            transaction
+          )
+      )
+
+      expect(checkoutSession.stripeSetupIntentId).not.toBeNull()
+      expect(checkoutSession.type).toBe(CheckoutSessionType.Product)
+      expect(checkoutSession.priceId).toBe(usagePrice.id)
+    })
+  })
+
+  describe('Add payment method checkout sessions', () => {
+    it('should create a checkout session for AddPaymentMethod', async () => {
+      const checkoutSession = await adminTransaction(
+        async ({ transaction }) =>
+          createNonInvoiceCheckoutSession(
+            {
+              price: subscriptionPrice,
+              organizationId: organization.id,
+              targetSubscriptionId: 'sub_123',
+              customerId: customer.id,
+            },
+            transaction
+          )
+      )
+
+      expect(checkoutSession.stripeSetupIntentId).not.toBeNull()
+      expect(checkoutSession.type).toBe(
+        CheckoutSessionType.AddPaymentMethod
+      )
+      expect(checkoutSession.targetSubscriptionId).toBe('sub_123')
+      expect(checkoutSession.customerId).toBe(customer.id)
+    })
+  })
+})

--- a/platform/flowglad-next/src/utils/checkoutSessionState.ts
+++ b/platform/flowglad-next/src/utils/checkoutSessionState.ts
@@ -232,6 +232,17 @@ export const createNonInvoiceCheckoutSession = async (
     }
   }
 
+  // Validate that checkout sessions cannot be created for default products
+  const product = await selectProductById(
+    price.productId,
+    transaction
+  )
+  if (product.default) {
+    throw new Error(
+      'Checkout sessions cannot be created for default products. Default products are automatically assigned to customers and do not require manual checkout.'
+    )
+  }
+
   const checkoutSession = await insertCheckoutSession(
     checkoutSessionInsert,
     transaction
@@ -240,17 +251,6 @@ export const createNonInvoiceCheckoutSession = async (
     organizationId,
     transaction
   )
-  const product = await selectProductById(
-    price.productId,
-    transaction
-  )
-
-  // Validate that checkout sessions cannot be created for default products
-  if (product.default) {
-    throw new Error(
-      'Checkout sessions cannot be created for default products. Default products are automatically assigned to customers and do not require manual checkout.'
-    )
-  }
 
   let stripeSetupIntentId: string | null = null
   let stripePaymentIntentId: string | null = null

--- a/platform/flowglad-next/src/utils/checkoutSessionState.ts
+++ b/platform/flowglad-next/src/utils/checkoutSessionState.ts
@@ -245,6 +245,13 @@ export const createNonInvoiceCheckoutSession = async (
     transaction
   )
 
+  // Validate that checkout sessions cannot be created for default products
+  if (product.default) {
+    throw new Error(
+      'Checkout sessions cannot be created for default products. Default products are automatically assigned to customers and do not require manual checkout.'
+    )
+  }
+
   let stripeSetupIntentId: string | null = null
   let stripePaymentIntentId: string | null = null
   /**


### PR DESCRIPTION
## What Does this PR Do?
 - disallow creating checkout sessions on default products
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Block checkout sessions for default products. Default products are auto-assigned, so purchase flows are disabled in the UI and validated on the server to prevent manual checkout.

- **New Features**
  - Server: Reject checkout sessions when the price’s product is default in createCheckoutSessionTransaction and createNonInvoiceCheckoutSession.
  - UI: Disable Subscribe, Copy purchase link, and Preview for default products with helper text in Billing, Products table, and Product details.

<!-- End of auto-generated description by cubic. -->

