### PR TITLE
Fix pricing-model/setup pr

### DIFF
--- a/platform/flowglad-next/src/server/routers/pricesRouter.test.ts
+++ b/platform/flowglad-next/src/server/routers/pricesRouter.test.ts
@@ -611,7 +611,7 @@ describe('pricesRouter - Default Price Constraints', () => {
       
       // Test the validation by trying to update the existing default price on default product
       await expect(
-        pricesRouter.createCaller(ctx).edit({
+        pricesRouter.createCaller(ctx).update({
           id: defaultPriceId,
           price: {
             id: defaultPriceId,


### PR DESCRIPTION
## What Does this PR Do?

change .edit to .update
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the default price constraints test to call pricesRouter.update instead of edit to match the current API. This prevents a method name mismatch and keeps the default price update validation working.

<!-- End of auto-generated description by cubic. -->

