### PR TITLE
fixed subscription adjust endpoint

### DIFF
--- a/platform/flowglad-next/src/server/routers/subscriptionsRouter.routeConfigs.test.ts
+++ b/platform/flowglad-next/src/server/routers/subscriptionsRouter.routeConfigs.test.ts
@@ -123,12 +123,11 @@ describe('subscriptionsRouteConfigs', () => {
         )
       ).toBe(false)
 
-      // Test mapParams - Note: trpcToRest default case expects matches[1] not matches[0]
-      // This appears to be a bug in the implementation
+      // Test mapParams - simulate route handler behavior by slicing the matches
       const fullMatch = routeConfig!.pattern.exec(
         'subscriptions/test-id/adjust'
       )
-      const result = routeConfig!.mapParams(fullMatch as any)
+      const result = routeConfig!.mapParams(fullMatch!.slice(1) as any)
       expect(result).toEqual({ id: 'test-id' })
     })
 
@@ -153,12 +152,11 @@ describe('subscriptionsRouteConfigs', () => {
         )
       ).toBe(false)
 
-      // Test mapParams - Note: trpcToRest default case expects matches[1] not matches[0]
-      // This appears to be a bug in the implementation
+      // Test mapParams - simulate route handler behavior by slicing the matches
       const fullMatch = routeConfig!.pattern.exec(
         'subscriptions/test-id/cancel'
       )
-      const result = routeConfig!.mapParams(fullMatch as any)
+      const result = routeConfig!.mapParams(fullMatch!.slice(1) as any)
       expect(result).toEqual({ id: 'test-id' })
     })
   })
@@ -340,11 +338,11 @@ describe('subscriptionsRouteConfigs', () => {
         'POST /subscriptions/:id/adjust'
       )
 
-      // trpcToRest default case expects full match array with matches[1]
+      // Simulate route handler behavior by slicing the matches
       const fullMatch = routeConfig!.pattern.exec(
         'subscriptions/subscription-adjust-123/adjust'
       )
-      const result = routeConfig!.mapParams(fullMatch as any)
+      const result = routeConfig!.mapParams(fullMatch!.slice(1) as any)
 
       expect(result).toEqual({
         id: 'subscription-adjust-123',
@@ -356,11 +354,11 @@ describe('subscriptionsRouteConfigs', () => {
         'POST /subscriptions/:id/cancel'
       )
 
-      // trpcToRest default case expects full match array with matches[1]
+      // Simulate route handler behavior by slicing the matches
       const fullMatch = routeConfig!.pattern.exec(
         'subscriptions/subscription-cancel-456/cancel'
       )
-      const result = routeConfig!.mapParams(fullMatch as any)
+      const result = routeConfig!.mapParams(fullMatch!.slice(1) as any)
 
       expect(result).toEqual({
         id: 'subscription-cancel-456',
@@ -447,7 +445,7 @@ describe('subscriptionsRouteConfigs', () => {
             ? 'subscriptions/test-id/adjust'
             : 'subscriptions/test-id/cancel'
           const fullMatch = config!.pattern.exec(path)
-          const result = config!.mapParams(fullMatch as any, {
+          const result = config!.mapParams(fullMatch!.slice(1) as any, {
             someData: 'value',
           })
           expect(result).toHaveProperty('id', 'test-id')

--- a/platform/flowglad-next/src/utils/openapi.test.ts
+++ b/platform/flowglad-next/src/utils/openapi.test.ts
@@ -218,7 +218,7 @@ describe('trpcToRest', () => {
       expect(pattern.test('subscriptions/123/adjust')).toBe(true)
       expect(pattern.test('subscriptions/123')).toBe(false)
 
-      const matches = pattern.exec('subscriptions/123/adjust')!
+      const matches = pattern.exec('subscriptions/123/adjust')!.slice(1)
       const testBody = { amount: 100 }
       expect(
         result['POST /subscriptions/:id/adjust'].mapParams(

--- a/platform/flowglad-next/src/utils/openapi.ts
+++ b/platform/flowglad-next/src/utils/openapi.ts
@@ -340,7 +340,7 @@ export const trpcToRest = (
           pattern: new RegExp(`^${entity}\/([^\\/]+)\/${action}$`),
           mapParams: (matches, body) => ({
             ...body,
-            id: matches[1],
+            id: matches[0],
           }),
         },
       }


### PR DESCRIPTION
## What Does this PR Do?

-fixed subscription adjust endpoint
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes subscription adjust and cancel endpoints by correctly extracting the subscription id from the URL. Requests to POST /subscriptions/:id/adjust and /subscriptions/:id/cancel now receive the right id and no longer fail.

- **Bug Fixes**
  - Fixed trpcToRest param mapping to use the first capture group for id.
  - Updated tests to slice regex matches to match route handler behavior.

<!-- End of auto-generated description by cubic. -->

