### PR TITLE
Standardize router methods: use 'update' instead of 'edit'

### DIFF
--- a/platform/flowglad-next/src/components/forms/ArchivePriceModal.tsx
+++ b/platform/flowglad-next/src/components/forms/ArchivePriceModal.tsx
@@ -48,7 +48,7 @@ const ArchivePriceModal: React.FC<ArchivePriceModalProps> = ({
   price,
 }) => {
   const router = useRouter()
-  const editPrice = trpc.prices.edit.useMutation()
+  const editPrice = trpc.prices.update.useMutation()
 
   const handleArchive = async () => {
     const data = priceToArchivePriceInput(price)

--- a/platform/flowglad-next/src/components/forms/ArchiveProductModal.tsx
+++ b/platform/flowglad-next/src/components/forms/ArchiveProductModal.tsx
@@ -34,7 +34,7 @@ const ArchiveProductModal: React.FC<ArchiveProductModalProps> = ({
   product,
 }) => {
   const router = useRouter()
-  const editProduct = trpc.products.edit.useMutation()
+  const editProduct = trpc.products.update.useMutation()
 
   const handleArchive = async () => {
     const data: EditProductInput = {

--- a/platform/flowglad-next/src/components/forms/EditPriceModal.tsx
+++ b/platform/flowglad-next/src/components/forms/EditPriceModal.tsx
@@ -25,7 +25,7 @@ const EditPriceModal: React.FC<EditPriceModalProps> = ({
   setIsOpen,
   price,
 }) => {
-  const editPrice = trpc.prices.edit.useMutation()
+  const editPrice = trpc.prices.update.useMutation()
   const editPriceInput: EditPriceInput = {
     id: price.id,
     price,

--- a/platform/flowglad-next/src/components/forms/EditProductModal.tsx
+++ b/platform/flowglad-next/src/components/forms/EditProductModal.tsx
@@ -26,7 +26,7 @@ const EditProductModal: React.FC<EditProductModalProps> = ({
   setIsOpen,
   product,
 }) => {
-  const editProduct = trpc.products.edit.useMutation()
+  const editProduct = trpc.products.update.useMutation()
 
   const { data: pricesData, isLoading: pricesLoading } =
     trpc.prices.list.useQuery({

--- a/platform/flowglad-next/src/components/forms/SetPriceAsDefaultModal.tsx
+++ b/platform/flowglad-next/src/components/forms/SetPriceAsDefaultModal.tsx
@@ -49,7 +49,7 @@ const SetPriceAsDefault: React.FC<SetPriceAsDefaultProps> = ({
   price,
 }) => {
   const router = useRouter()
-  const editPrice = trpc.prices.edit.useMutation()
+  const editPrice = trpc.prices.update.useMutation()
 
   const handleMakeDefault = async () => {
     const data = priceToSetPriceAsDefaultInput(price)

--- a/platform/flowglad-next/src/server/routers/checkoutSessionsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/checkoutSessionsRouter.ts
@@ -12,7 +12,7 @@ import {
   selectCheckoutSessionById,
   selectCheckoutSessions,
   selectCheckoutSessionsPaginated,
-  updateCheckoutSession,
+  updateCheckoutSession as updateCheckoutSessionDb,
   updateCheckoutSessionAutomaticallyUpdateSubscriptions,
   updateCheckoutSessionBillingAddress,
   updateCheckoutSessionCustomerEmail,
@@ -81,7 +81,7 @@ export const createCheckoutSession = protectedProcedure
     )
   )
 
-export const editCheckoutSession = protectedProcedure
+export const updateCheckoutSession = protectedProcedure
   //   .meta(openApiMetas.PUT)
   .input(editCheckoutSessionInputSchema)
   .output(singleCheckoutSessionOutputSchema)
@@ -112,7 +112,7 @@ export const editCheckoutSession = protectedProcedure
           })
         }
 
-        const updatedCheckoutSession = await updateCheckoutSession(
+        const updatedCheckoutSession = await updateCheckoutSessionDb(
           {
             ...checkoutSession,
             ...input.checkoutSession,
@@ -253,7 +253,7 @@ export const setAutomaticallyUpdateSubscriptionsProcedure =
 
 export const checkoutSessionsRouter = router({
   create: createCheckoutSession,
-  edit: editCheckoutSession,
+  update: updateCheckoutSession,
   get: getCheckoutSessionProcedure,
   list: listCheckoutSessionsProcedure,
   getIntentStatus: getIntentStatusProcedure,

--- a/platform/flowglad-next/src/server/routers/pricesRouter.test.ts
+++ b/platform/flowglad-next/src/server/routers/pricesRouter.test.ts
@@ -275,7 +275,7 @@ describe('pricesRouter - Default Price Constraints', () => {
   })
 
   describe('router-level behaviors', () => {
-    it('pricesRouter.edit: throws NOT_FOUND for missing price id', async () => {
+    it('pricesRouter.update: throws NOT_FOUND for missing price id', async () => {
       const { apiKey } = await setupUserAndApiKey({
         organizationId,
         livemode,
@@ -288,7 +288,7 @@ describe('pricesRouter - Default Price Constraints', () => {
         path: '',
       }
       await expect(
-        pricesRouter.createCaller(ctx).edit({
+        pricesRouter.createCaller(ctx).update({
           price: {
             id: 'price_missing_' + core.nanoid(),
             type: PriceType.Subscription,
@@ -297,7 +297,7 @@ describe('pricesRouter - Default Price Constraints', () => {
       ).rejects.toThrow(TRPCError)
     })
 
-    it('productsRouter.edit: enforces cross-product price guard (BAD_REQUEST)', async () => {
+    it('productsRouter.update: enforces cross-product price guard (BAD_REQUEST)', async () => {
       const { apiKey } = await setupUserAndApiKey({
         organizationId,
         livemode,
@@ -357,7 +357,7 @@ describe('pricesRouter - Default Price Constraints', () => {
           transaction
         )
         await expect(
-          productsRouter.createCaller(ctx).edit({
+          productsRouter.createCaller(ctx).update({
             product: { id: defaultProductId },
             price: { id: otherPrice.id } as any,
           } as any)

--- a/platform/flowglad-next/src/server/routers/pricesRouter.ts
+++ b/platform/flowglad-next/src/server/routers/pricesRouter.ts
@@ -128,7 +128,7 @@ export const createPrice = protectedProcedure
     )
   })
 
-export const editPrice = protectedProcedure
+export const updatePrice = protectedProcedure
   .meta(openApiMetas.PUT)
   .input(editPriceSchema)
   .output(singlePriceOutputSchema)
@@ -230,7 +230,7 @@ export const listUsagePricesForProduct = protectedProcedure
 export const pricesRouter = router({
   list: listPrices,
   create: createPrice,
-  edit: editPrice,
+  update: updatePrice,
   getTableRows,
   listUsagePricesForProduct,
 })

--- a/platform/flowglad-next/src/server/routers/productsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/productsRouter.ts
@@ -109,7 +109,7 @@ export const createProduct = protectedProcedure
     }
   })
 
-export const editProduct = protectedProcedure
+export const updateProduct = protectedProcedure
   .meta(openApiMetas.PUT)
   .input(editProductSchema)
   .output(singleProductOutputSchema)
@@ -175,7 +175,7 @@ export const editProduct = protectedProcedure
               existingPrice,
               existingProduct
             )
-            // Disallow slug changes for the default price of a default product (parity with pricesRouter.edit)
+            // Disallow slug changes for the default price of a default product (parity with pricesRouter.update)
             if (
               existingProduct.default &&
               existingPrice.isDefault &&
@@ -353,7 +353,7 @@ export const productsRouter = router({
   list: listProducts,
   get: getProduct,
   create: createProduct,
-  update: editProduct,
+  update: updateProduct,
   getTableRows,
   getCountsByStatus,
 })

--- a/platform/flowglad-next/src/utils/bookkeeping/fees/checkoutSession.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/fees/checkoutSession.ts
@@ -157,7 +157,6 @@ export const createCheckoutSessionFeeCalculationInsertForPrice =
     } = params
     const base = calculatePriceBaseAmount({ price, purchase })
     const discountAmt = calculateDiscountAmount(base, discount)
-    console.log('=====discountAmt', discountAmt)
     const insert = createBaseFeeCalculationInsert({
       organization,
       billingAddress,
@@ -268,10 +267,6 @@ export const createFeeCalculationForCheckoutSession = async (
   const organizationCountry = await selectCountryById(
     organizationCountryId,
     transaction
-  )
-  console.log(
-    '=====createCheckoutSessionFeeCalculation: discount',
-    discount
   )
   return createCheckoutSessionFeeCalculation(
     {


### PR DESCRIPTION
## What Does this PR Do?

-Standardize router methods: use 'update' instead of 'edit'
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized router method names by renaming “edit” to “update” across prices, products, and checkout sessions. This aligns APIs and TRPC callers for consistency without changing behavior.

- **Refactors**
  - Renamed procedures: prices.edit → prices.update, products.edit → products.update, checkoutSessions.edit → checkoutSessions.update.
  - Updated TRPC mutations in modals and tests to use .update.
  - Aliased DB update function in checkoutSessionsRouter to avoid name collision.
  - Removed leftover console logs in fee calculation utilities.

- **Migration**
  - Replace any remaining trpc.*.edit calls with .update.
  - No API behavior changes expected.

<!-- End of auto-generated description by cubic. -->

