### PR TITLE
feat: Add 48px minimum height to table rows

### DIFF
--- a/platform/flowglad-next/src/app/finance/subscriptions/[id]/InnerSubscriptionPage.tsx
+++ b/platform/flowglad-next/src/app/finance/subscriptions/[id]/InnerSubscriptionPage.tsx
@@ -39,7 +39,9 @@ const InnerSubscriptionPage = ({
                 className="flex flex-row items-center gap-2"
               />
             </div>
-            <SubscriptionStatusBadge status={subscription.status} />
+            <div className="w-fit">
+              <SubscriptionStatusBadge status={subscription.status} />
+            </div>
           </div>
         </div>
         <TableHeader title="Details" noButtons />

--- a/platform/flowglad-next/src/components/ui/table.tsx
+++ b/platform/flowglad-next/src/components/ui/table.tsx
@@ -66,7 +66,7 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      'border-b transition-colors hover:bg-muted data-[state=selected]:bg-muted',
+      'min-h-[48px] border-b transition-colors hover:bg-muted data-[state=selected]:bg-muted',
       className
     )}
     {...props}


### PR DESCRIPTION
## Changes
- Added `min-h-[48px]` to the base TableRow component for consistent vertical spacing across all tables

## Impact
This change applies to all tables in the application that use the Shadcn UI TableRow component, including:
- ProductsDataTable
- CustomersDataTable
- DiscountsDataTable
- PricingModelsDataTable
- Generic DataTable component
- All other tables using the base table components

## Testing
- ✅ No linter errors introduced
- ✅ Change is purely visual/styling
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set a 48px minimum height on TableRow to standardize row spacing across all tables and improve readability. Also wrapped SubscriptionStatusBadge in a w-fit container to prevent stretching in the subscription page header.

<!-- End of auto-generated description by cubic. -->

