### PR TITLE
feat: add billing portal URL to useBilling response with organization-only format

### DIFF
--- a/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.integration.test.ts
+++ b/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.integration.test.ts
@@ -289,10 +289,16 @@ describe('Customer Billing Portal Router', () => {
           pricingModel: expect.objectContaining({
             id: pricingModel.id,
           }),
+          billingPortalUrl: expect.any(String),
         })
 
         // Verify all invoices are returned when no pagination
         expect(result.invoices.length).toBeGreaterThanOrEqual(3)
+        
+        // Verify billing portal URL is properly formatted without customer external ID
+        expect(result.billingPortalUrl).toContain('/billing-portal/')
+        expect(result.billingPortalUrl).toContain(organization.id)
+        expect(result.billingPortalUrl).not.toContain(customer.externalId)
       }
     )
 
@@ -398,6 +404,38 @@ describe('Customer Billing Portal Router', () => {
           totalCount: 10, // 3 original + 7 new
           totalPages: 2, // 10 invoices / 5 per page
         })
+      }
+    )
+
+    test(
+      'generates correct billing portal URL with organization ID only',
+      { timeout: 10000 },
+      async () => {
+        const ctx = createTestContext()
+        const input = {}
+
+        const result = await customerBillingPortalRouter
+          .createCaller(ctx)
+          .getBilling(input)
+
+        // Test that billingPortalUrl is a valid URL
+        expect(result.billingPortalUrl).toBeDefined()
+        expect(typeof result.billingPortalUrl).toBe('string')
+        
+        // Validate URL format using URL constructor
+        expect(() => new URL(result.billingPortalUrl)).not.toThrow()
+        
+        // Test specific URL structure (without customer external ID)
+        const url = new URL(result.billingPortalUrl)
+        expect(url.pathname).toBe(`/billing-portal/${organization.id}`)
+        
+        // Test that URL contains expected components
+        expect(result.billingPortalUrl).toContain('/billing-portal/')
+        expect(result.billingPortalUrl).toContain(organization.id)
+        expect(result.billingPortalUrl).not.toContain(customer.externalId)
+        
+        // Test that URL is properly formatted (starts with http/https)
+        expect(result.billingPortalUrl).toMatch(/^https?:\/\//)
       }
     )
 

--- a/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.ts
+++ b/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.ts
@@ -49,7 +49,7 @@ import {
   selectUserById,
   selectUsers,
 } from '@/db/tableMethods/userMethods'
-import core, { customerBillingPortalURL } from '@/utils/core'
+import core, { organizationBillingPortalURL } from '@/utils/core'
 import { betterAuthUserToApplicationUser } from '@/utils/authHelpers'
 import { setCustomerBillingPortalOrganizationId } from '@/utils/customerBillingPortalState'
 import { selectBetterAuthUserById } from '@/db/tableMethods/betterAuthSchemaMethods'
@@ -107,6 +107,7 @@ const getBillingProcedure = customerProtectedProcedure
         ),
       catalog: pricingModelWithProductsAndUsageMetersSchema,
       pricingModel: pricingModelWithProductsAndUsageMetersSchema,
+      billingPortalUrl: z.url().describe('The billing portal URL for the customer'),
     })
   )
   .query(async ({ ctx, input }) => {
@@ -181,6 +182,9 @@ const getBillingProcedure = customerProtectedProcedure
       subscriptions,
       catalog: pricingModel,
       pricingModel,
+      billingPortalUrl: organizationBillingPortalURL({
+        organizationId: organizationId!,
+      }),
     }
   })
 

--- a/platform/flowglad-next/src/utils/core.test.ts
+++ b/platform/flowglad-next/src/utils/core.test.ts
@@ -21,3 +21,14 @@ describe('customerBillingPortalURL', () => {
     )
   })
 })
+
+describe('organizationBillingPortalURL', () => {
+  it('creates correct URL for billing portal with organization ID only', () => {
+    const url = core.organizationBillingPortalURL({
+      organizationId: 'organizationid',
+    })
+    expect(url).toBe(
+      'http://localhost:3000/billing-portal/organizationid'
+    )
+  })
+})

--- a/platform/flowglad-next/src/utils/core.ts
+++ b/platform/flowglad-next/src/utils/core.ts
@@ -499,6 +499,16 @@ export const customerBillingPortalURL = (params: {
   )
 }
 
+export const organizationBillingPortalURL = (params: {
+  organizationId: string
+}) => {
+  const { organizationId } = params
+  return safeUrl(
+    `/billing-portal/${organizationId}`,
+    process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
+  )
+}
+
 export const core = {
   IS_PROD,
   IS_TEST,
@@ -538,6 +548,7 @@ export const core = {
   formatDateRange,
   gitCommitId,
   customerBillingPortalURL,
+  organizationBillingPortalURL,
   safeZodNullOrUndefined,
   safeZodNullishString,
   safeZodPositiveInteger,


### PR DESCRIPTION
## Summary

✅ Add billing portal URL to `useBilling()` response using organization-only format  
✅ Address CTO feedback to remove customer external ID from API response URLs  
✅ Preserve existing functionality for emails, admin UI, and Stripe redirects  

## Changes Made

### New Organization-Only URL Function
- **Added `organizationBillingPortalURL()`**: Generates URLs with format `/billing-portal/{organizationId}` 
- **Preserved `customerBillingPortalURL()`**: Maintains existing format `/billing-portal/{organizationId}/{customerId}` for other use cases

### Updated useBilling() API Response  
- **Added `billingPortalUrl` field** to getBilling procedure output schema
- **Uses organization-only URL format** for API responses per CTO requirements
- **No breaking changes** to existing functionality

### Comprehensive Testing
- **Integration tests** verify API returns organization-only URLs without customer external ID
- **Unit tests** cover both URL generation functions  
- **All existing tests pass** - no regressions introduced

## Context & Rationale

### Why Organization-Only URLs for useBilling()?
- **API consumers already have customer context** when calling useBilling()
- **Better security** - no customer external IDs exposed in API response URLs
- **Future-ready** - aligns with planned magic link functionality  
- **Cleaner API design** - URLs don't need customer-specific routing for authenticated users

### Why Preserve Customer-Specific URLs Elsewhere?
- **Email links** - Work for users who may not be logged in
- **Admin UI** - Direct navigation to specific customer billing pages
- **Stripe redirects** - Proper post-payment routing to customer's billing portal

## Files Changed

- `src/utils/core.ts` - Added `organizationBillingPortalURL()` function
- `src/server/routers/customerBillingPortalRouter.ts` - Updated getBilling to include billingPortalUrl field  
- `src/utils/core.test.ts` - Unit tests for both URL functions
- `src/server/routers/customerBillingPortalRouter.integration.test.ts` - Integration tests for API response

## Test Plan

- [x] Unit tests pass for both URL generation functions
- [x] Integration tests verify getBilling includes billingPortalUrl field 
- [x] Integration tests confirm organization-only URL format
- [x] Integration tests verify customer external ID is NOT included
- [x] All existing functionality preserved (emails, admin UI, Stripe redirects)

🤖 Generated with [Claude Code](https://claude.ai/code)