### PR TITLE
fix schema mismatch in subscriptionMethods

### DIFF
--- a/platform/flowglad-next/src/db/tableMethods/subscriptionMethods.ts
+++ b/platform/flowglad-next/src/db/tableMethods/subscriptionMethods.ts
@@ -35,9 +35,9 @@ import {
 } from 'drizzle-orm'
 import { SubscriptionStatus, CancellationReason } from '@/types'
 import { DbTransaction } from '@/db/types'
-import { customers, customersSelectSchema } from '../schema/customers'
-import { prices, pricesSelectSchema } from '../schema/prices'
-import { products, productsSelectSchema } from '../schema/products'
+import { customers, customerClientSelectSchema } from '../schema/customers'
+import { prices, pricesClientSelectSchema } from '../schema/prices'
+import { products, productsClientSelectSchema } from '../schema/products'
 import { z } from 'zod'
 import { PaymentMethod } from '../schema/paymentMethods'
 
@@ -233,9 +233,9 @@ export const selectSubscriptionsTableRowData =
               subscription.cancellationReason
             ),
           },
-          price: pricesSelectSchema.parse(price),
-          product: productsSelectSchema.parse(product),
-          customer: customersSelectSchema.parse(customer),
+          price: pricesClientSelectSchema.parse(price),
+          product: productsClientSelectSchema.parse(product),
+          customer: customerClientSelectSchema.parse(customer),
         }
       })
     }


### PR DESCRIPTION
## What Does this PR Do?

-fix schema mismatch in subscriptionMethods

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes schema mismatches in subscriptionMethods by using the client select schemas for customers, prices, and products. Addresses FG-132 and prevents Zod parse errors when selecting subscription data.

- **Bug Fixes**
  - Switched to customerClientSelectSchema, pricesClientSelectSchema, and productsClientSelectSchema.
  - Updated parse() calls in selectSubscriptionsTableRowData to use the client schemas.

<!-- End of auto-generated description by cubic. -->

