### PR TITLE
Fix FG-168: Standardize API reference category naming and ensure list…

### DIFF
--- a/platform/flowglad-next/src/server/routers/paymentMethodsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/paymentMethodsRouter.ts
@@ -15,7 +15,7 @@ import { z } from 'zod'
 
 const { openApiMetas, routeConfigs } = generateOpenApiMetas({
   resource: 'PaymentMethod',
-  tags: ['PaymentMethods'],
+  tags: ['Payment Methods'],
 })
 
 export const paymentMethodsRouteConfigs = routeConfigs

--- a/platform/flowglad-next/src/server/routers/pricingModelsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/pricingModelsRouter.ts
@@ -203,7 +203,7 @@ const clonePricingModelProcedure = protectedProcedure
       method: 'POST',
       path: '/api/v1/pricing-models/{id}/clone',
       summary: 'Clone a PricingModel',
-      tags: ['PricingModels'],
+      tags: ['Pricing Models'],
       protect: true,
     },
   })
@@ -267,7 +267,7 @@ const setupPricingModelProcedure = protectedProcedure
       method: 'POST',
       path: '/api/v1/pricing-models/setup',
       summary: 'Setup a PricingModel',
-      tags: ['PricingModels'],
+      tags: ['Pricing Models'],
       protect: true,
     },
   })

--- a/platform/flowglad-next/src/server/routers/productFeaturesRouter.ts
+++ b/platform/flowglad-next/src/server/routers/productFeaturesRouter.ts
@@ -23,7 +23,7 @@ import { selectProductById } from '@/db/tableMethods/productMethods'
 
 const { openApiMetas, routeConfigs } = generateOpenApiMetas({
   resource: 'productFeature', // singular, camelCase
-  tags: ['ProductFeatures'], // plural, PascalCase
+  tags: ['Product Features'], // plural, space-separated
 })
 
 export const productFeaturesRouteConfigs = routeConfigs
@@ -109,7 +109,7 @@ export const expireProductFeature = protectedProcedure
       requireIdParam: true,
       summary:
         'Expire a product feature, making it no longer available for subscription items',
-      tags: ['ProductFeatures'],
+      tags: ['Product Features'],
     })
   )
   .input(idInputSchema) // Input is the ID of the ProductFeature record

--- a/platform/flowglad-next/src/server/routers/subscriptionItemFeaturesRouter.ts
+++ b/platform/flowglad-next/src/server/routers/subscriptionItemFeaturesRouter.ts
@@ -27,7 +27,7 @@ import { kebabCase } from 'change-case'
 
 const resourceName = 'subscriptionItemFeature' // Using camelCase for resource name consistent with other routers
 const pluralResourceName = 'subscriptionItemFeatures' // Explicitly define plural for openapi path
-const tags = ['SubscriptionItemFeatures']
+const tags = ['Subscription Item Features']
 
 const { openApiMetas, routeConfigs: baseRouteConfigsObj } =
   generateOpenApiMetas({

--- a/platform/flowglad-next/src/server/routers/usageEventsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/usageEventsRouter.ts
@@ -33,7 +33,7 @@ import { ingestAndProcessUsageEvent } from '@/utils/usage/usageEventHelpers'
 
 const { openApiMetas, routeConfigs } = generateOpenApiMetas({
   resource: 'usageEvent',
-  tags: ['UsageEvents'],
+  tags: ['Usage Events'],
 })
 
 export const usageEventsRouteConfigs = routeConfigs

--- a/platform/flowglad-next/src/server/routers/usageMetersRouter.ts
+++ b/platform/flowglad-next/src/server/routers/usageMetersRouter.ts
@@ -27,7 +27,7 @@ import { z } from 'zod'
 
 const { openApiMetas, routeConfigs } = generateOpenApiMetas({
   resource: 'usageMeter',
-  tags: ['UsageMeters'],
+  tags: ['Usage Meters'],
 })
 
 export const usageMetersRouteConfigs = routeConfigs


### PR DESCRIPTION
… usage events endpoint

- Updated all router tags from PascalCase to space-separated format:
  - PaymentMethods -> Payment Methods
  - PricingModels -> Pricing Models
  - ProductFeatures -> Product Features
  - SubscriptionItemFeatures -> Subscription Item Features
  - UsageEvents -> Usage Events
  - UsageMeters -> Usage Meters

Note: The list usage events endpoint is already correctly implemented and appears in the generated OpenAPI specification. The docs site may need to be refreshed to reflect these changes.

🤖 Generated with [Claude Code](https://claude.ai/code)

## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized API reference category names in OpenAPI router tags to use space-separated labels and confirmed the list Usage Events endpoint is correctly surfaced. Addresses Linear FG-168 to align generated OpenAPI with docs naming.

- **Refactors**
  - Updated tags to space-separated for: Payment Methods, Pricing Models, Product Features, Subscription Item Features, Usage Events, Usage Meters.

- **Migration**
  - Regenerate OpenAPI and refresh the docs site to reflect the new category names.

<!-- End of auto-generated description by cubic. -->

