### PR TITLE
Revert "added billing portal url to useBilling() (#484)"

### DIFF
--- a/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.integration.test.ts
+++ b/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.integration.test.ts
@@ -289,16 +289,10 @@ describe('Customer Billing Portal Router', () => {
           pricingModel: expect.objectContaining({
             id: pricingModel.id,
           }),
-          billingPortalUrl: expect.any(String),
         })
 
         // Verify all invoices are returned when no pagination
         expect(result.invoices.length).toBeGreaterThanOrEqual(3)
-        
-        // Verify billing portal URL is properly formatted
-        expect(result.billingPortalUrl).toContain('/billing-portal/')
-        expect(result.billingPortalUrl).toContain(customer.organizationId)
-        expect(result.billingPortalUrl).toContain(customer.externalId)
       }
     )
 
@@ -404,38 +398,6 @@ describe('Customer Billing Portal Router', () => {
           totalCount: 10, // 3 original + 7 new
           totalPages: 2, // 10 invoices / 5 per page
         })
-      }
-    )
-
-    test(
-      'generates correct billing portal URL with proper format and validation',
-      { timeout: 10000 },
-      async () => {
-        const ctx = createTestContext()
-        const input = {}
-
-        const result = await customerBillingPortalRouter
-          .createCaller(ctx)
-          .getBilling(input)
-
-        // Test that billingPortalUrl is a valid URL
-        expect(result.billingPortalUrl).toBeDefined()
-        expect(typeof result.billingPortalUrl).toBe('string')
-        
-        // Validate URL format using URL constructor
-        expect(() => new URL(result.billingPortalUrl)).not.toThrow()
-        
-        // Test specific URL structure
-        const url = new URL(result.billingPortalUrl)
-        expect(url.pathname).toBe(`/billing-portal/${organization.id}/${customer.externalId}`)
-        
-        // Test that URL contains expected components
-        expect(result.billingPortalUrl).toContain('/billing-portal/')
-        expect(result.billingPortalUrl).toContain(organization.id)
-        expect(result.billingPortalUrl).toContain(customer.externalId)
-        
-        // Test that URL is properly formatted (starts with http/https)
-        expect(result.billingPortalUrl).toMatch(/^https?:\/\//)
       }
     )
 

--- a/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.ts
+++ b/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.ts
@@ -107,7 +107,6 @@ const getBillingProcedure = customerProtectedProcedure
         ),
       catalog: pricingModelWithProductsAndUsageMetersSchema,
       pricingModel: pricingModelWithProductsAndUsageMetersSchema,
-      billingPortalUrl: z.url().describe('The billing portal URL for the customer'),
     })
   )
   .query(async ({ ctx, input }) => {
@@ -182,10 +181,6 @@ const getBillingProcedure = customerProtectedProcedure
       subscriptions,
       catalog: pricingModel,
       pricingModel,
-      billingPortalUrl: customerBillingPortalURL({
-        organizationId: organizationId!,
-        customerId: customer.externalId,
-      }),
     }
   })
 


### PR DESCRIPTION
This reverts commit b5a8025c1b35999f745109133249a8c463781e6a, We may re-add billing portal url but will wait until further review
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed billingPortalUrl from getBilling() and reverted related tests and schema. The billing API response no longer includes billingPortalUrl.

- **Migration**
  - Remove any usage of billingPortalUrl from clients of useBilling/getBilling. Replace or hide portal links until reintroduced.

<!-- End of auto-generated description by cubic. -->

