### PR TITLE
added billing portal url to useBilling()

### DIFF
--- a/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.integration.test.ts
+++ b/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.integration.test.ts
@@ -407,6 +407,38 @@ describe('Customer Billing Portal Router', () => {
       }
     )
 
+    test(
+      'generates correct billing portal URL with proper format and validation',
+      { timeout: 10000 },
+      async () => {
+        const ctx = createTestContext()
+        const input = {}
+
+        const result = await customerBillingPortalRouter
+          .createCaller(ctx)
+          .getBilling(input)
+
+        // Test that billingPortalUrl is a valid URL
+        expect(result.billingPortalUrl).toBeDefined()
+        expect(typeof result.billingPortalUrl).toBe('string')
+        
+        // Validate URL format using URL constructor
+        expect(() => new URL(result.billingPortalUrl)).not.toThrow()
+        
+        // Test specific URL structure
+        const url = new URL(result.billingPortalUrl)
+        expect(url.pathname).toBe(`/billing-portal/${organization.id}/${customer.externalId}`)
+        
+        // Test that URL contains expected components
+        expect(result.billingPortalUrl).toContain('/billing-portal/')
+        expect(result.billingPortalUrl).toContain(organization.id)
+        expect(result.billingPortalUrl).toContain(customer.externalId)
+        
+        // Test that URL is properly formatted (starts with http/https)
+        expect(result.billingPortalUrl).toMatch(/^https?:\/\//)
+      }
+    )
+
     test.skip('throws error when organizationId is missing from context', async () => {
       // Skip this test as the procedure doesn't actually check for missing organizationId in the way we're testing
       const ctxWithoutOrgId = {

--- a/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.integration.test.ts
+++ b/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.integration.test.ts
@@ -289,10 +289,16 @@ describe('Customer Billing Portal Router', () => {
           pricingModel: expect.objectContaining({
             id: pricingModel.id,
           }),
+          billingPortalUrl: expect.any(String),
         })
 
         // Verify all invoices are returned when no pagination
         expect(result.invoices.length).toBeGreaterThanOrEqual(3)
+        
+        // Verify billing portal URL is properly formatted
+        expect(result.billingPortalUrl).toContain('/billing-portal/')
+        expect(result.billingPortalUrl).toContain(customer.organizationId)
+        expect(result.billingPortalUrl).toContain(customer.externalId)
       }
     )
 

--- a/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.ts
+++ b/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.ts
@@ -107,7 +107,7 @@ const getBillingProcedure = customerProtectedProcedure
         ),
       catalog: pricingModelWithProductsAndUsageMetersSchema,
       pricingModel: pricingModelWithProductsAndUsageMetersSchema,
-      billingPortalUrl: z.string().describe('The billing portal URL for the customer'),
+      billingPortalUrl: z.url().describe('The billing portal URL for the customer'),
     })
   )
   .query(async ({ ctx, input }) => {

--- a/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.ts
+++ b/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.ts
@@ -107,6 +107,7 @@ const getBillingProcedure = customerProtectedProcedure
         ),
       catalog: pricingModelWithProductsAndUsageMetersSchema,
       pricingModel: pricingModelWithProductsAndUsageMetersSchema,
+      billingPortalUrl: z.string().describe('The billing portal URL for the customer'),
     })
   )
   .query(async ({ ctx, input }) => {
@@ -181,6 +182,10 @@ const getBillingProcedure = customerProtectedProcedure
       subscriptions,
       catalog: pricingModel,
       pricingModel,
+      billingPortalUrl: customerBillingPortalURL({
+        organizationId: organizationId!,
+        customerId: customer.externalId,
+      }),
     }
   })
 


### PR DESCRIPTION
## What Does this PR Do?

-added billing portal url to useBilling()
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add billingPortalUrl to useBilling() so clients can link users directly to their billing portal. Aligns with Linear FG-145.

- **New Features**
  - Expose billingPortalUrl in the getBilling response (Zod schema updated).
  - Generate URL via customerBillingPortalURL using organizationId and customer.externalId; integration test asserts format.

<!-- End of auto-generated description by cubic. -->

