### PR TITLE
add configurable env var for local development emailing

### DIFF
--- a/platform/flowglad-next/.env.example
+++ b/platform/flowglad-next/.env.example
@@ -3,3 +3,5 @@ STRIPE_TEST_MODE_SECRET_KEY=sk_test_stub
 UNKEY_ROOT_KEY=unkey_root_stub
 UNKEY_API_ID=api_stub
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+DEV_EMAIL_REDIRECT=your-email@domain.com #This is the email address that all emails will be sent to in local development

--- a/platform/flowglad-next/.env_user
+++ b/platform/flowglad-next/.env_user
@@ -1,1 +1,9 @@
-LOCAL_USER=AGREE
+# LOCAL_USER determines which Flowglad developer's environment variables to use
+# This affects which prefixed variables get stripped (e.g., BROOKS_DEV_EMAIL_REDIRECT -> DEV_EMAIL_REDIRECT)
+# To change it, update this value to your name (e.g., LOCAL_USER=BROOKS)
+
+# Note: This file is for Flowglad core developers only
+# External contributors should copy .env.example to .env.local and configure
+# their own environment variables instead of using this user-based system
+
+LOCAL_USER=BROOKS

--- a/platform/flowglad-next/src/scripts/set_local_user.sh
+++ b/platform/flowglad-next/src/scripts/set_local_user.sh
@@ -32,6 +32,7 @@ local_user=$(grep '^LOCAL_USER=' "$src_env_file" | cut -d '=' -f2)
 # Mac OS's implementation of sed forces us to write to a tmp file. This is compatible across all Linux systems
 sed -e "s/${local_user}_TRIGGER_API_KEY/TRIGGER_API_KEY/" \
     -e "s/${local_user}_TRIGGER_SECRET_KEY/TRIGGER_SECRET_KEY/" \
+    -e "s/${local_user}_DEV_EMAIL_REDIRECT/DEV_EMAIL_REDIRECT/" \
     "$target_env_file" > tmp_file
 
 # Overwrite the target env file with the modified content

--- a/platform/flowglad-next/src/utils/core.ts
+++ b/platform/flowglad-next/src/utils/core.ts
@@ -19,8 +19,9 @@ import { CurrencyCode, Nullish, StripePriceMode } from '@/types'
 
 export const envVariable = (key: string) => process.env[key] || ''
 
-export const localizedEnvVariable = (key: string) =>
-  envVariable(`${envVariable('LOCAL_USER')}_${key}`)
+//This would make self hosting more complicated to implement, we currently only use stripping user suffix from env vars on vercel:env-pull post processing step.
+// export const localizedEnvVariable = (key: string) =>
+//   envVariable(`${envVariable('LOCAL_USER')}_${key}`)
 
 export const safeUrl = (path: string, urlBase: string) => {
   const protocol = urlBase.match('localhost') ? 'http' : 'https'
@@ -509,7 +510,7 @@ export const core = {
   fetch: middlewareFetch,
   post,
   sliceIntoChunks,
-  localizedEnvVariable,
+  // localizedEnvVariable,
   formatDate,
   safeContactList,
   devPrefixString,

--- a/platform/flowglad-next/src/utils/email.ts
+++ b/platform/flowglad-next/src/utils/email.ts
@@ -45,7 +45,7 @@ export const safeSend = (
 }
 
 const safeTo = (email: string) =>
-  core.IS_PROD ? email : 'agree.ahmed@flowglad.com'
+  core.IS_PROD ? email : core.envVariable('DEV_EMAIL_REDIRECT') || 'agree.ahmed@flowglad.com'
 
 export const sendReceiptEmail = async (params: {
   to: string[]


### PR DESCRIPTION
## What Does this PR Do?

-add configurable env var for local development emailing
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds DEV_EMAIL_REDIRECT to route all non-prod emails to a single address during local development, ensuring all local emails go to the host’s inbox (FG-109). Updates env examples and tooling to support per-developer overrides.

- New Features
  - Non-prod emails now send to process.env.DEV_EMAIL_REDIRECT; falls back to agree.ahmed@flowglad.com.
  - .env.example documents DEV_EMAIL_REDIRECT.
  - set_local_user.sh maps {LOCAL_USER}_DEV_EMAIL_REDIRECT -> DEV_EMAIL_REDIRECT for user-specific setups.
  - Removed use of localizedEnvVariable in core to simplify env handling.

- Migration
  - Add DEV_EMAIL_REDIRECT to your local env (e.g., .env.local).
  - If using the LOCAL_USER flow, set LOCAL_USER in .env_user and define {YOURNAME}_DEV_EMAIL_REDIRECT.

<!-- End of auto-generated description by cubic. -->

