### PR TITLE
Fix cursor pagination SQL parameter errors and count query consistency

### DIFF
--- a/platform/flowglad-next/public/preview/manifest.json
+++ b/platform/flowglad-next/public/preview/manifest.json
@@ -1,6 +1,6 @@
 {
-  "hash": "1f79b08f",
+  "hash": "9a0bff84",
   "path": "/preview/preview.css",
-  "size": 63315,
-  "generatedAt": "2025-09-15T16:28:30.469Z"
+  "size": 85718,
+  "generatedAt": "2025-09-25T21:19:22.205Z"
 }

--- a/platform/flowglad-next/src/db/tableUtils.test.ts
+++ b/platform/flowglad-next/src/db/tableUtils.test.ts
@@ -12,6 +12,7 @@ import { authenticatedTransaction } from '@/db/authenticatedTransaction'
 import { nulledPriceColumns, Price, prices } from '@/db/schema/prices'
 import { PriceType, CurrencyCode, FlowgladApiKeyType } from '@/types'
 import { eq, and as drizzleAnd } from 'drizzle-orm'
+import { pgTable, text, integer, boolean } from 'drizzle-orm/pg-core'
 import { ApiKey, apiKeys } from '@/db/schema/apiKeys'
 import { users } from '@/db/schema/users'
 import { memberships } from '@/db/schema/memberships'
@@ -962,22 +963,19 @@ describe('RLS Integration Tests: organizationId integrity on pricingModels', () 
   })
 })
 
+// Create a properly typed mock table for testing whereClauseFromObject
+const mockTable = pgTable('mock_table', {
+  id: text('id').primaryKey(),
+  name: text('name'),
+  email: text('email'),
+  active: boolean('active'),
+  organizationId: text('organization_id'),
+  tags: text('tags').array(),
+  count: integer('count'),
+  metadata: text('metadata')
+})
+
 describe('whereClauseFromObject', () => {
-  let mockTable: any
-  
-  beforeEach(() => {
-    // Create a mock table with mock columns for testing
-    mockTable = {
-      id: { name: 'id' },
-      name: { name: 'name' },
-      email: { name: 'email' },
-      active: { name: 'active' },
-      organizationId: { name: 'organization_id' },
-      tags: { name: 'tags' },
-      count: { name: 'count' },
-      metadata: { name: 'metadata' }
-    }
-  })
 
   describe('basic functionality', () => {
     it('should return undefined for empty object', () => {

--- a/platform/flowglad-next/src/db/tableUtils.test.ts
+++ b/platform/flowglad-next/src/db/tableUtils.test.ts
@@ -963,7 +963,6 @@ describe('RLS Integration Tests: organizationId integrity on pricingModels', () 
   })
 })
 
-// Create a properly typed mock table for testing whereClauseFromObject
 const mockTable = pgTable('mock_table', {
   id: text('id').primaryKey(),
   name: text('name'),

--- a/platform/flowglad-next/src/db/tableUtils.test.ts
+++ b/platform/flowglad-next/src/db/tableUtils.test.ts
@@ -1009,7 +1009,7 @@ describe('whereClauseFromObject', () => {
         name: '',
         email: undefined,
         active: ''
-      }
+      } as any
       const result = whereClauseFromObject(mockTable, selectConditions)
       expect(result).toBeUndefined()
     })
@@ -1085,20 +1085,20 @@ describe('whereClauseFromObject', () => {
     })
 
     it('should filter undefined and empty strings from arrays', () => {
-      const selectConditions = { tags: ['tag1', undefined, '', 'tag2', null] }
+      const selectConditions = { tags: ['tag1', undefined, '', 'tag2', null] as any }
       const result = whereClauseFromObject(mockTable, selectConditions)
       expect(result).toBeDefined()
     })
 
     it('should handle array with only undefined/empty values', () => {
-      const selectConditions = { tags: [undefined, '', undefined] }
+      const selectConditions = { tags: [undefined, '', undefined] as any }
       const result = whereClauseFromObject(mockTable, selectConditions)
       expect(result).toBeDefined()
     })
 
     it('should handle mixed array types', () => {
       const selectConditions = { 
-        tags: ['string', 123, true, null]
+        tags: ['string', 123, true, null] as any
       }
       const result = whereClauseFromObject(mockTable, selectConditions)
       expect(result).toBeDefined()
@@ -1179,13 +1179,13 @@ describe('whereClauseFromObject', () => {
 
   describe('type coercion and conversion', () => {
     it('should handle string numbers', () => {
-      const selectConditions = { count: '123' }
+      const selectConditions = { count: '123' } as any
       const result = whereClauseFromObject(mockTable, selectConditions)
       expect(result).toBeDefined()
     })
 
     it('should handle string booleans', () => {
-      const selectConditions = { active: 'true' }
+      const selectConditions = { active: 'true' } as any
       const result = whereClauseFromObject(mockTable, selectConditions)
       expect(result).toBeDefined()
     })
@@ -1207,7 +1207,7 @@ describe('whereClauseFromObject', () => {
     it('should handle very deep nested structures safely', () => {
       const selectConditions = {
         metadata: { deep: { nested: { object: 'value' } } }
-      }
+      } as any
       const result = whereClauseFromObject(mockTable, selectConditions)
       expect(result).toBeDefined()
     })

--- a/platform/flowglad-next/src/db/tableUtils.test.ts
+++ b/platform/flowglad-next/src/db/tableUtils.test.ts
@@ -22,6 +22,7 @@ import {
   updateProduct,
 } from './tableMethods/productMethods'
 import { insertPrice, updatePrice } from './tableMethods/priceMethods'
+import { whereClauseFromObject } from './tableUtils'
 
 describe('createCursorPaginatedSelectFunction', () => {
   let organizationId: string
@@ -958,5 +959,345 @@ describe('RLS Integration Tests: organizationId integrity on pricingModels', () 
       }
     )
     expect(checkPricingModel.length).toBe(0)
+  })
+})
+
+describe('whereClauseFromObject', () => {
+  let mockTable: any
+  
+  beforeEach(() => {
+    // Create a mock table with mock columns for testing
+    mockTable = {
+      id: { name: 'id' },
+      name: { name: 'name' },
+      email: { name: 'email' },
+      active: { name: 'active' },
+      organizationId: { name: 'organization_id' },
+      tags: { name: 'tags' },
+      count: { name: 'count' },
+      metadata: { name: 'metadata' }
+    }
+  })
+
+  describe('basic functionality', () => {
+    it('should return undefined for empty object', () => {
+      const result = whereClauseFromObject(mockTable, {})
+      expect(result).toBeUndefined()
+    })
+
+    it('should return undefined when all values are undefined', () => {
+      const selectConditions = {
+        id: undefined,
+        name: undefined,
+        email: undefined
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeUndefined()
+    })
+
+    it('should return undefined when all values are empty strings', () => {
+      const selectConditions = {
+        name: '',
+        email: '',
+        organizationId: ''
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeUndefined()
+    })
+
+    it('should return undefined for mixed undefined and empty string values', () => {
+      const selectConditions = {
+        id: undefined,
+        name: '',
+        email: undefined,
+        active: ''
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('single condition handling', () => {
+    it('should handle single string equality condition', () => {
+      const selectConditions = { name: 'test-name' }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle single boolean condition', () => {
+      const selectConditions = { active: true }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle single number condition', () => {
+      const selectConditions = { count: 42 }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle single null condition', () => {
+      const selectConditions = { metadata: null }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('multiple condition handling', () => {
+    it('should handle multiple conditions with AND logic', () => {
+      const selectConditions = {
+        name: 'test-name',
+        active: true,
+        count: 42
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should filter out undefined/empty values from mixed conditions', () => {
+      const selectConditions = {
+        name: 'test-name',
+        email: undefined,
+        active: true,
+        organizationId: '',
+        count: 0
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('array handling', () => {
+    it('should handle array with single value', () => {
+      const selectConditions = { tags: ['tag1'] }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle array with multiple values', () => {
+      const selectConditions = { tags: ['tag1', 'tag2', 'tag3'] }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle empty array', () => {
+      const selectConditions = { tags: [] }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should filter undefined and empty strings from arrays', () => {
+      const selectConditions = { tags: ['tag1', undefined, '', 'tag2', null] }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle array with only undefined/empty values', () => {
+      const selectConditions = { tags: [undefined, '', undefined] }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle mixed array types', () => {
+      const selectConditions = { 
+        tags: ['string', 123, true, null]
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('null value handling', () => {
+    it('should properly handle explicit null values', () => {
+      const selectConditions = { metadata: null }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle multiple null values', () => {
+      const selectConditions = {
+        metadata: null,
+        email: null,
+        name: 'test'
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('edge cases and data validation', () => {
+    it('should handle zero values correctly', () => {
+      const selectConditions = { count: 0 }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle false boolean values correctly', () => {
+      const selectConditions = { active: false }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle very long strings', () => {
+      const longString = 'a'.repeat(10000)
+      const selectConditions = { name: longString }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle special characters in string values', () => {
+      const selectConditions = { 
+        name: "O'Reilly & Co. <script>alert('test')</script>",
+        email: 'test+tag@example.com'
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle Unicode characters', () => {
+      const selectConditions = { 
+        name: '测试用户名 🚀 émoji',
+        email: 'тест@example.com'
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle very large arrays', () => {
+      const largeArray = Array.from({ length: 1000 }, (_, i) => `item-${i}`)
+      const selectConditions = { tags: largeArray }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle arrays with duplicate values', () => {
+      const selectConditions = { 
+        tags: ['tag1', 'tag1', 'tag2', 'tag1', 'tag2'] 
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('type coercion and conversion', () => {
+    it('should handle string numbers', () => {
+      const selectConditions = { count: '123' }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle string booleans', () => {
+      const selectConditions = { active: 'true' }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle mixed types in same condition set', () => {
+      const selectConditions = {
+        name: 'test',
+        count: 42,
+        active: true,
+        metadata: null,
+        tags: ['tag1', 'tag2']
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('edge case handling', () => {
+    it('should handle very deep nested structures safely', () => {
+      const selectConditions = {
+        metadata: { deep: { nested: { object: 'value' } } }
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('boundary value testing', () => {
+    it('should handle maximum safe integer', () => {
+      const selectConditions = { count: Number.MAX_SAFE_INTEGER }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle minimum safe integer', () => {
+      const selectConditions = { count: Number.MIN_SAFE_INTEGER }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle NaN values', () => {
+      const selectConditions = { count: NaN }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle Infinity values', () => {
+      const selectConditions = { count: Infinity }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('real-world usage patterns', () => {
+    it('should handle common filtering scenarios', () => {
+      const selectConditions = {
+        organizationId: 'org_123',
+        active: true,
+        tags: ['premium', 'verified'],
+        metadata: null
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle search-like scenarios with partial matches', () => {
+      const selectConditions = {
+        email: 'john@example.com',
+        name: 'John Doe',
+        active: true
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+
+    it('should handle pagination scenarios', () => {
+      const selectConditions = {
+        organizationId: 'org_123',
+        id: ['id1', 'id2', 'id3', 'id4', 'id5']
+      }
+      const result = whereClauseFromObject(mockTable, selectConditions)
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('data consistency', () => {
+    it('should produce consistent results for same inputs', () => {
+      const selectConditions = {
+        name: 'test-user',
+        active: true,
+        tags: ['tag1', 'tag2']
+      }
+      
+      const result1 = whereClauseFromObject(mockTable, selectConditions)
+      const result2 = whereClauseFromObject(mockTable, selectConditions)
+      
+      expect(result1).toBeDefined()
+      expect(result2).toBeDefined()
+      // Both should be defined and have same structure
+    })
+
+    it('should handle object property order independence', () => {
+      const selectConditions1 = { name: 'test', active: true, count: 42 }
+      const selectConditions2 = { active: true, count: 42, name: 'test' }
+      
+      const result1 = whereClauseFromObject(mockTable, selectConditions1)
+      const result2 = whereClauseFromObject(mockTable, selectConditions2)
+      
+      expect(result1).toBeDefined()
+      expect(result2).toBeDefined()
+    })
   })
 })

--- a/platform/flowglad-next/src/db/tableUtils.ts
+++ b/platform/flowglad-next/src/db/tableUtils.ts
@@ -328,7 +328,12 @@ export const whereClauseFromObject = <T extends PgTableWithId>(
   table: T,
   selectConditions: SelectConditions<T>
 ) => {
-  const keys = Object.keys(selectConditions)
+  const keys = Object.keys(selectConditions).filter((key) => {
+    const value = selectConditions[key]
+    // Filter out undefined, null (handled separately), and empty strings
+    // Allow empty arrays as they are valid filter values for inArray()
+    return value !== undefined && value !== ''
+  })
   if (keys.length === 0) {
     return undefined
   }
@@ -1520,7 +1525,7 @@ export const createCursorPaginatedSelectFunction = <
         .select({ count: count() })
         .from(table as SelectTable)
         .$dynamic()
-        .where(filterClause)
+        .where(and(filterClause, searchQueryClause))
 
       const data: z.infer<S>[] = queryResult
         .map((item) => selectSchema.parse(item))

--- a/platform/flowglad-next/src/db/tableUtils.ts
+++ b/platform/flowglad-next/src/db/tableUtils.ts
@@ -330,8 +330,9 @@ export const whereClauseFromObject = <T extends PgTableWithId>(
 ) => {
   const keys = Object.keys(selectConditions).filter((key) => {
     const value = selectConditions[key]
-    // Filter out undefined, null (handled separately), and empty strings
-    // Allow empty arrays as they are valid filter values for inArray()
+    // Filter out undefined and empty strings to prevent invalid SQL parameters
+    // null values are kept and handled separately by isNull() condition
+    // Arrays (including empty arrays) are kept for inArray() processing
     return value !== undefined && value !== ''
   })
   if (keys.length === 0) {
@@ -339,9 +340,11 @@ export const whereClauseFromObject = <T extends PgTableWithId>(
   }
   const conditions = keys.map((key) => {
     if (Array.isArray(selectConditions[key])) {
+      // Filter out undefined and empty strings from arrays to prevent SQL parameter issues
+      const cleanArray = selectConditions[key].filter((item: any) => item !== undefined && item !== '')
       return inArray(
         table[key as keyof typeof table] as PgColumn,
-        selectConditions[key]
+        cleanArray
       )
     }
     if (selectConditions[key] === null) {

--- a/platform/flowglad-next/src/server/routers/pricesRouter.test.ts
+++ b/platform/flowglad-next/src/server/routers/pricesRouter.test.ts
@@ -611,7 +611,7 @@ describe('pricesRouter - Default Price Constraints', () => {
       
       // Test the validation by trying to update the existing default price on default product
       await expect(
-        pricesRouter.createCaller(ctx).edit({
+        pricesRouter.createCaller(ctx).update({
           id: defaultPriceId,
           price: {
             id: defaultPriceId,


### PR DESCRIPTION
## Summary
- Fixes invalid SQL parameter binding errors in cursor pagination (e.g., "params: ,11" when customer_id is undefined)
- Ensures pagination count queries include search criteria for accurate totals
- Prevents undefined and empty string values from creating invalid WHERE clauses

## Root Cause
The `whereClauseFromObject` function was creating SQL conditions for undefined and empty string values, leading to invalid parameter binding. Additionally, the cursor pagination count query was inconsistent with the main query when search criteria were applied.

## Changes Made
1. **Filter invalid values in `whereClauseFromObject`**: Added filtering to exclude undefined and empty string values while preserving null handling and empty arrays
2. **Fix count query consistency**: Updated cursor pagination count query to include both filter and search clauses, matching the main query logic

## Test Plan
- [x] Linting and type checking pass
- [x] Registry validation passes  
- [ ] Test invoice table with undefined customer_id filter
- [ ] Verify pagination counts are correct when using search functionality
- [ ] Test other paginated tables to ensure no regressions

## Technical Details
- The fix prevents `eq(column, undefined)` from generating invalid SQL
- Count queries now properly reflect filtered + searched results instead of just filtered results
- No breaking changes - only filters out invalid conditions that would cause SQL errors

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed invalid SQL parameters in cursor pagination and aligned count queries with search filters, so totals match visible rows. Addresses Linear FG-130: invoices.getTableRows error when customer_id is undefined.

- **Bug Fixes**
  - Ignore undefined and empty string values when building WHERE clauses (null and empty arrays still supported).
  - Include searchQueryClause in the count query alongside filterClause for accurate pagination totals.

<!-- End of auto-generated description by cubic. -->

