### PR TITLE
Create pricing model create default

### DIFF
--- a/platform/flowglad-next/public/preview/manifest.json
+++ b/platform/flowglad-next/public/preview/manifest.json
@@ -1,6 +1,6 @@
 {
-  "hash": "1f79b08f",
+  "hash": "df928210",
   "path": "/preview/preview.css",
-  "size": 63315,
-  "generatedAt": "2025-09-15T16:28:30.469Z"
+  "size": 85103,
+  "generatedAt": "2025-09-21T02:05:25.205Z"
 }

--- a/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
+++ b/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
@@ -33,6 +33,7 @@ import { logger } from '@/utils/logger'
 import {
   pricingModelsRouteConfigs,
   getDefaultPricingModelRouteConfig,
+  setupPricingModelRouteConfig,
 } from '@/server/routers/pricingModelsRouter'
 import {
   paymentsRouteConfigs,
@@ -91,6 +92,7 @@ const arrayRoutes: Record<string, RouteConfig> = routeConfigs.reduce(
 
 const routes: Record<string, RouteConfig> = {
   ...getDefaultPricingModelRouteConfig,
+  ...setupPricingModelRouteConfig,
   ...refundPaymentRouteConfig,
   ...customerBillingRouteConfig,
   ...discountsRouteConfigs,

--- a/platform/flowglad-next/src/constants/defaultPlanConfig.ts
+++ b/platform/flowglad-next/src/constants/defaultPlanConfig.ts
@@ -1,0 +1,22 @@
+import { PriceType, IntervalUnit } from '@/types'
+
+export const createDefaultProductConfig = () => ({
+  name: 'Free Plan',
+  slug: 'free',
+  default: true,
+})
+
+export const createDefaultPriceConfig = () => ({
+  name: 'Free Plan',
+  slug: 'free',
+  unitPrice: 0,
+  isDefault: true,
+  type: PriceType.Subscription,
+  intervalCount: 1,
+  intervalUnit: IntervalUnit.Month,
+})
+
+export const createDefaultPlanConfig = () => ({
+  product: createDefaultProductConfig(),
+  price: createDefaultPriceConfig(),
+})

--- a/platform/flowglad-next/src/db/schema/prices.ts
+++ b/platform/flowglad-next/src/db/schema/prices.ts
@@ -429,6 +429,19 @@ export const pricesClientInsertSchema = z
     singlePaymentPriceClientInsertSchema,
     usagePriceClientInsertSchema,
   ])
+  .refine(
+    (data) => {
+      // Allow 'free' slug only for default prices with zero amount
+      if (data.slug === 'free' && (!data.isDefault || data.unitPrice !== 0)) {
+        return false
+      }
+      return true
+    },
+    {
+      message: "Slug 'free' is reserved for default prices with zero amount only",
+      path: ['slug']
+    }
+  )
   .meta({
     id: 'PricesInsert',
   })

--- a/platform/flowglad-next/src/db/schema/prices.ts
+++ b/platform/flowglad-next/src/db/schema/prices.ts
@@ -431,15 +431,28 @@ export const pricesClientInsertSchema = z
   ])
   .refine(
     (data) => {
-      // Allow 'free' slug only for default prices with zero amount
-      if (data.slug === 'free' && (!data.isDefault || data.unitPrice !== 0)) {
+      // Rule 1: 'free' slug is only allowed for default prices
+      if (data.slug === 'free' && !data.isDefault) {
         return false
       }
       return true
     },
     {
-      message: "Slug 'free' is reserved for default prices with zero amount only",
+      message: "Slug 'free' is reserved for default prices only",
       path: ['slug']
+    }
+  )
+  .refine(
+    (data) => {
+      // Rule 2: Default prices must have zero amount
+      if (data.isDefault && data.unitPrice !== 0) {
+        return false
+      }
+      return true
+    },
+    {
+      message: "Default prices must have zero amount",
+      path: ['unitPrice']
     }
   )
   .meta({

--- a/platform/flowglad-next/src/db/schema/products.ts
+++ b/platform/flowglad-next/src/db/schema/products.ts
@@ -162,6 +162,19 @@ export const productsClientSelectSchema = productsSelectSchema
 
 export const productsClientInsertSchema = productsInsertSchema
   .omit(nonClientEditableColumns)
+  .refine(
+    (data) => {
+      // Allow 'free' slug only for default products
+      if (data.slug === 'free' && !data.default) {
+        return false
+      }
+      return true
+    },
+    {
+      message: "Slug 'free' is reserved for default products only",
+      path: ['slug']
+    }
+  )
   .meta({
     id: 'ProductInsert',
   })

--- a/platform/flowglad-next/src/server/routers/pricingModelsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/pricingModelsRouter.ts
@@ -54,6 +54,14 @@ export const getDefaultPricingModelRouteConfig: Record<
   },
 }
 
+export const setupPricingModelRouteConfig: Record<string, RouteConfig> = {
+  'POST /pricing-models/setup': {
+    procedure: 'pricingModels.setup',
+    pattern: new RegExp(`^pricing-models\/setup$`),
+    mapParams: (matches, body) => body,
+  },
+}
+
 const listPricingModelsProcedure = protectedProcedure
   .meta(openApiMetas.LIST)
   .input(pricingModelsPaginatedSelectSchema)

--- a/platform/flowglad-next/src/utils/bookkeeping.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping.ts
@@ -1,4 +1,5 @@
 import * as R from 'ramda'
+import { createDefaultPriceConfig } from '@/constants/defaultPlanConfig'
 import { selectInvoiceLineItemsAndInvoicesByInvoiceWhere } from '@/db/tableMethods/invoiceLineItemMethods'
 import {
   insertCustomer,
@@ -283,50 +284,51 @@ export const createFreePlanPriceInsert = (
   defaultCurrency: CurrencyCode,
   defaultPlanIntervalUnit?: IntervalUnit
 ): Price.Insert => {
+  const config = createDefaultPriceConfig()
   if (defaultPlanIntervalUnit) {
     // Return subscription price when interval unit is provided
     return {
       productId: defaultProduct.id,
-      unitPrice: 0,
-      isDefault: true,
+      unitPrice: config.unitPrice,
+      isDefault: config.isDefault,
       type: PriceType.Subscription,
       intervalUnit: defaultPlanIntervalUnit,
-      intervalCount: 1,
+      intervalCount: config.intervalCount,
       currency: defaultCurrency,
       livemode: defaultProduct.livemode,
       active: true,
-      name: 'Free Plan',
+      name: config.name,
       trialPeriodDays: null,
       setupFeeAmount: null,
       usageEventsPerUnit: null,
       usageMeterId: null,
       externalId: null,
-      slug: 'free',
+      slug: config.slug,
       startsWithCreditTrial: false,
       overagePriceId: null,
-    }
+    } as Price.Insert
   } else {
     // Return single payment price when no interval unit is provided
     return {
       productId: defaultProduct.id,
-      unitPrice: 0,
-      isDefault: true,
+      unitPrice: config.unitPrice,
+      isDefault: config.isDefault,
       type: PriceType.SinglePayment,
       intervalUnit: null,
       intervalCount: null,
       currency: defaultCurrency,
       livemode: defaultProduct.livemode,
       active: true,
-      name: 'Free Plan',
+      name: config.name,
       trialPeriodDays: null,
       setupFeeAmount: null,
       usageEventsPerUnit: null,
       usageMeterId: null,
       externalId: null,
-      slug: 'free',
+      slug: config.slug,
       startsWithCreditTrial: null,
       overagePriceId: null,
-    }
+    } as Price.Insert
   }
 }
 export const createCustomerBookkeeping = async (

--- a/platform/flowglad-next/src/utils/defaultProductValidation.test.ts
+++ b/platform/flowglad-next/src/utils/defaultProductValidation.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { validateDefaultProductSchema } from './defaultProductValidation'
+import { createDefaultPlanConfig } from '@/constants/defaultPlanConfig'
+import { PriceType } from '@/types'
+
+describe('defaultProductValidation', () => {
+  describe('validateDefaultProductSchema', () => {
+    it('should pass validation for valid default product', () => {
+      const product = {
+        name: 'Free Plan',
+        slug: 'free-plan',
+        prices: [{
+          amount: 0,
+          type: PriceType.SinglePayment,
+          slug: 'free',
+          trialDays: 0,
+          setupFee: 0
+        }]
+      }
+      
+      expect(() => validateDefaultProductSchema(product)).not.toThrow()
+    })
+
+    it('should fail for product with non-zero price', () => {
+      const product = {
+        name: 'Paid Plan',
+        slug: 'paid-plan',
+        prices: [{
+          amount: 1000,
+          type: PriceType.SinglePayment,
+          slug: 'paid',
+          trialDays: 0,
+          setupFee: 0
+        }]
+      }
+      
+      expect(() => validateDefaultProductSchema(product)).toThrow('Default products must have zero price')
+    })
+
+    it('should fail for product with multiple prices', () => {
+      const product = {
+        name: 'Multi Price Plan',
+        slug: 'multi-price',
+        prices: [
+          { amount: 0, type: PriceType.SinglePayment, slug: 'free', trialDays: 0, setupFee: 0 },
+          { amount: 1000, type: PriceType.SinglePayment, slug: 'paid', trialDays: 0, setupFee: 0 }
+        ]
+      }
+      
+      expect(() => validateDefaultProductSchema(product)).toThrow('Default products must have exactly one price')
+    })
+
+    it('should fail for product with trial days', () => {
+      const product = {
+        name: 'Trial Plan',
+        slug: 'trial-plan',
+        prices: [{
+          amount: 0,
+          type: PriceType.SinglePayment,
+          slug: 'trial',
+          trialDays: 7,
+          setupFee: 0
+        }]
+      }
+      
+      expect(() => validateDefaultProductSchema(product)).toThrow('Default products cannot have trials')
+    })
+
+    it('should fail for product with setup fee', () => {
+      const product = {
+        name: 'Setup Fee Plan',
+        slug: 'setup-fee-plan',
+        prices: [{
+          amount: 0,
+          type: PriceType.SinglePayment,
+          slug: 'setup-fee',
+          trialDays: 0,
+          setupFee: 500
+        }]
+      }
+      
+      expect(() => validateDefaultProductSchema(product)).toThrow('Default products cannot have setup fees')
+    })
+
+    it('should fail for product with reserved slug', () => {
+      const product = {
+        name: 'Free Plan',
+        slug: 'free',
+        prices: [{
+          amount: 0,
+          type: PriceType.SinglePayment,
+          slug: 'free',
+          trialDays: 0,
+          setupFee: 0
+        }]
+      }
+      
+      expect(() => validateDefaultProductSchema(product)).toThrow("Slug 'free' is reserved for auto-generated default plans")
+    })
+  })
+
+  describe('createDefaultPlanConfig', () => {
+    it('should create valid default plan config', () => {
+      const config = createDefaultPlanConfig()
+      
+      expect(config.product.name).toBe('Free Plan')
+      expect(config.product.slug).toBe('free')
+      expect(config.product.default).toBe(true)
+      
+      expect(config.price.name).toBe('Free Plan')
+      expect(config.price.slug).toBe('free')
+      expect(config.price.unitPrice).toBe(0)
+      expect(config.price.isDefault).toBe(true)
+      expect(config.price.type).toBe(PriceType.Subscription)
+      expect(config.price.intervalCount).toBe(1)
+    })
+  })
+})

--- a/platform/flowglad-next/src/utils/pricingModels/setupSchemas.test.ts
+++ b/platform/flowglad-next/src/utils/pricingModels/setupSchemas.test.ts
@@ -43,7 +43,7 @@ describe('setupPricingModelSchema', () => {
           },
           prices: [
             {
-              name: null,
+              name: 'Test Price',
               intervalCount: 1,
               type: PriceType.Subscription,
               isDefault: false,
@@ -149,7 +149,7 @@ describe('validateSetupPricingModelInput', () => {
               intervalCount: 1,
               unitPrice: 100,
               isDefault: false,
-              name: null,
+              name: 'Test Price',
               usageMeterId: null,
               trialPeriodDays: null,
               setupFeeAmount: null,
@@ -164,7 +164,7 @@ describe('validateSetupPricingModelInput', () => {
               usageMeterSlug: 'm1',
               unitPrice: 10,
               isDefault: false,
-              name: null,
+              name: 'Test Price',
               intervalUnit: IntervalUnit.Month,
               intervalCount: 1,
               trialPeriodDays: null,
@@ -190,7 +190,7 @@ describe('validateSetupPricingModelInput', () => {
       features: [
         {
           type: FeatureType.Toggle,
-          name: '',
+          name: 'Test Product',
           description: '',
           livemode: false,
           slug: 'dup',
@@ -198,7 +198,7 @@ describe('validateSetupPricingModelInput', () => {
         },
         {
           type: FeatureType.Toggle,
-          name: '',
+          name: 'Test Product',
           description: '',
           livemode: false,
           slug: 'dup',
@@ -236,7 +236,7 @@ describe('validateSetupPricingModelInput', () => {
       features: [
         {
           type: FeatureType.Toggle,
-          name: '',
+          name: 'Test Product',
           description: '',
           livemode: false,
           slug: 'f1',
@@ -247,7 +247,7 @@ describe('validateSetupPricingModelInput', () => {
       products: [
         {
           product: {
-            name: '',
+            name: 'Test Product',
             default: false,
             description: '',
             slug: 'p',
@@ -274,7 +274,7 @@ describe('validateSetupPricingModelInput', () => {
       features: [
         {
           type: FeatureType.UsageCreditGrant,
-          name: '',
+          name: 'Test Product',
           description: '',
           livemode: false,
           slug: 'fg',
@@ -288,7 +288,7 @@ describe('validateSetupPricingModelInput', () => {
       products: [
         {
           product: {
-            name: '',
+            name: 'Test Product',
             default: false,
             description: '',
             slug: 'p',
@@ -317,7 +317,7 @@ describe('validateSetupPricingModelInput', () => {
       products: [
         {
           product: {
-            name: '',
+            name: 'Test Product',
             default: false,
             description: '',
             slug: 'p',
@@ -332,7 +332,7 @@ describe('validateSetupPricingModelInput', () => {
             {
               type: PriceType.Subscription,
               isDefault: false,
-              name: null,
+              name: 'Test Price',
               usageMeterId: null,
               trialPeriodDays: null,
               setupFeeAmount: null,
@@ -350,7 +350,7 @@ describe('validateSetupPricingModelInput', () => {
       ],
     }
     expect(() => validateSetupPricingModelInput(input)).toThrowError(
-      /Price slug is required/
+      /Field is required/
     )
   })
 
@@ -363,7 +363,7 @@ describe('validateSetupPricingModelInput', () => {
       products: [
         {
           product: {
-            name: '',
+            name: 'Test Product',
             default: false,
             description: '',
             slug: 'p',
@@ -379,7 +379,7 @@ describe('validateSetupPricingModelInput', () => {
               type: PriceType.Usage,
               slug: 'u1',
               isDefault: false,
-              name: null,
+              name: 'Test Price',
               trialPeriodDays: null,
               setupFeeAmount: null,
               overagePriceId: null,
@@ -409,7 +409,7 @@ describe('validateSetupPricingModelInput', () => {
       products: [
         {
           product: {
-            name: '',
+            name: 'Test Product',
             default: false,
             description: '',
             slug: 'p',
@@ -426,7 +426,7 @@ describe('validateSetupPricingModelInput', () => {
               slug: 'u1',
               usageMeterSlug: 'nope',
               isDefault: false,
-              name: null,
+              name: 'Test Price',
               trialPeriodDays: null,
               setupFeeAmount: null,
               usageEventsPerUnit: 1,
@@ -455,7 +455,7 @@ describe('validateSetupPricingModelInput', () => {
       products: [
         {
           product: {
-            name: '',
+            name: 'Test Product',
             default: false,
             description: '',
             slug: 'p1',
@@ -471,7 +471,7 @@ describe('validateSetupPricingModelInput', () => {
               type: PriceType.Subscription,
               slug: 'dup',
               isDefault: false,
-              name: null,
+              name: 'Test Price',
               usageMeterId: null,
               trialPeriodDays: null,
               setupFeeAmount: null,
@@ -487,7 +487,7 @@ describe('validateSetupPricingModelInput', () => {
         },
         {
           product: {
-            name: '',
+            name: 'Test Product',
             default: false,
             description: '',
             slug: 'p2',
@@ -503,7 +503,7 @@ describe('validateSetupPricingModelInput', () => {
               type: PriceType.Subscription,
               slug: 'dup',
               isDefault: false,
-              name: null,
+              name: 'Test Price',
               usageMeterId: null,
               trialPeriodDays: null,
               setupFeeAmount: null,

--- a/platform/flowglad-next/src/utils/pricingModels/setupTransaction.test.ts
+++ b/platform/flowglad-next/src/utils/pricingModels/setupTransaction.test.ts
@@ -15,17 +15,20 @@ import {
   FeatureUsageGrantFrequency,
   PriceType,
   IntervalUnit,
+  CurrencyCode,
 } from '@/types'
 import type { Organization } from '@/db/schema/organizations'
 
 let organization: Organization.Record
 
 beforeEach(async () => {
+  // Set up a fresh organization for each test to ensure isolation
   const orgData = await setupOrg()
   organization = orgData.organization
 })
 
 afterEach(async () => {
+  // Clean up the organization and all related data after each test
   if (organization) {
     await teardownOrg({ organizationId: organization.id })
   }
@@ -186,7 +189,7 @@ describe('setupPricingModelTransaction (integration)', () => {
               type: PriceType.Subscription,
               slug: 'ps',
               isDefault: false,
-              name: null,
+                name: 'Test Price',
               usageMeterId: null,
               trialPeriodDays: null,
               setupFeeAmount: null,
@@ -202,7 +205,7 @@ describe('setupPricingModelTransaction (integration)', () => {
               type: PriceType.Usage,
               slug: 'pu',
               isDefault: false,
-              name: null,
+                name: 'Test Price',
               usageMeterSlug: 'um',
               trialPeriodDays: null,
               setupFeeAmount: null,
@@ -242,21 +245,24 @@ describe('setupPricingModelTransaction (integration)', () => {
       input.features.map((f) => f.slug)
     )
 
-    // Products
-    expect(result.products).toHaveLength(input.products.length)
-    expect(result.products.map((p) => p.slug)).toEqual(
-      input.products.map((p) => p.product.slug)
-    )
+    // Products - should have user products + auto-generated default product
+    expect(result.products).toHaveLength(input.products.length + 1) // +1 for auto-generated default
+    const userProductSlugs = input.products.map((p) => p.product.slug)
+    const resultProductSlugs = result.products.map((p) => p.slug)
+    expect(resultProductSlugs).toEqual(expect.arrayContaining(userProductSlugs))
+    expect(resultProductSlugs).toContain('free') // Auto-generated default product
     expect(
       result.products.every((p) => typeof p.externalId === 'string')
     ).toBe(true)
 
-    // Prices
+    // Prices - should have user prices + auto-generated default price
     const allPriceSlugs = input.products.flatMap((p) =>
       p.prices.map((pr) => pr.slug!)
     )
-    expect(result.prices).toHaveLength(allPriceSlugs.length)
-    expect(result.prices.map((pr) => pr.slug)).toEqual(allPriceSlugs)
+    expect(result.prices).toHaveLength(allPriceSlugs.length + 1) // +1 for auto-generated default
+    const resultPriceSlugs = result.prices.map((pr) => pr.slug)
+    expect(resultPriceSlugs).toEqual(expect.arrayContaining(allPriceSlugs))
+    expect(resultPriceSlugs).toContain('free') // Auto-generated default price
 
     // ProductFeatures
     const totalFeatures = input.products.flatMap((p) => p.features)
@@ -266,6 +272,473 @@ describe('setupPricingModelTransaction (integration)', () => {
     result.productFeatures.forEach((pf) => {
       expect(productIds).toContain(pf.productId)
       expect(featureIds).toContain(pf.featureId)
+    })
+  })
+
+  describe('Default Product Auto-Generation', () => {
+    it('should auto-generate default free plan when no default product provided', async () => {
+      const input: SetupPricingModelInput = {
+        name: 'Test Pricing Model',
+        isDefault: false,
+        usageMeters: [],
+        features: [],
+        products: [], // No products provided
+      }
+
+      const result = await adminTransaction(async ({ transaction }) =>
+        setupPricingModelTransaction(
+          { input, organizationId: organization.id, livemode: false },
+          transaction
+        )
+      )
+
+      // Should have auto-generated default product
+      expect(result.products).toHaveLength(1)
+      const defaultProduct = result.products[0]
+      expect(defaultProduct.name).toEqual('Free Plan')
+      expect(defaultProduct.slug).toEqual('free')
+      expect(defaultProduct.default).toBe(true)
+
+      // Should have auto-generated default price
+      expect(result.prices).toHaveLength(1)
+      const defaultPrice = result.prices[0]
+      expect(defaultPrice.name).toEqual('Free Plan')
+      expect(defaultPrice.slug).toEqual('free')
+      expect(defaultPrice.unitPrice).toEqual(0)
+      expect(defaultPrice.isDefault).toBe(true)
+      expect(defaultPrice.type).toEqual(PriceType.Subscription)
+      expect(defaultPrice.intervalUnit).toEqual(IntervalUnit.Month)
+      expect(defaultPrice.intervalCount).toEqual(1)
+    })
+
+    it('should use organization default currency for auto-generated price', async () => {
+      const input: SetupPricingModelInput = {
+        name: 'Test Pricing Model',
+        isDefault: false,
+        usageMeters: [],
+        features: [],
+        products: [],
+      }
+
+      const result = await adminTransaction(async ({ transaction }) =>
+        setupPricingModelTransaction(
+          { input, organizationId: organization.id, livemode: false },
+          transaction
+        )
+      )
+
+      const defaultPrice = result.prices[0]
+      expect(defaultPrice.currency).toEqual(organization.defaultCurrency)
+    })
+  })
+
+  describe('Default Product Validation', () => {
+    it('should accept valid user-provided default product', async () => {
+      const input: SetupPricingModelInput = {
+        name: 'Test Pricing Model',
+        isDefault: false,
+        usageMeters: [],
+        features: [],
+        products: [
+          {
+            product: {
+              name: 'Custom Free Plan',
+              default: true,
+              description: 'Custom free plan',
+              slug: 'custom-free',
+              active: true,
+              imageURL: null,
+              displayFeatures: null,
+              singularQuantityLabel: null,
+              pluralQuantityLabel: null,
+            },
+            prices: [
+              {
+                type: PriceType.Subscription,
+                slug: 'custom-free-price',
+                isDefault: true,
+                name: 'Custom Free',
+                usageMeterId: null,
+                trialPeriodDays: null,
+                setupFeeAmount: null,
+                usageEventsPerUnit: null,
+                overagePriceId: null,
+                active: true,
+                intervalUnit: IntervalUnit.Month,
+                intervalCount: 1,
+                unitPrice: 0, // Zero price
+                startsWithCreditTrial: false,
+              },
+            ],
+            features: [],
+          },
+        ],
+      }
+
+      const result = await adminTransaction(async ({ transaction }) =>
+        setupPricingModelTransaction(
+          { input, organizationId: organization.id, livemode: false },
+          transaction
+        )
+      )
+
+      // Should have user-provided default product, no auto-generated one
+      expect(result.products).toHaveLength(1)
+      expect(result.products[0].name).toEqual('Custom Free Plan')
+      expect(result.products[0].default).toBe(true)
+    })
+
+    it('should reject multiple default products', async () => {
+      const input: SetupPricingModelInput = {
+        name: 'Test Pricing Model',
+        isDefault: false,
+        usageMeters: [],
+        features: [],
+        products: [
+          {
+            product: {
+              name: 'Default Product 1',
+              default: true,
+              description: '',
+              slug: 'default-1',
+              active: true,
+              imageURL: null,
+              displayFeatures: null,
+              singularQuantityLabel: null,
+              pluralQuantityLabel: null,
+            },
+            prices: [],
+            features: [],
+          },
+          {
+            product: {
+              name: 'Default Product 2',
+              default: true,
+              description: '',
+              slug: 'default-2',
+              active: true,
+              imageURL: null,
+              displayFeatures: null,
+              singularQuantityLabel: null,
+              pluralQuantityLabel: null,
+            },
+            prices: [],
+            features: [],
+          },
+        ],
+      }
+
+      await expect(
+        adminTransaction(async ({ transaction }) =>
+          setupPricingModelTransaction(
+            { input, organizationId: organization.id, livemode: false },
+            transaction
+          )
+        )
+      ).rejects.toThrow('Multiple default products not allowed')
+    })
+
+    it('should reject default product with non-zero price', async () => {
+      const input: SetupPricingModelInput = {
+        name: 'Test Pricing Model',
+        isDefault: false,
+        usageMeters: [],
+        features: [],
+        products: [
+          {
+            product: {
+              name: 'Invalid Default',
+              default: true,
+              description: '',
+              slug: 'invalid-default',
+              active: true,
+              imageURL: null,
+              displayFeatures: null,
+              singularQuantityLabel: null,
+              pluralQuantityLabel: null,
+            },
+            prices: [
+              {
+                type: PriceType.Subscription,
+                slug: 'invalid-price',
+                isDefault: true,
+                name: 'Invalid Price',
+                usageMeterId: null,
+                trialPeriodDays: null,
+                setupFeeAmount: null,
+                usageEventsPerUnit: null,
+                overagePriceId: null,
+                active: true,
+                intervalUnit: IntervalUnit.Month,
+                intervalCount: 1,
+                unitPrice: 100, // Non-zero price - should fail
+                startsWithCreditTrial: false,
+              },
+            ],
+            features: [],
+          },
+        ],
+      }
+
+      await expect(
+        adminTransaction(async ({ transaction }) =>
+          setupPricingModelTransaction(
+            { input, organizationId: organization.id, livemode: false },
+            transaction
+          )
+        )
+      ).rejects.toThrow('Default products must have zero price')
+    })
+
+    it('should reject default product with trials', async () => {
+      const input: SetupPricingModelInput = {
+        name: 'Test Pricing Model',
+        isDefault: false,
+        usageMeters: [],
+        features: [],
+        products: [
+          {
+            product: {
+              name: 'Invalid Default',
+              default: true,
+              description: '',
+              slug: 'invalid-default',
+              active: true,
+              imageURL: null,
+              displayFeatures: null,
+              singularQuantityLabel: null,
+              pluralQuantityLabel: null,
+            },
+            prices: [
+              {
+                type: PriceType.Subscription,
+                slug: 'invalid-price',
+                isDefault: true,
+                name: 'Invalid Price',
+                usageMeterId: null,
+                trialPeriodDays: 7, // Trial days - should fail
+                setupFeeAmount: null,
+                usageEventsPerUnit: null,
+                overagePriceId: null,
+                active: true,
+                intervalUnit: IntervalUnit.Month,
+                intervalCount: 1,
+                unitPrice: 0,
+                startsWithCreditTrial: false,
+              },
+            ],
+            features: [],
+          },
+        ],
+      }
+
+      await expect(
+        adminTransaction(async ({ transaction }) =>
+          setupPricingModelTransaction(
+            { input, organizationId: organization.id, livemode: false },
+            transaction
+          )
+        )
+      ).rejects.toThrow('Default products cannot have trials')
+    })
+
+    it('should reject default product with setup fees', async () => {
+      const input: SetupPricingModelInput = {
+        name: 'Test Pricing Model',
+        isDefault: false,
+        usageMeters: [],
+        features: [],
+        products: [
+          {
+            product: {
+              name: 'Invalid Default',
+              default: true,
+              description: '',
+              slug: 'invalid-default',
+              active: true,
+              imageURL: null,
+              displayFeatures: null,
+              singularQuantityLabel: null,
+              pluralQuantityLabel: null,
+            },
+            prices: [
+              {
+                type: PriceType.Subscription,
+                slug: 'invalid-price',
+                isDefault: true,
+                name: 'Invalid Price',
+                usageMeterId: null,
+                trialPeriodDays: null,
+                setupFeeAmount: 50, // Setup fee - should fail
+                usageEventsPerUnit: null,
+                overagePriceId: null,
+                active: true,
+                intervalUnit: IntervalUnit.Month,
+                intervalCount: 1,
+                unitPrice: 0,
+                startsWithCreditTrial: false,
+              },
+            ],
+            features: [],
+          },
+        ],
+      }
+
+      await expect(
+        adminTransaction(async ({ transaction }) =>
+          setupPricingModelTransaction(
+            { input, organizationId: organization.id, livemode: false },
+            transaction
+          )
+        )
+      ).rejects.toThrow('Default products cannot have setup fees')
+    })
+
+    it('should reject default product using reserved "free" slug', async () => {
+      const input: SetupPricingModelInput = {
+        name: 'Test Pricing Model',
+        isDefault: false,
+        usageMeters: [],
+        features: [],
+        products: [
+          {
+            product: {
+              name: 'Invalid Default',
+              default: true,
+              description: '',
+              slug: 'free', // Reserved slug - should fail
+              active: true,
+              imageURL: null,
+              displayFeatures: null,
+              singularQuantityLabel: null,
+              pluralQuantityLabel: null,
+            },
+            prices: [
+              {
+                type: PriceType.Subscription,
+                slug: 'free-price',
+                isDefault: true,
+                name: 'Free Price',
+                usageMeterId: null,
+                trialPeriodDays: null,
+                setupFeeAmount: null,
+                usageEventsPerUnit: null,
+                overagePriceId: null,
+                active: true,
+                intervalUnit: IntervalUnit.Month,
+                intervalCount: 1,
+                unitPrice: 0,
+                startsWithCreditTrial: false,
+              },
+            ],
+            features: [],
+          },
+        ],
+      }
+
+      await expect(
+        adminTransaction(async ({ transaction }) =>
+          setupPricingModelTransaction(
+            { input, organizationId: organization.id, livemode: false },
+            transaction
+          )
+        )
+      ).rejects.toThrow("Slug 'free' is reserved for auto-generated default plans")
+    })
+  })
+
+  describe('Input Validation', () => {
+
+    it('should reject input with names exceeding length limits', async () => {
+      const longName = 'A'.repeat(300) // Exceeds 255 character limit
+      const input: SetupPricingModelInput = {
+        name: longName,
+        isDefault: false,
+        usageMeters: [],
+        features: [],
+        products: [],
+      }
+
+      await expect(
+        adminTransaction(async ({ transaction }) =>
+          setupPricingModelTransaction(
+            { input, organizationId: organization.id, livemode: false },
+            transaction
+          )
+        )
+      ).rejects.toThrow('Field must be less than 255 characters')
+    })
+
+    it('should reject input with empty name', async () => {
+      const input: SetupPricingModelInput = {
+        name: '',
+        isDefault: false,
+        usageMeters: [],
+        features: [],
+        products: [],
+      }
+
+      await expect(
+        adminTransaction(async ({ transaction }) =>
+          setupPricingModelTransaction(
+            { input, organizationId: organization.id, livemode: false },
+            transaction
+          )
+        )
+      ).rejects.toThrow('Field is required')
+    })
+
+    it('should reject input with invalid currency codes', async () => {
+      const input: SetupPricingModelInput = {
+        name: 'Test Pricing Model',
+        isDefault: false,
+        usageMeters: [],
+        features: [],
+        products: [
+          {
+            product: {
+              name: 'Test Product',
+              default: false,
+              description: '',
+              slug: 'test-product',
+              active: true,
+              imageURL: null,
+              displayFeatures: null,
+              singularQuantityLabel: null,
+              pluralQuantityLabel: null,
+            },
+            prices: [
+              {
+                type: PriceType.Subscription,
+                slug: 'test-price',
+                isDefault: false,
+                name: 'Test Price',
+                usageMeterId: null,
+                trialPeriodDays: null,
+                setupFeeAmount: null,
+                usageEventsPerUnit: null,
+                overagePriceId: null,
+                active: true,
+                intervalUnit: IntervalUnit.Month,
+                intervalCount: 1,
+                unitPrice: 100,
+                startsWithCreditTrial: false,
+                currency: 'INVALID_CURRENCY' as any, // Invalid currency
+              },
+            ],
+            features: [],
+          },
+        ],
+      }
+
+      await expect(
+        adminTransaction(async ({ transaction }) =>
+          setupPricingModelTransaction(
+            { input, organizationId: organization.id, livemode: false },
+            transaction
+          )
+        )
+      ).rejects.toThrow('Invalid currency code')
     })
   })
 })

--- a/platform/flowglad-next/src/utils/pricingModels/setupTransaction.ts
+++ b/platform/flowglad-next/src/utils/pricingModels/setupTransaction.ts
@@ -19,6 +19,9 @@ import { hashData } from '@/utils/backendCore'
 import { UsageMeter } from '@/db/schema/usageMeters'
 import { selectOrganizationById } from '@/db/tableMethods/organizationMethods'
 import { ProductFeature } from '@/db/schema/productFeatures'
+import { validateDefaultProductSchema } from '@/utils/defaultProductValidation'
+import { IntervalUnit } from '@/types'
+import { createDefaultPlanConfig } from '@/constants/defaultPlanConfig'
 
 export const externalIdFromProductData = (
   product: SetupPricingModelProductInput,
@@ -40,6 +43,29 @@ export const setupPricingModelTransaction = async (
   transaction: DbTransaction
 ) => {
   const input = validateSetupPricingModelInput(rawInput)
+  
+  // Check for multiple default products
+  const defaultProducts = input.products.filter(p => p.product.default)
+  if (defaultProducts.length > 1) {
+    throw new Error("Multiple default products not allowed")
+  }
+  
+  // Validate single default product if provided
+  if (defaultProducts.length === 1) {
+    const defaultProduct = defaultProducts[0]
+    validateDefaultProductSchema({
+      name: defaultProduct.product.name,
+      slug: defaultProduct.product.slug || undefined,
+      prices: defaultProduct.prices.map(p => ({
+        amount: p.unitPrice,
+        type: p.type,
+        slug: p.slug || undefined,
+        trialDays: p.trialPeriodDays || undefined,
+        setupFee: p.setupFeeAmount || undefined
+      }))
+    })
+  }
+  
   const pricingModelInsert: PricingModel.Insert = {
     name: input.name,
     livemode,
@@ -150,34 +176,140 @@ export const setupPricingModelTransaction = async (
         throw new Error(`Product ${product.product.name} not found`)
       }
       return product.prices.map((price) => {
-        if (price.type === PriceType.Usage) {
-          const usageMeterId = usageMetersBySlug.get(
-            price.usageMeterSlug
-          )?.id
-          if (!usageMeterId) {
-            throw new Error(
-              `Usage meter ${price.usageMeterSlug} not found`
-            )
+        switch (price.type) {
+          case PriceType.Usage: {
+            const usageMeterId = usageMetersBySlug.get(
+              price.usageMeterSlug
+            )?.id
+            if (!usageMeterId) {
+              throw new Error(
+                `Usage meter ${price.usageMeterSlug} not found`
+              )
+            }
+            return {
+              type: PriceType.Usage,
+              name: price.name ?? null,
+              slug: price.slug ?? null,
+              unitPrice: price.unitPrice,
+              isDefault: price.isDefault,
+              active: price.active,
+              intervalCount: price.intervalCount,
+              intervalUnit: price.intervalUnit,
+              trialPeriodDays: price.trialPeriodDays,
+              setupFeeAmount: price.setupFeeAmount,
+              usageEventsPerUnit: price.usageEventsPerUnit,
+              overagePriceId: price.overagePriceId,
+              startsWithCreditTrial: price.startsWithCreditTrial,
+              currency: organization.defaultCurrency,
+              productId,
+              livemode,
+              externalId: null,
+              usageMeterId,
+            } as Price.Insert
           }
-          return {
-            ...price,
-            currency: organization.defaultCurrency,
-            productId,
-            livemode,
-            externalId: null,
-            usageMeterId,
-          }
-        }
-        return {
-          ...price,
-          currency: organization.defaultCurrency,
-          productId,
-          livemode,
-          externalId: null,
+          
+          case PriceType.Subscription:
+            return {
+              type: PriceType.Subscription,
+              name: price.name ?? null,
+              slug: price.slug ?? null,
+              unitPrice: price.unitPrice,
+              isDefault: price.isDefault,
+              active: price.active,
+              intervalCount: price.intervalCount,
+              intervalUnit: price.intervalUnit,
+              trialPeriodDays: price.trialPeriodDays,
+              setupFeeAmount: price.setupFeeAmount,
+              usageEventsPerUnit: price.usageEventsPerUnit,
+              overagePriceId: price.overagePriceId,
+              startsWithCreditTrial: price.startsWithCreditTrial,
+              currency: organization.defaultCurrency,
+              productId,
+              livemode,
+              externalId: null,
+              usageMeterId: null,
+            } as Price.Insert
+          
+          case PriceType.SinglePayment:
+            return {
+              type: PriceType.SinglePayment,
+              name: price.name ?? null,
+              slug: price.slug ?? null,
+              unitPrice: price.unitPrice,
+              isDefault: price.isDefault,
+              active: price.active,
+              intervalCount: null,
+              intervalUnit: null,
+              trialPeriodDays: price.trialPeriodDays,
+              setupFeeAmount: price.setupFeeAmount,
+              usageEventsPerUnit: price.usageEventsPerUnit,
+              overagePriceId: null,
+              startsWithCreditTrial: null,
+              currency: organization.defaultCurrency,
+              productId,
+              livemode,
+              externalId: null,
+              usageMeterId: null,
+            } as Price.Insert
+
+            default:
+              throw new Error(`Unknown or unhandled price type on price: ${price}`)
         }
       })
     }
   )
+
+  // Auto-generate default plan if none provided
+  if (defaultProducts.length === 0) {
+    const defaultPlanConfig = createDefaultPlanConfig()
+    
+    // Create the default product
+    const defaultProductInsert: Product.Insert = {
+      ...defaultPlanConfig.product,
+      pricingModelId: pricingModel.id,
+      organizationId,
+      livemode,
+      externalId: hashData(JSON.stringify({ name: 'Free Plan', pricingModelId: pricingModel.id })),
+      displayFeatures: null,
+      description: null,
+      imageURL: null,
+      active: true,
+      singularQuantityLabel: null,
+      pluralQuantityLabel: null
+    }
+    
+    const defaultProductsResult = await bulkInsertProducts([defaultProductInsert], transaction)
+    const defaultProduct = defaultProductsResult[0]
+    
+    // Add the default product to our products array
+    products.push(defaultProduct)
+    productsByExternalId.set(defaultProduct.externalId, defaultProduct)
+    
+    // Create the default price
+    const defaultPriceInsert: Price.Insert = {
+      type: defaultPlanConfig.price.type,
+      name: defaultPlanConfig.price.name,
+      slug: defaultPlanConfig.price.slug,
+      unitPrice: defaultPlanConfig.price.unitPrice,
+      isDefault: defaultPlanConfig.price.isDefault,
+      active: true,
+      intervalCount: defaultPlanConfig.price.intervalCount,
+      intervalUnit: defaultPlanConfig.price.intervalUnit,
+      trialPeriodDays: null,
+      setupFeeAmount: null,
+      usageEventsPerUnit: null,
+      overagePriceId: null,
+      startsWithCreditTrial: null,
+      currency: organization.defaultCurrency,
+      productId: defaultProduct.id,
+      livemode,
+      externalId: null,
+      usageMeterId: null
+    } as Price.Insert
+    
+    // Add default price to priceInserts
+    priceInserts.push(defaultPriceInsert)
+  }
 
   const prices = await bulkInsertPrices(priceInserts, transaction)
   const featuresBySlug = new Map(


### PR DESCRIPTION
## What Does this PR Do?

### Database Schema Updates
- **Products Schema**: Added validation to reserve 'free' slug for default products only
- **Prices Schema**: Added validation to reserve 'free' slug for default prices

### API & Configuration
- **New Route**: Added `POST /pricing-models/setup` endpoint configuration
- **Default Plan Config**: Created centralized default plan configuration constants
- **Bookkeeping Updates**: Modified `createFreePlanPriceInsert` to use centralized configuration instead of hardcoded values

### Input Validation & Security
- **Schema Validation**: Added comprehensive input validation with sanitized string schemas
- **Field Requirements**: Made name fields required with 255 character limits
- **Currency Validation**: Added proper currency code validation

### Default Product Auto-Generation
- **Auto-Creation Logic**: Automatically creates default "Free Plan" when none provided
- **Validation Rules**: Added strict validation for default products:
  - Must have exactly one price with zero amount
  - Cannot have trials or setup fees
  - Cannot use reserved 'free' slug for user-provided products
  - Prevents multiple default products

### Transaction Processing
- **Enhanced Setup**: Updated `setupPricingModelTransaction` for default product auto-generation
- **Price Type Handling**: Improved price creation with proper type-specific handling
- **Error Handling**: Added comprehensive validation and error messages

### Testing
- **Comprehensive Coverage**: Added extensive test cases for:
  - Default product auto-generation scenarios
  - Validation of user-provided default products
  - Input validation (name length, currency codes, required fields)
  - Error cases (multiple defaults, non-zero prices, trials, setup fees, reserved slugs)
