### PR TITLE
fixed naming mismatch betweemn routes and procedures

### DIFF
--- a/platform/flowglad-next/src/server/routers/productFeaturesRouter.ts
+++ b/platform/flowglad-next/src/server/routers/productFeaturesRouter.ts
@@ -127,7 +127,7 @@ export const expireProductFeature = protectedProcedure
   )
 
 export const productFeaturesRouter = router({
-  createOrRestore: createOrRestoreProductFeature,
+  create: createOrRestoreProductFeature,
   list: listProductFeatures,
   get: getProductFeature,
   expire: expireProductFeature,

--- a/platform/flowglad-next/src/server/routers/productsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/productsRouter.ts
@@ -353,7 +353,7 @@ export const productsRouter = router({
   list: listProducts,
   get: getProduct,
   create: createProduct,
-  edit: editProduct,
+  update: editProduct,
   getTableRows,
   getCountsByStatus,
 })


### PR DESCRIPTION
## What Does this PR Do?

-fix create productfeatures route by fixing a naming mismatch
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed name mismatches between routers and procedures. Restores the product features create endpoint and standardizes product update naming (Linear FG-111).

- **Bug Fixes**
  - productFeaturesRouter: expose create route (was createOrRestore) mapped to createOrRestoreProductFeature.
  - productsRouter: rename route edit to update for consistent API naming.

<!-- End of auto-generated description by cubic. -->

