### PR TITLE
discount application ux

### DIFF
--- a/platform/flowglad-next/src/components/DiscountCodeInput.tsx
+++ b/platform/flowglad-next/src/components/DiscountCodeInput.tsx
@@ -227,7 +227,7 @@ export default function DiscountCodeInput() {
                         autoCapitalize="characters"
                         value={field.value}
                         name={field.name}
-                        ref={inputElementRef}
+                        ref={(el) => { inputElementRef.current = el; field.ref(el) }}
                         onChange={(e) => {
                           const code = e.target.value.toUpperCase()
                           field.onChange(code)

--- a/platform/flowglad-next/src/components/forms/CreateDiscountModal.test.tsx
+++ b/platform/flowglad-next/src/components/forms/CreateDiscountModal.test.tsx
@@ -174,10 +174,6 @@ describe('CreateDiscountModal', () => {
     })
   })
 
-  // Removed overly synthetic percent form submission test relying on internal mocks
-
-  // Dropped noisy console logging test: behavior is covered by data flow assertions
-
   describe('Error Handling', () => {
     it('should handle mutation errors gracefully', async () => {
       const mockError = new Error('Failed to create discount')

--- a/platform/flowglad-next/src/db/schema/discounts.test.ts
+++ b/platform/flowglad-next/src/db/schema/discounts.test.ts
@@ -105,7 +105,6 @@ describe('Discount Form Validation', () => {
           numberOfPayments: null,
         },
         __rawAmountString: '15.75',
-        // Missing id field
       } as any
 
       const result = editDiscountFormSchema.safeParse(invalidEditDiscount)


### PR DESCRIPTION
## What Does this PR Do?

- Apply code → see result hint + "Clear" button
- Start typing → hint disappears, button becomes "Apply"
- Type back the same code → original hint reappears
- Click "Clear" → field clears and focuses for new input
- Can't retry same code unnecessarily
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improves the discount code input UX with clearer Apply/Clear behavior, smarter hints, and blocking duplicate submissions. Clearing now resets state and focuses the field; we only re-apply when the code changes.

- New Features
  - Swap Apply/Clear; Clear resets state and focuses the input.
  - Contextual hints: Checking…, Applied!, Invalid; hide while editing and reappear when the same code is re-entered.
  - Prevent retrying the same code; Apply is disabled if unchanged since last attempt.
  - Debounced auto-apply on blur when the code changed and hasn’t been tried yet.

<!-- End of auto-generated description by cubic. -->

