### PR TITLE
standardize update > edit in trpc routers

### DIFF
--- a/platform/flowglad-next/src/server/index.ts
+++ b/platform/flowglad-next/src/server/index.ts
@@ -2,9 +2,9 @@ import { router } from './trpc'
 import { pong } from '@/server/mutations/pong'
 import { generateDescription } from '@/server/mutations/generateDescription'
 import { getPresignedURL } from '@/server/mutations/getPresignedURL'
-import { editFile } from '@/server/mutations/editFile'
+import { updateFile } from '@/server/mutations/editFile'
 import { createLink } from '@/server/mutations/createLink'
-import { editLink } from '@/server/mutations/editLink'
+import { updateLink } from '@/server/mutations/editLink'
 import { deleteLinkProcedure } from '@/server/mutations/deleteLink'
 import { deleteFileProcedure } from '@/server/mutations/deleteFile'
 import { getProperNouns } from '@/server/queries/getProperNouns'
@@ -41,13 +41,13 @@ import { setReferralSelection } from './mutations/setReferralSelection'
 
 const filesRouter = router({
   create: createFile,
-  update: editFile,
+  update: updateFile,
   delete: deleteFileProcedure,
 })
 
 const linksRouter = router({
   create: createLink,
-  update: editLink,
+  update: updateLink,
   delete: deleteLinkProcedure,
 })
 

--- a/platform/flowglad-next/src/server/mutations/editFile.ts
+++ b/platform/flowglad-next/src/server/mutations/editFile.ts
@@ -1,6 +1,6 @@
 import { protectedProcedure } from '@/server/trpc'
 import { editFileInputSchema } from '@/db/schema/files'
-import { updateFile } from '@/db/tableMethods/fileMethods'
+import { updateFile as updateFileDB } from '@/db/tableMethods/fileMethods'
 import { authenticatedTransaction } from '@/db/authenticatedTransaction'
 
 export const updateFile = protectedProcedure
@@ -8,7 +8,7 @@ export const updateFile = protectedProcedure
   .mutation(async ({ input, ctx }) => {
     const updatedFile = await authenticatedTransaction(
       async ({ transaction }) => {
-        return updateFile(input.file, transaction)
+        return updateFileDB(input.file, transaction)
       }
     )
     return {

--- a/platform/flowglad-next/src/server/mutations/editFile.ts
+++ b/platform/flowglad-next/src/server/mutations/editFile.ts
@@ -3,7 +3,7 @@ import { editFileInputSchema } from '@/db/schema/files'
 import { updateFile } from '@/db/tableMethods/fileMethods'
 import { authenticatedTransaction } from '@/db/authenticatedTransaction'
 
-export const editFile = protectedProcedure
+export const updateFile = protectedProcedure
   .input(editFileInputSchema)
   .mutation(async ({ input, ctx }) => {
     const updatedFile = await authenticatedTransaction(

--- a/platform/flowglad-next/src/server/mutations/editLink.ts
+++ b/platform/flowglad-next/src/server/mutations/editLink.ts
@@ -1,14 +1,14 @@
 import { protectedProcedure } from '@/server/trpc'
 import { authenticatedTransaction } from '@/db/authenticatedTransaction'
 import { editLinkInputSchema } from '@/db/schema/links'
-import { updateLink } from '@/db/tableMethods/linkMethods'
+import { updateLink as updateLinkDB } from '@/db/tableMethods/linkMethods'
 
 export const updateLink = protectedProcedure
   .input(editLinkInputSchema)
   .mutation(async ({ input }) => {
     const link = await authenticatedTransaction(
       async ({ transaction }) => {
-        return updateLink(input.link, transaction)
+        return updateLinkDB(input.link, transaction)
       }
     )
 

--- a/platform/flowglad-next/src/server/mutations/editLink.ts
+++ b/platform/flowglad-next/src/server/mutations/editLink.ts
@@ -3,7 +3,7 @@ import { authenticatedTransaction } from '@/db/authenticatedTransaction'
 import { editLinkInputSchema } from '@/db/schema/links'
 import { updateLink } from '@/db/tableMethods/linkMethods'
 
-export const editLink = protectedProcedure
+export const updateLink = protectedProcedure
   .input(editLinkInputSchema)
   .mutation(async ({ input }) => {
     const link = await authenticatedTransaction(

--- a/platform/flowglad-next/src/server/routers/customersRouter.ts
+++ b/platform/flowglad-next/src/server/routers/customersRouter.ts
@@ -11,7 +11,7 @@ import {
   selectCustomerById,
   selectCustomers,
   selectCustomersPaginated,
-  updateCustomer,
+  updateCustomer as updateCustomerDb,
   selectCustomersCursorPaginatedWithTableRowData,
   selectCustomerByExternalIdAndOrganizationId,
 } from '@/db/tableMethods/customerMethods'
@@ -136,7 +136,7 @@ const createCustomerProcedure = protectedProcedure
     )
   )
 
-export const editCustomer = protectedProcedure
+export const updateCustomer = protectedProcedure
   .meta(openApiMetas.PUT)
   .input(editCustomerInputSchema)
   .output(editCustomerOutputSchema)
@@ -160,7 +160,7 @@ export const editCustomer = protectedProcedure
               message: `Customer with externalId ${input.externalId} not found`,
             })
           }
-          const updatedCustomer = await updateCustomer(
+          const updatedCustomer = await updateCustomerDb(
             {
               ...customer,
               id: customerRecord.id,
@@ -355,7 +355,7 @@ export const customersRouter = router({
   /**
    * Forward/backward compatibility with the old update endpoint
    */
-  update: editCustomer,
+  update: updateCustomer,
   getBilling: getCustomerBilling,
   get: getCustomer,
   internal__getById: getCustomerById,

--- a/platform/flowglad-next/src/server/routers/discountsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/discountsRouter.ts
@@ -2,7 +2,7 @@ import { router } from '../trpc'
 import { editDiscountInputSchema } from '@/db/schema/discounts'
 import {
   selectDiscountById,
-  updateDiscount,
+  updateDiscount as updateDiscountDB,
   selectDiscountsTableRowData,
 } from '@/db/tableMethods/discountMethods'
 import { attemptDiscountCode } from '@/server/mutations/attemptDiscountCode'
@@ -114,7 +114,7 @@ export const updateDiscount = protectedProcedure
   .mutation(async ({ input, ctx }) => {
     const discount = await authenticatedTransaction(
       async ({ transaction }) => {
-        const updatedDiscount = await updateDiscount(
+        const updatedDiscount = await updateDiscountDB(
           {
             ...input.discount,
             id: input.id,

--- a/platform/flowglad-next/src/server/routers/discountsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/discountsRouter.ts
@@ -107,7 +107,7 @@ const getTableRowsProcedure = protectedProcedure
     authenticatedProcedureTransaction(selectDiscountsTableRowData)
   )
 
-export const editDiscount = protectedProcedure
+export const updateDiscount = protectedProcedure
   .meta(openApiMetas.PUT)
   .input(editDiscountInputSchema)
   .output(z.object({ discount: discountClientSelectSchema }))
@@ -160,7 +160,7 @@ export const getDiscount = protectedProcedure
 export const discountsRouter = router({
   get: getDiscount,
   create: createDiscount,
-  update: editDiscount,
+  update: updateDiscount,
   delete: deleteDiscount,
   attempt: attemptDiscountCode,
   clear: clearDiscountCode,

--- a/platform/flowglad-next/src/server/routers/featuresRouter.ts
+++ b/platform/flowglad-next/src/server/routers/featuresRouter.ts
@@ -6,7 +6,7 @@ import {
 } from '@/db/schema/features'
 import {
   selectFeatureById,
-  updateFeature,
+  updateFeature as updateFeatureDB,
   insertFeature,
   selectFeaturesPaginated,
   selectFeaturesTableRowData,
@@ -93,7 +93,7 @@ export const updateFeature = protectedProcedure
   .mutation(
     authenticatedProcedureTransaction(
       async ({ input, transaction }) => {
-        const feature = await updateFeature(
+        const feature = await updateFeatureDB(
           {
             ...input.feature,
             id: input.id,

--- a/platform/flowglad-next/src/server/routers/featuresRouter.ts
+++ b/platform/flowglad-next/src/server/routers/featuresRouter.ts
@@ -86,7 +86,7 @@ const listFeaturesProcedure = protectedProcedure
     )
   })
 
-export const editFeature = protectedProcedure
+export const updateFeature = protectedProcedure
   .meta(openApiMetas.PUT)
   .input(editFeatureSchema)
   .output(z.object({ feature: featuresClientSelectSchema }))
@@ -161,7 +161,7 @@ const getFeaturesForPricingModel = protectedProcedure
 export const featuresRouter = router({
   get: getFeature,
   create: createFeature,
-  update: editFeature,
+  update: updateFeature,
   list: listFeaturesProcedure,
   getTableRows,
   getFeaturesForPricingModel,

--- a/platform/flowglad-next/src/server/routers/organizationsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/organizationsRouter.ts
@@ -16,7 +16,7 @@ import {
   membershipsClientSelectSchema,
   membershipsTableRowDataSchema,
 } from '@/db/schema/memberships'
-import { updateOrganization } from '@/db/tableMethods/organizationMethods'
+import { updateOrganization as updateOrganizationDB } from '@/db/tableMethods/organizationMethods'
 import { selectRevenueDataForOrganization } from '@/db/tableMethods/paymentMethods'
 import {
   createOrganizationSchema,
@@ -328,7 +328,7 @@ const updateOrganization = protectedProcedure
     authenticatedProcedureTransaction(
       async ({ input, transaction, userId }) => {
         const { organization } = input
-        await updateOrganization(organization, transaction)
+        await updateOrganizationDB(organization, transaction)
         return {
           data: organization,
         }

--- a/platform/flowglad-next/src/server/routers/organizationsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/organizationsRouter.ts
@@ -322,7 +322,7 @@ const createOrganization = protectedProcedure
     }
   })
 
-const editOrganization = protectedProcedure
+const updateOrganization = protectedProcedure
   .input(editOrganizationSchema)
   .mutation(
     authenticatedProcedureTransaction(
@@ -411,7 +411,7 @@ const getMembersTableRowData = protectedProcedure
 
 export const organizationsRouter = router({
   create: createOrganization,
-  update: editOrganization,
+  update: updateOrganization,
   requestStripeConnect: requestStripeConnectOnboardingLink,
   getMembers: getMembers,
   getMembersTableRowData: getMembersTableRowData,

--- a/platform/flowglad-next/src/server/routers/pricingModelsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/pricingModelsRouter.ts
@@ -126,7 +126,7 @@ const createPricingModelProcedure = protectedProcedure
     }
   })
 
-const editPricingModelProcedure = protectedProcedure
+const updatePricingModelProcedure = protectedProcedure
   .meta(openApiMetas.PUT)
   .input(editPricingModelSchema)
   .output(
@@ -300,7 +300,7 @@ export const pricingModelsRouter = router({
   get: getPricingModelProcedure,
   getDefault: getDefaultPricingModelProcedure,
   create: createPricingModelProcedure,
-  update: editPricingModelProcedure,
+  update: updatePricingModelProcedure,
   clone: clonePricingModelProcedure,
   getTableRows: getTableRowsProcedure,
 })

--- a/platform/flowglad-next/src/server/routers/subscriptionItemFeaturesRouter.ts
+++ b/platform/flowglad-next/src/server/routers/subscriptionItemFeaturesRouter.ts
@@ -8,7 +8,7 @@ import {
 } from '@/db/schema/subscriptionItemFeatures'
 import {
   selectSubscriptionItemFeatureById,
-  updateSubscriptionItemFeature,
+  updateSubscriptionItemFeature as updateSubscriptionItemFeatureDB,
   insertSubscriptionItemFeature,
   expireSubscriptionItemFeature as expireSubscriptionItemFeatureMethod,
   selectClientSubscriptionItemFeatureAndFeatureById,
@@ -110,7 +110,7 @@ const updateSubscriptionItemFeature = protectedProcedure
           id: input.id,
         } as SubscriptionItemFeature.Update
 
-        await updateSubscriptionItemFeature(
+        await updateSubscriptionItemFeatureDB(
           updatePayload,
           transaction
         )

--- a/platform/flowglad-next/src/server/routers/subscriptionItemFeaturesRouter.ts
+++ b/platform/flowglad-next/src/server/routers/subscriptionItemFeaturesRouter.ts
@@ -98,7 +98,7 @@ const createSubscriptionItemFeature = protectedProcedure
     )
   )
 
-const editSubscriptionItemFeature = protectedProcedure
+const updateSubscriptionItemFeature = protectedProcedure
   .meta(openApiMetas.PUT)
   .input(editSubscriptionItemFeatureInputSchema)
   .output(subscriptionItemFeatureClientResponse)
@@ -194,6 +194,6 @@ const expireSubscriptionItemFeature = protectedProcedure
 export const subscriptionItemFeaturesRouter = router({
   get: getSubscriptionItemFeature,
   create: createSubscriptionItemFeature,
-  update: editSubscriptionItemFeature,
+  update: updateSubscriptionItemFeature,
   deactivate: expireSubscriptionItemFeature,
 })

--- a/platform/flowglad-next/src/server/routers/usageMetersRouter.ts
+++ b/platform/flowglad-next/src/server/routers/usageMetersRouter.ts
@@ -8,7 +8,7 @@ import {
 } from '@/db/schema/usageMeters'
 import {
   selectUsageMeterById,
-  updateUsageMeter,
+  updateUsageMeter as updateUsageMeterDB,
   selectUsageMetersPaginated,
   selectUsageMetersCursorPaginated,
 } from '@/db/tableMethods/usageMeterMethods'
@@ -79,7 +79,7 @@ const updateUsageMeter = protectedProcedure
   .mutation(
     authenticatedProcedureTransaction(
       async ({ input, transaction }) => {
-        const usageMeter = await updateUsageMeter(
+        const usageMeter = await updateUsageMeterDB(
           {
             ...input.usageMeter,
             id: input.id,

--- a/platform/flowglad-next/src/server/routers/usageMetersRouter.ts
+++ b/platform/flowglad-next/src/server/routers/usageMetersRouter.ts
@@ -72,7 +72,7 @@ const listUsageMetersProcedure = protectedProcedure
     )
   )
 
-const editUsageMeter = protectedProcedure
+const updateUsageMeter = protectedProcedure
   .meta(openApiMetas.PUT)
   .input(editUsageMeterSchema)
   .output(z.object({ usageMeter: usageMetersClientSelectSchema }))
@@ -127,7 +127,7 @@ const getTableRowsProcedure = protectedProcedure
 export const usageMetersRouter = router({
   get: getUsageMeter,
   create: createUsageMeter,
-  update: editUsageMeter,
+  update: updateUsageMeter,
   list: listUsageMetersProcedure,
   getTableRows: getTableRowsProcedure,
 })

--- a/platform/flowglad-next/src/server/routers/webhooksRouter.ts
+++ b/platform/flowglad-next/src/server/routers/webhooksRouter.ts
@@ -74,7 +74,7 @@ export const createWebhook = protectedProcedure
     )
   )
 
-export const editWebhook = protectedProcedure
+export const updateWebhook = protectedProcedure
   .meta(openApiMetas.PUT)
   .input(editWebhookInputSchema)
   .output(z.object({ webhook: webhookClientSelectSchema }))
@@ -152,7 +152,7 @@ export const getTableRows = protectedProcedure
 export const webhooksRouter = router({
   get: getWebhook,
   create: createWebhook,
-  update: editWebhook,
+  update: updateWebhook,
   requestSigningSecret: requestWebhookSigningSecret,
   getTableRows,
 })

--- a/platform/flowglad-next/src/server/routers/webhooksRouter.ts
+++ b/platform/flowglad-next/src/server/routers/webhooksRouter.ts
@@ -6,7 +6,7 @@ import {
 import {
   selectWebhookById,
   insertWebhook,
-  updateWebhook,
+  updateWebhook as updateWebhookDB,
   selectWebhookAndOrganizationByWebhookId,
   selectWebhooksTableRowData,
 } from '@/db/tableMethods/webhookMethods'
@@ -81,7 +81,7 @@ export const updateWebhook = protectedProcedure
   .mutation(
     authenticatedProcedureTransaction(
       async ({ input, transaction, ctx }) => {
-        const webhook = await updateWebhook(
+        const webhook = await updateWebhookDB(
           {
             ...input.webhook,
             id: input.id,


### PR DESCRIPTION
## What Does this PR Do?

- standardize update > edit in trpc routers
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized tRPC mutation names from edit* to update* across routers and mutations to match API/DB naming conventions (FG-116). No behavior or API contract changes.

- **Refactors**
  - Renamed all edit* procedures to update* (files, links, customers, discounts, features, organizations, pricing models, subscription item features, usage meters, webhooks).
  - Router endpoints remain update and schemas stay the same.
  - Aliased DB method updateCustomer to updateCustomerDb to avoid name collision.

<!-- End of auto-generated description by cubic. -->

