### PR TITLE
added signup login reciprocal linking

### DIFF
--- a/platform/flowglad-next/src/app/sign-in/page.tsx
+++ b/platform/flowglad-next/src/app/sign-in/page.tsx
@@ -189,7 +189,7 @@ export default function SignIn() {
       </CardContent>
       <CardFooter className="flex flex-col gap-2">
         <div className="text-center text-sm text-muted-foreground">
-          Don't have an account?{' '}
+          Don&apos;t have an account?{' '}
           <Link 
             href="/sign-up" 
             className="text-primary hover:underline"

--- a/platform/flowglad-next/src/app/sign-in/page.tsx
+++ b/platform/flowglad-next/src/app/sign-in/page.tsx
@@ -187,6 +187,17 @@ export default function SignIn() {
           />
         </div>
       </CardContent>
+      <CardFooter className="flex flex-col gap-2">
+        <div className="text-center text-sm text-muted-foreground">
+          Don't have an account?{' '}
+          <Link 
+            href="/sign-up" 
+            className="text-primary hover:underline"
+          >
+            Sign up
+          </Link>
+        </div>
+      </CardFooter>
     </Card>
   )
 }

--- a/platform/flowglad-next/src/app/sign-up/page.tsx
+++ b/platform/flowglad-next/src/app/sign-up/page.tsx
@@ -17,6 +17,7 @@ import { Loader2, X } from 'lucide-react'
 import { signIn, signUp } from '@/utils/authClient'
 import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { ErrorContext } from 'better-auth/react'
 import ErrorLabel from '@/components/ErrorLabel'
@@ -206,6 +207,17 @@ export default function SignUp() {
           />
         </div>
       </CardContent>
+      <CardFooter className="flex flex-col gap-2">
+        <div className="text-center text-sm text-muted-foreground">
+          Already have an account?{' '}
+          <Link 
+            href="/sign-in" 
+            className="text-primary hover:underline"
+          >
+            Sign in
+          </Link>
+        </div>
+      </CardFooter>
     </Card>
   )
 }


### PR DESCRIPTION
## What Does this PR Do?

- added signup login reciprocal linking
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added footer links to switch between sign-in and sign-up pages. Improves navigation and reduces friction if users land on the wrong page.

<!-- End of auto-generated description by cubic. -->

