### PR TITLE
allow users with default plans to access checkout pages

### DIFF
--- a/platform/flowglad-next/src/app/checkout/[id]/page.test.tsx
+++ b/platform/flowglad-next/src/app/checkout/[id]/page.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import React from 'react'
+
+// Mock next/navigation redirect
+const redirect = vi.fn()
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+  redirect: (url: string) => redirect(url),
+}))
+
+// Mock checkoutInfo schema parsing to bypass strict Zod requirements in unit tests
+vi.mock('@/db/tableMethods/purchaseMethods', () => ({
+  checkoutInfoSchema: {
+    parse: (x: any) => x,
+  },
+}))
+
+// Mock server utilities used by the page
+vi.mock('@/db/adminTransaction', () => ({
+  adminTransaction: (fn: any) => fn({ transaction: {} }),
+}))
+
+vi.mock('@/utils/stripe', () => ({
+  getPaymentIntent: vi.fn(async (id: string) => ({ client_secret: `pi_secret_${id}` })),
+  getSetupIntent: vi.fn(async (id: string) => ({ client_secret: `si_secret_${id}` })),
+}))
+
+vi.mock('@/utils/checkoutHelpers', () => ({
+  checkoutInfoForCheckoutSession: vi.fn(async (id: string) => ({
+    checkoutSession: {
+      id,
+      status: 'open',
+      stripePaymentIntentId: null,
+      stripeSetupIntentId: 'seti_123',
+      successUrl: null,
+    },
+    product: { id: 'prod_1' },
+    price: { id: 'price_1', type: 'subscription' },
+    sellerOrganization: { id: 'org_1', allowMultipleSubscriptionsPerCustomer: false },
+    feeCalculation: null,
+    maybeCustomer: { id: 'cust_1', email: 'a@b.com' },
+    maybeCurrentSubscriptions: [
+      { status: 'active', isFreePlan: true },
+    ],
+    discount: null,
+  })),
+}))
+
+// Import after mocks
+import Page from './page'
+import { PriceType, CheckoutSessionStatus, SubscriptionStatus } from '@/types'
+import { checkoutInfoForCheckoutSession } from '@/utils/checkoutHelpers'
+
+describe('CheckoutSessionPage', () => {
+  beforeEach(() => {
+    redirect.mockReset()
+  })
+
+  it('renders when only free subscription exists (no block)', async () => {
+    const ui = await Page({ params: Promise.resolve({ id: 'cs_123' }) } as any)
+    expect(ui).toBeTruthy()
+    expect(redirect).not.toHaveBeenCalled()
+  })
+
+  it('redirects when session not open and setup intent present', async () => {
+    // Adjust mock to return non-open status
+    vi.mocked(checkoutInfoForCheckoutSession).mockResolvedValueOnce({
+      checkoutSession: {
+        id: 'cs_456',
+        status: CheckoutSessionStatus.Succeeded,
+        stripePaymentIntentId: null,
+        stripeSetupIntentId: 'seti_999',
+        successUrl: null,
+      },
+      product: { id: 'prod_1' },
+      price: { id: 'price_1', type: PriceType.Subscription },
+      sellerOrganization: { id: 'org_1', allowMultipleSubscriptionsPerCustomer: false },
+      feeCalculation: null,
+      maybeCustomer: { id: 'cust_1', email: 'a@b.com' },
+      maybeCurrentSubscriptions: [],
+      discount: null,
+    } as any)
+
+    await Page({ params: Promise.resolve({ id: 'cs_456' }) } as any)
+    expect(redirect).toHaveBeenCalledWith('/purchase/post-payment?setup_intent=seti_999')
+  })
+
+  it('blocks when active paid exists and multiples disallowed, redirect to successUrl if defined', async () => {
+    vi.mocked(checkoutInfoForCheckoutSession).mockResolvedValueOnce({
+      checkoutSession: {
+        id: 'cs_789',
+        status: CheckoutSessionStatus.Open,
+        stripePaymentIntentId: null,
+        stripeSetupIntentId: 'seti_111',
+        successUrl: 'https://example.com/success',
+      },
+      product: { id: 'prod_1' },
+      price: { id: 'price_1', type: PriceType.Subscription },
+      sellerOrganization: { id: 'org_1', allowMultipleSubscriptionsPerCustomer: false },
+      feeCalculation: null,
+      maybeCustomer: { id: 'cust_1', email: 'a@b.com' },
+      maybeCurrentSubscriptions: [
+        { status: SubscriptionStatus.Active, isFreePlan: false },
+      ],
+      discount: null,
+    } as any)
+
+    await Page({ params: Promise.resolve({ id: 'cs_789' }) } as any)
+    expect(redirect).toHaveBeenCalledWith('https://example.com/success')
+  })
+})
+
+

--- a/platform/flowglad-next/src/app/checkout/[id]/page.test.tsx
+++ b/platform/flowglad-next/src/app/checkout/[id]/page.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import React from 'react'
+import Page from './page'
+import { PriceType, CheckoutSessionStatus, SubscriptionStatus } from '@/types'
+import { checkoutInfoForCheckoutSession } from '@/utils/checkoutHelpers'
 
 // Mock next/navigation redirect
 const redirect = vi.fn()
@@ -45,11 +47,6 @@ vi.mock('@/utils/checkoutHelpers', () => ({
     discount: null,
   })),
 }))
-
-// Import after mocks
-import Page from './page'
-import { PriceType, CheckoutSessionStatus, SubscriptionStatus } from '@/types'
-import { checkoutInfoForCheckoutSession } from '@/utils/checkoutHelpers'
 
 describe('CheckoutSessionPage', () => {
   beforeEach(() => {

--- a/platform/flowglad-next/src/app/checkout/guard.test.ts
+++ b/platform/flowglad-next/src/app/checkout/guard.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { shouldBlockCheckout } from './guard'
+import { PriceType, SubscriptionStatus } from '@/types'
+
+describe('shouldBlockCheckout', () => {
+  const activePaid = {
+    status: SubscriptionStatus.Active,
+    isFreePlan: false,
+  }
+  const activeFree = {
+    status: SubscriptionStatus.Active,
+    isFreePlan: true,
+  }
+  const canceledPaid = {
+    status: SubscriptionStatus.Canceled,
+    isFreePlan: false,
+  }
+
+  it('blocks when active paid exists, price is subscription, multiples disallowed', () => {
+    const result = shouldBlockCheckout({
+      currentSubscriptions: [activePaid],
+      priceType: PriceType.Subscription,
+      allowMultipleSubscriptionsPerCustomer: false,
+    })
+    expect(result).toBe(true)
+  })
+
+  it('does not block when only free plan exists', () => {
+    const result = shouldBlockCheckout({
+      currentSubscriptions: [activeFree],
+      priceType: PriceType.Subscription,
+      allowMultipleSubscriptionsPerCustomer: false,
+    })
+    expect(result).toBe(false)
+  })
+
+  it('does not block for single payment price types', () => {
+    const result = shouldBlockCheckout({
+      currentSubscriptions: [activePaid],
+      priceType: PriceType.SinglePayment,
+      allowMultipleSubscriptionsPerCustomer: false,
+    })
+    expect(result).toBe(false)
+  })
+
+  it('does not block when multiples are allowed', () => {
+    const result = shouldBlockCheckout({
+      currentSubscriptions: [activePaid],
+      priceType: PriceType.Subscription,
+      allowMultipleSubscriptionsPerCustomer: true,
+    })
+    expect(result).toBe(false)
+  })
+
+  it('treats null allowMultipleSubscriptionsPerCustomer as disallowed', () => {
+    const result = shouldBlockCheckout({
+      currentSubscriptions: [activePaid],
+      priceType: PriceType.Subscription,
+      allowMultipleSubscriptionsPerCustomer: null,
+    })
+    expect(result).toBe(true)
+  })
+
+  it('ignores canceled paid subscriptions', () => {
+    const result = shouldBlockCheckout({
+      currentSubscriptions: [canceledPaid],
+      priceType: PriceType.Subscription,
+      allowMultipleSubscriptionsPerCustomer: false,
+    })
+    expect(result).toBe(false)
+  })
+})
+
+

--- a/platform/flowglad-next/src/app/checkout/guard.ts
+++ b/platform/flowglad-next/src/app/checkout/guard.ts
@@ -1,0 +1,24 @@
+import { PriceType, SubscriptionStatus } from '@/types'
+
+type MinimalSub = { status: SubscriptionStatus; isFreePlan: boolean | null }
+
+export function shouldBlockCheckout({
+  currentSubscriptions,
+  priceType,
+  allowMultipleSubscriptionsPerCustomer,
+}: {
+  currentSubscriptions: MinimalSub[]
+  priceType: PriceType
+  allowMultipleSubscriptionsPerCustomer: boolean | null
+}): boolean {
+  const hasActivePaid = (currentSubscriptions ?? []).some(
+    (s) => s.status === SubscriptionStatus.Active && s.isFreePlan === false
+  )
+  return (
+    hasActivePaid &&
+    priceType === PriceType.Subscription &&
+    !(allowMultipleSubscriptionsPerCustomer ?? false)
+  )
+}
+
+


### PR DESCRIPTION
## What Does this PR Do?

- when org allowMultipleSubscriptionsPerCustomer is false, still allow customers on default plans to access checkout pages
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Allow customers on free/default plans to access checkout even when the org disallows multiple subscriptions. Still blocks users with an active paid subscription to prevent duplicate paid plans.

- **Bug Fixes**
  - Added shouldBlockCheckout guard: blocks only when an active paid subscription exists, price is a subscription, and multiples are disallowed (null treated as false).
  - Allows free/default → paid upgrades; ignores canceled subscriptions.
  - Checkout page updates: redirect to successUrl when blocked; redirect to post-payment when session is not open and a setup intent exists.
  - Added unit tests for guard and checkout page.

<!-- End of auto-generated description by cubic. -->

