### PR TITLE
add customer object with external id and internal id to webhooks

### DIFF
--- a/platform/flowglad-next/src/db/authenticatedTransaction.test.ts
+++ b/platform/flowglad-next/src/db/authenticatedTransaction.test.ts
@@ -275,6 +275,10 @@ describe('comprehensiveAuthenticatedTransaction', () => {
           payload: {
             object: EventNoun.Payment,
             id: 'test_event_1',
+            customer: {
+              id: 'test_customer_id',
+              externalId: 'test_external_id',
+            },
           },
           organizationId: testOrg1.id,
           metadata: {},

--- a/platform/flowglad-next/src/db/schema/events.ts
+++ b/platform/flowglad-next/src/db/schema/events.ts
@@ -112,12 +112,10 @@ export const events = pgTable(
 export const eventPayloadSchema = z.object({
   id: z.string(),
   object: core.createSafeZodEnum(EventNoun),
-  customer: z
-    .object({
-      id: z.string(),
-      externalId: z.string(),
-    })
-    .optional(),
+  customer: z.object({
+    id: z.string(),
+    externalId: z.string(),
+  }),
 })
 
 const columnRefinements = {

--- a/platform/flowglad-next/src/db/schema/events.ts
+++ b/platform/flowglad-next/src/db/schema/events.ts
@@ -112,10 +112,14 @@ export const events = pgTable(
 export const eventPayloadSchema = z.object({
   id: z.string(),
   object: core.createSafeZodEnum(EventNoun),
-  customer: z.object({
-    id: z.string(),
-    externalId: z.string(),
-  }),
+  // TODO: Make customer required after running DB migration to update existing events
+  // with customer payloads. Currently optional to avoid breaking existing events.
+  customer: z
+    .object({
+      id: z.string(),
+      externalId: z.string(),
+    })
+    .optional(),
 })
 
 const columnRefinements = {

--- a/platform/flowglad-next/src/subscriptions/createSubscription/workflow.ts
+++ b/platform/flowglad-next/src/subscriptions/createSubscription/workflow.ts
@@ -140,6 +140,11 @@ export const createSubscriptionWorkflow = async (
     updatedSubscription.customerId,
     transaction
   )
+  
+  if (!customer) {
+    throw new Error(`Customer not found for subscription ${updatedSubscription.id}`)
+  }
+  
   const eventInserts: Event.Insert[] = [
     {
       type: FlowgladEventType.SubscriptionCreated,
@@ -149,12 +154,10 @@ export const createSubscriptionWorkflow = async (
       payload: {
         object: EventNoun.Subscription,
         id: updatedSubscription.id,
-        customer: customer
-          ? {
-              id: customer.id,
-              externalId: customer.externalId,
-            }
-          : undefined,
+        customer: {
+          id: customer.id,
+          externalId: customer.externalId,
+        },
       },
       submittedAt: timestamp,
       hash: constructSubscriptionCreatedEventHash(

--- a/platform/flowglad-next/src/utils/bookkeeping.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping.ts
@@ -396,6 +396,10 @@ export const createCustomerBookkeeping = async (
     payload: {
       object: EventNoun.Customer,
       id: customer.id,
+      customer:{
+        id: customer.id,
+        externalId: customer.externalId,
+      }
     },
     submittedAt: timestamp,
     hash: constructCustomerCreatedEventHash(customer),

--- a/platform/flowglad-next/src/utils/bookkeeping/processPaymentIntentStatusUpdated.test.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/processPaymentIntentStatusUpdated.test.ts
@@ -1763,6 +1763,10 @@ describe('Process payment intent status updated', async () => {
       expect(purchaseCompletedEvent!.payload).toEqual({
         id: purchase.id,
         object: EventNoun.Purchase,
+        customer: {
+          id: customer.id,
+          externalId: customer.externalId,
+        },
       })
       expect(purchaseCompletedEvent!.processedAt).toBeNull()
     })
@@ -2068,6 +2072,10 @@ describe('Process payment intent status updated', async () => {
       expect(purchaseCompletedEvent!.payload).toEqual({
         id: purchase.id,
         object: EventNoun.Purchase,
+        customer: {
+          id: customer.id,
+          externalId: customer.externalId,
+        },
       })
     })
 

--- a/platform/flowglad-next/src/utils/bookkeeping/processPaymentIntentStatusUpdated.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/processPaymentIntentStatusUpdated.ts
@@ -532,6 +532,10 @@ export const processPaymentIntentStatusUpdated = async (
       payload: {
         id: payment.id,
         object: EventNoun.Payment,
+        customer: {
+          id: customer.id,
+          externalId: customer.externalId,
+        },
       },
       submittedAt: timestamp,
       hash: constructPaymentFailedEventHash(payment),
@@ -540,6 +544,10 @@ export const processPaymentIntentStatusUpdated = async (
     })
   }
   if (purchase && purchase.status === PurchaseStatus.Paid) {
+    const customer = await selectCustomerById(
+      purchase.customerId,
+      transaction
+    )
     eventInserts.push({
       type: FlowgladEventType.PurchaseCompleted,
       occurredAt: timestamp,
@@ -548,6 +556,12 @@ export const processPaymentIntentStatusUpdated = async (
       payload: {
         id: purchase.id,
         object: EventNoun.Purchase,
+        customer: customer
+          ? {
+              id: customer.id,
+              externalId: customer.externalId,
+            }
+          : undefined,
       },
       submittedAt: timestamp,
       hash: constructPurchaseCompletedEventHash(purchase),

--- a/platform/flowglad-next/src/utils/bookkeeping/processSetupIntent.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/processSetupIntent.ts
@@ -425,6 +425,10 @@ export const createSubscriptionFromSetupIntentableCheckoutSession =
   ): Promise<
     TransactionOutput<ProcessSubscriptionCreatingCheckoutSessionSetupIntentSucceededResult>
   > => {
+    if (!customer) {
+      throw new Error(`Customer is required for setup intent ${setupIntent.id}`)
+    }
+    
     if (!isCheckoutSessionSubscriptionCreating(checkoutSession)) {
       throw new Error(
         `createSubscriptionFromSetupIntentableCheckoutSession: checkout session ${checkoutSession.id} is not supported because it is of type ${checkoutSession.type}.`
@@ -579,6 +583,11 @@ export const createSubscriptionFromSetupIntentableCheckoutSession =
         output.result.subscription.customerId,
         transaction
       )
+      
+      if (!customer) {
+        throw new Error(`Customer not found for subscription ${output.result.subscription.id}`)
+      }
+      
       eventInserts.push({
         type: FlowgladEventType.SubscriptionCreated,
         occurredAt: new Date(),
@@ -593,12 +602,10 @@ export const createSubscriptionFromSetupIntentableCheckoutSession =
         payload: {
           object: EventNoun.Subscription,
           id: output.result.subscription.id,
-          customer: customer
-            ? {
-                id: customer.id,
-                externalId: customer.externalId,
-              }
-            : undefined,
+          customer: {
+            id: customer.id,
+            externalId: customer.externalId,
+          },
         },
       })
     }
@@ -612,7 +619,7 @@ export const createSubscriptionFromSetupIntentableCheckoutSession =
       },
       transaction
     )
-    
+
     eventInserts.push({
       type: FlowgladEventType.PurchaseCompleted,
       occurredAt: new Date(),
@@ -625,12 +632,10 @@ export const createSubscriptionFromSetupIntentableCheckoutSession =
       payload: {
         id: updatedPurchase.id,
         object: EventNoun.Purchase,
-        customer: customer
-          ? {
-              id: customer.id,
-              externalId: customer.externalId,
-            }
-          : undefined,
+        customer: {
+          id: customer.id,
+          externalId: customer.externalId,
+        },
       },
     })
 

--- a/platform/flowglad-next/src/utils/bookkeeping/processSetupIntent.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/processSetupIntent.ts
@@ -575,6 +575,10 @@ export const createSubscriptionFromSetupIntentableCheckoutSession =
         transaction
       )
       // Add upgrade event to the events to log
+      const customer = await selectCustomerById(
+        output.result.subscription.customerId,
+        transaction
+      )
       eventInserts.push({
         type: FlowgladEventType.SubscriptionCreated,
         occurredAt: new Date(),
@@ -589,6 +593,12 @@ export const createSubscriptionFromSetupIntentableCheckoutSession =
         payload: {
           object: EventNoun.Subscription,
           id: output.result.subscription.id,
+          customer: customer
+            ? {
+                id: customer.id,
+                externalId: customer.externalId,
+              }
+            : undefined,
         },
       })
     }
@@ -602,6 +612,7 @@ export const createSubscriptionFromSetupIntentableCheckoutSession =
       },
       transaction
     )
+    
     eventInserts.push({
       type: FlowgladEventType.PurchaseCompleted,
       occurredAt: new Date(),
@@ -614,6 +625,12 @@ export const createSubscriptionFromSetupIntentableCheckoutSession =
       payload: {
         id: updatedPurchase.id,
         object: EventNoun.Purchase,
+        customer: customer
+          ? {
+              id: customer.id,
+              externalId: customer.externalId,
+            }
+          : undefined,
       },
     })
 

--- a/platform/flowglad-next/src/utils/events.test.ts
+++ b/platform/flowglad-next/src/utils/events.test.ts
@@ -13,10 +13,11 @@ import { FlowgladEventType, EventNoun, PaymentStatus, PriceType, CurrencyCode, I
 import { adminTransaction } from '@/db/adminTransaction'
 import { selectEvents } from '@/db/tableMethods/eventMethods'
 import { setupOrg, setupCustomer, setupPaymentMethod, setupInvoice, setupPrice, setupProduct, setupPurchase, setupSubscription, setupPricingModel } from '@/../seedDatabase'
+import { insertPayment } from '@/db/tableMethods/paymentMethods'
 import core from './core'
 
 describe('Webhook Event Payloads - Simple Real Tests', () => {
-  it('should include externalId in CustomerCreated event payload', async () => {
+  it('should include customer.externalId in CustomerCreated event payload', async () => {
     // Set up minimal database state
     const orgData = await setupOrg()
     const customer = await setupCustomer({
@@ -51,7 +52,7 @@ describe('Webhook Event Payloads - Simple Real Tests', () => {
     })
   })
 
-  it('should include externalId in CustomerUpdated event payload', async () => {
+  it('should include customer.externalId in CustomerUpdated event payload', async () => {
     const orgData = await setupOrg()
     const customer = await setupCustomer({
       organizationId: orgData.organization.id,
@@ -82,7 +83,7 @@ describe('Webhook Event Payloads - Simple Real Tests', () => {
     })
   })
 
-  it('should include externalId in PaymentSucceeded event payload', async () => {
+  it('should include customer.externalId in PaymentSucceeded event payload', async () => {
     const orgData = await setupOrg()
     const customer = await setupCustomer({
       organizationId: orgData.organization.id,
@@ -126,7 +127,6 @@ describe('Webhook Event Payloads - Simple Real Tests', () => {
     })
     
     const payment = await adminTransaction(async ({ transaction }) => {
-      const { insertPayment } = await import('@/db/tableMethods/paymentMethods')
       return await insertPayment({
         stripeChargeId: `ch_${core.nanoid()}`,
         status: PaymentStatus.Succeeded,
@@ -165,7 +165,7 @@ describe('Webhook Event Payloads - Simple Real Tests', () => {
     })
   })
 
-  it('should include externalId in PaymentFailed event payload', async () => {
+  it('should include customer.externalId in PaymentFailed event payload', async () => {
     const orgData = await setupOrg()
     const customer = await setupCustomer({
       organizationId: orgData.organization.id,
@@ -209,7 +209,6 @@ describe('Webhook Event Payloads - Simple Real Tests', () => {
     })
     
     const payment = await adminTransaction(async ({ transaction }) => {
-      const { insertPayment } = await import('@/db/tableMethods/paymentMethods')
       return await insertPayment({
         stripeChargeId: `ch_${core.nanoid()}`,
         status: PaymentStatus.Failed,
@@ -248,7 +247,7 @@ describe('Webhook Event Payloads - Simple Real Tests', () => {
     })
   })
 
-  it('should include externalId in PurchaseCompleted event payload', async () => {
+  it('should include customer.externalId in PurchaseCompleted event payload', async () => {
     const orgData = await setupOrg()
     const customer = await setupCustomer({
       organizationId: orgData.organization.id,
@@ -308,7 +307,7 @@ describe('Webhook Event Payloads - Simple Real Tests', () => {
     })
   })
 
-  it('should include externalId in SubscriptionCreated event payload', async () => {
+  it('should include customer.externalId in SubscriptionCreated event payload', async () => {
     const orgData = await setupOrg()
     const customer = await setupCustomer({
       organizationId: orgData.organization.id,
@@ -374,7 +373,7 @@ describe('Webhook Event Payloads - Simple Real Tests', () => {
     })
   })
 
-  it('should include externalId in SubscriptionUpdated event payload', async () => {
+  it('should include customer.externalId in SubscriptionUpdated event payload', async () => {
     const orgData = await setupOrg()
     const customer = await setupCustomer({
       organizationId: orgData.organization.id,
@@ -440,7 +439,7 @@ describe('Webhook Event Payloads - Simple Real Tests', () => {
     })
   })
 
-  it('should include externalId in SubscriptionCancelled event payload', async () => {
+  it('should include customer.externalId in SubscriptionCancelled event payload', async () => {
     const orgData = await setupOrg()
     const customer = await setupCustomer({
       organizationId: orgData.organization.id,

--- a/platform/flowglad-next/src/utils/events.test.ts
+++ b/platform/flowglad-next/src/utils/events.test.ts
@@ -1,0 +1,508 @@
+import { describe, it, expect } from 'vitest'
+import { 
+  commitCustomerCreatedEvent,
+  commitCustomerUpdatedEvent,
+  commitPaymentSucceededEvent,
+  commitPaymentCanceledEvent,
+  commitPurchaseCompletedEvent,
+  commitSubscriptionCreatedEvent,
+  commitSubscriptionUpdatedEvent,
+  commitSubscriptionCancelledEvent
+} from './events'
+import { FlowgladEventType, EventNoun, PaymentStatus, PriceType, CurrencyCode, IntervalUnit, PaymentMethodType } from '@/types'
+import { adminTransaction } from '@/db/adminTransaction'
+import { selectEvents } from '@/db/tableMethods/eventMethods'
+import { setupOrg, setupCustomer, setupPaymentMethod, setupInvoice, setupPrice, setupProduct, setupPurchase, setupSubscription, setupPricingModel } from '@/../seedDatabase'
+import core from './core'
+
+describe('Webhook Event Payloads - Simple Real Tests', () => {
+  it('should include externalId in CustomerCreated event payload', async () => {
+    // Set up minimal database state
+    const orgData = await setupOrg()
+    const customer = await setupCustomer({
+      organizationId: orgData.organization.id,
+      externalId: `ext_cust_${core.nanoid()}`,
+      livemode: true,
+    })
+
+    // Call the actual function
+    await adminTransaction(async ({ transaction }) => {
+      await commitCustomerCreatedEvent(customer, transaction)
+    })
+
+    // Query the database to get the actual event that was created
+    const events = await adminTransaction(async ({ transaction }) => {
+      return await selectEvents({ organizationId: orgData.organization.id }, transaction)
+    })
+
+    const customerCreatedEvent = events.find(
+      e => e.type === FlowgladEventType.CustomerCreated
+    )
+
+    // Verify the real payload includes externalId
+    expect(customerCreatedEvent).toBeDefined()
+    expect(customerCreatedEvent!.payload).toEqual({
+      id: customer.id,
+      object: EventNoun.Customer,
+      customer: {
+        id: customer.id,
+        externalId: customer.externalId,
+      },
+    })
+  })
+
+  it('should include externalId in CustomerUpdated event payload', async () => {
+    const orgData = await setupOrg()
+    const customer = await setupCustomer({
+      organizationId: orgData.organization.id,
+      externalId: `ext_cust_${core.nanoid()}`,
+      livemode: true,
+    })
+
+    await adminTransaction(async ({ transaction }) => {
+      await commitCustomerUpdatedEvent(customer, transaction)
+    })
+
+    const events = await adminTransaction(async ({ transaction }) => {
+      return await selectEvents({ organizationId: orgData.organization.id }, transaction)
+    })
+
+    const customerUpdatedEvent = events.find(
+      e => e.type === FlowgladEventType.CustomerUpdated
+    )
+
+    expect(customerUpdatedEvent).toBeDefined()
+    expect(customerUpdatedEvent!.payload).toEqual({
+      id: customer.id,
+      object: EventNoun.Customer,
+      customer: {
+        id: customer.id,
+        externalId: customer.externalId,
+      },
+    })
+  })
+
+  it('should include externalId in PaymentSucceeded event payload', async () => {
+    const orgData = await setupOrg()
+    const customer = await setupCustomer({
+      organizationId: orgData.organization.id,
+      externalId: `ext_cust_${core.nanoid()}`,
+      livemode: true,
+    })
+    
+    // Set up required dependencies for payment
+    const pricingModel = await setupPricingModel({
+      organizationId: orgData.organization.id,
+      livemode: true,
+    })
+    const product = await setupProduct({
+      organizationId: orgData.organization.id,
+      name: `Test Product ${core.nanoid()}`,
+      pricingModelId: pricingModel.id,
+      livemode: true,
+    })
+    const price = await setupPrice({
+      productId: product.id,
+      name: 'Test Price',
+      type: PriceType.SinglePayment,
+      unitPrice: 5000,
+      intervalUnit: IntervalUnit.Month,
+      intervalCount: 1,
+      isDefault: false,
+      livemode: true,
+    })
+    const invoice = await setupInvoice({
+      organizationId: orgData.organization.id,
+      customerId: customer.id,
+      priceId: price.id,
+      livemode: true,
+    })
+    
+    const paymentMethod = await setupPaymentMethod({
+      customerId: customer.id,
+      organizationId: orgData.organization.id,
+      type: PaymentMethodType.Card,
+      livemode: true,
+    })
+    
+    const payment = await adminTransaction(async ({ transaction }) => {
+      const { insertPayment } = await import('@/db/tableMethods/paymentMethods')
+      return await insertPayment({
+        stripeChargeId: `ch_${core.nanoid()}`,
+        status: PaymentStatus.Succeeded,
+        amount: 5000,
+        currency: CurrencyCode.USD,
+        chargeDate: new Date(),
+        paymentMethod: PaymentMethodType.Card,
+        livemode: true,
+        customerId: customer.id,
+        organizationId: orgData.organization.id,
+        stripePaymentIntentId: `pi_${core.nanoid()}`,
+        invoiceId: invoice.id,
+      }, transaction)
+    })
+
+    await adminTransaction(async ({ transaction }) => {
+      await commitPaymentSucceededEvent(payment, transaction)
+    })
+
+    const events = await adminTransaction(async ({ transaction }) => {
+      return await selectEvents({ organizationId: orgData.organization.id }, transaction)
+    })
+
+    const paymentSucceededEvent = events.find(
+      e => e.type === FlowgladEventType.PaymentSucceeded
+    )
+
+    expect(paymentSucceededEvent).toBeDefined()
+    expect(paymentSucceededEvent!.payload).toEqual({
+      id: payment.id,
+      object: EventNoun.Payment,
+      customer: {
+        id: customer.id,
+        externalId: customer.externalId,
+      },
+    })
+  })
+
+  it('should include externalId in PaymentFailed event payload', async () => {
+    const orgData = await setupOrg()
+    const customer = await setupCustomer({
+      organizationId: orgData.organization.id,
+      externalId: `ext_cust_${core.nanoid()}`,
+      livemode: true,
+    })
+    
+    // Set up required dependencies for payment
+    const pricingModel = await setupPricingModel({
+      organizationId: orgData.organization.id,
+      livemode: true,
+    })
+    const product = await setupProduct({
+      organizationId: orgData.organization.id,
+      name: `Test Product ${core.nanoid()}`,
+      pricingModelId: pricingModel.id,
+      livemode: true,
+    })
+    const price = await setupPrice({
+      productId: product.id,
+      name: 'Test Price',
+      type: PriceType.SinglePayment,
+      unitPrice: 5000,
+      intervalUnit: IntervalUnit.Month,
+      intervalCount: 1,
+      isDefault: false,
+      livemode: true,
+    })
+    const invoice = await setupInvoice({
+      organizationId: orgData.organization.id,
+      customerId: customer.id,
+      priceId: price.id,
+      livemode: true,
+    })
+    
+    const paymentMethod = await setupPaymentMethod({
+      customerId: customer.id,
+      organizationId: orgData.organization.id,
+      type: PaymentMethodType.Card,
+      livemode: true,
+    })
+    
+    const payment = await adminTransaction(async ({ transaction }) => {
+      const { insertPayment } = await import('@/db/tableMethods/paymentMethods')
+      return await insertPayment({
+        stripeChargeId: `ch_${core.nanoid()}`,
+        status: PaymentStatus.Failed,
+        amount: 5000,
+        currency: CurrencyCode.USD,
+        chargeDate: new Date(),
+        paymentMethod: PaymentMethodType.Card,
+        livemode: true,
+        customerId: customer.id,
+        organizationId: orgData.organization.id,
+        stripePaymentIntentId: `pi_${core.nanoid()}`,
+        invoiceId: invoice.id,
+      }, transaction)
+    })
+
+    await adminTransaction(async ({ transaction }) => {
+      await commitPaymentCanceledEvent(payment, transaction)
+    })
+
+    const events = await adminTransaction(async ({ transaction }) => {
+      return await selectEvents({ organizationId: orgData.organization.id }, transaction)
+    })
+
+    const paymentFailedEvent = events.find(
+      e => e.type === FlowgladEventType.PaymentFailed
+    )
+
+    expect(paymentFailedEvent).toBeDefined()
+    expect(paymentFailedEvent!.payload).toEqual({
+      id: payment.id,
+      object: EventNoun.Payment,
+      customer: {
+        id: customer.id,
+        externalId: customer.externalId,
+      },
+    })
+  })
+
+  it('should include externalId in PurchaseCompleted event payload', async () => {
+    const orgData = await setupOrg()
+    const customer = await setupCustomer({
+      organizationId: orgData.organization.id,
+      externalId: `ext_cust_${core.nanoid()}`,
+      livemode: true,
+    })
+    
+    // Set up required dependencies for purchase
+    const pricingModel = await setupPricingModel({
+      organizationId: orgData.organization.id,
+      livemode: true,
+    })
+    const product = await setupProduct({
+      organizationId: orgData.organization.id,
+      name: `Test Product ${core.nanoid()}`,
+      pricingModelId: pricingModel.id,
+      livemode: true,
+    })
+    const price = await setupPrice({
+      productId: product.id,
+      name: 'Test Price',
+      type: PriceType.SinglePayment,
+      unitPrice: 5000,
+      intervalUnit: IntervalUnit.Month,
+      intervalCount: 1,
+      isDefault: false,
+      livemode: true,
+    })
+    
+    const purchase = await setupPurchase({
+      organizationId: orgData.organization.id,
+      customerId: customer.id,
+      priceId: price.id,
+      livemode: true,
+    })
+
+    await adminTransaction(async ({ transaction }) => {
+      await commitPurchaseCompletedEvent(purchase, transaction)
+    })
+
+    const events = await adminTransaction(async ({ transaction }) => {
+      return await selectEvents({ organizationId: orgData.organization.id }, transaction)
+    })
+
+    const purchaseCompletedEvent = events.find(
+      e => e.type === FlowgladEventType.PurchaseCompleted
+    )
+
+    expect(purchaseCompletedEvent).toBeDefined()
+    expect(purchaseCompletedEvent!.payload).toEqual({
+      id: purchase.id,
+      object: EventNoun.Purchase,
+      customer: {
+        id: customer.id,
+        externalId: customer.externalId,
+      },
+    })
+  })
+
+  it('should include externalId in SubscriptionCreated event payload', async () => {
+    const orgData = await setupOrg()
+    const customer = await setupCustomer({
+      organizationId: orgData.organization.id,
+      externalId: `ext_cust_${core.nanoid()}`,
+      livemode: true,
+    })
+    
+    // Set up required dependencies for subscription
+    const pricingModel = await setupPricingModel({
+      organizationId: orgData.organization.id,
+      livemode: true,
+    })
+    const product = await setupProduct({
+      organizationId: orgData.organization.id,
+      name: `Test Product ${core.nanoid()}`,
+      pricingModelId: pricingModel.id,
+      livemode: true,
+    })
+    const price = await setupPrice({
+      productId: product.id,
+      name: 'Test Price',
+      type: PriceType.SinglePayment,
+      unitPrice: 5000,
+      intervalUnit: IntervalUnit.Month,
+      intervalCount: 1,
+      isDefault: false,
+      livemode: true,
+    })
+    const paymentMethod = await setupPaymentMethod({
+      organizationId: orgData.organization.id,
+      customerId: customer.id,
+      livemode: true,
+    })
+    
+    const subscription = await setupSubscription({
+      organizationId: orgData.organization.id,
+      customerId: customer.id,
+      priceId: price.id,
+      paymentMethodId: paymentMethod.id,
+      livemode: true,
+    })
+
+    await adminTransaction(async ({ transaction }) => {
+      await commitSubscriptionCreatedEvent(subscription, transaction)
+    })
+
+    const events = await adminTransaction(async ({ transaction }) => {
+      return await selectEvents({ organizationId: orgData.organization.id }, transaction)
+    })
+
+    const subscriptionCreatedEvent = events.find(
+      e => e.type === FlowgladEventType.SubscriptionCreated
+    )
+
+    expect(subscriptionCreatedEvent).toBeDefined()
+    expect(subscriptionCreatedEvent!.payload).toEqual({
+      id: subscription.id,
+      object: EventNoun.Subscription,
+      customer: {
+        id: customer.id,
+        externalId: customer.externalId,
+      },
+    })
+  })
+
+  it('should include externalId in SubscriptionUpdated event payload', async () => {
+    const orgData = await setupOrg()
+    const customer = await setupCustomer({
+      organizationId: orgData.organization.id,
+      externalId: `ext_cust_${core.nanoid()}`,
+      livemode: true,
+    })
+    
+    // Set up required dependencies for subscription
+    const pricingModel = await setupPricingModel({
+      organizationId: orgData.organization.id,
+      livemode: true,
+    })
+    const product = await setupProduct({
+      organizationId: orgData.organization.id,
+      name: `Test Product ${core.nanoid()}`,
+      pricingModelId: pricingModel.id,
+      livemode: true,
+    })
+    const price = await setupPrice({
+      productId: product.id,
+      name: 'Test Price',
+      type: PriceType.SinglePayment,
+      unitPrice: 5000,
+      intervalUnit: IntervalUnit.Month,
+      intervalCount: 1,
+      isDefault: false,
+      livemode: true,
+    })
+    const paymentMethod = await setupPaymentMethod({
+      organizationId: orgData.organization.id,
+      customerId: customer.id,
+      livemode: true,
+    })
+    
+    const subscription = await setupSubscription({
+      organizationId: orgData.organization.id,
+      customerId: customer.id,
+      priceId: price.id,
+      paymentMethodId: paymentMethod.id,
+      livemode: true,
+    })
+
+    await adminTransaction(async ({ transaction }) => {
+      await commitSubscriptionUpdatedEvent(subscription, transaction)
+    })
+
+    const events = await adminTransaction(async ({ transaction }) => {
+      return await selectEvents({ organizationId: orgData.organization.id }, transaction)
+    })
+
+    const subscriptionUpdatedEvent = events.find(
+      e => e.type === FlowgladEventType.SubscriptionUpdated
+    )
+
+    expect(subscriptionUpdatedEvent).toBeDefined()
+    expect(subscriptionUpdatedEvent!.payload).toEqual({
+      id: subscription.id,
+      object: EventNoun.Subscription,
+      customer: {
+        id: customer.id,
+        externalId: customer.externalId,
+      },
+    })
+  })
+
+  it('should include externalId in SubscriptionCancelled event payload', async () => {
+    const orgData = await setupOrg()
+    const customer = await setupCustomer({
+      organizationId: orgData.organization.id,
+      externalId: `ext_cust_${core.nanoid()}`,
+      livemode: true,
+    })
+    
+    // Set up required dependencies for subscription
+    const pricingModel = await setupPricingModel({
+      organizationId: orgData.organization.id,
+      livemode: true,
+    })
+    const product = await setupProduct({
+      organizationId: orgData.organization.id,
+      name: `Test Product ${core.nanoid()}`,
+      pricingModelId: pricingModel.id,
+      livemode: true,
+    })
+    const price = await setupPrice({
+      productId: product.id,
+      name: 'Test Price',
+      type: PriceType.SinglePayment,
+      unitPrice: 5000,
+      intervalUnit: IntervalUnit.Month,
+      intervalCount: 1,
+      isDefault: false,
+      livemode: true,
+    })
+    const paymentMethod = await setupPaymentMethod({
+      organizationId: orgData.organization.id,
+      customerId: customer.id,
+      livemode: true,
+    })
+    
+    const subscription = await setupSubscription({
+      organizationId: orgData.organization.id,
+      customerId: customer.id,
+      priceId: price.id,
+      paymentMethodId: paymentMethod.id,
+      livemode: true,
+    })
+
+    await adminTransaction(async ({ transaction }) => {
+      await commitSubscriptionCancelledEvent(subscription, transaction)
+    })
+
+    const events = await adminTransaction(async ({ transaction }) => {
+      return await selectEvents({ organizationId: orgData.organization.id }, transaction)
+    })
+
+    const subscriptionCancelledEvent = events.find(
+      e => e.type === FlowgladEventType.SubscriptionCancelled
+    )
+
+    expect(subscriptionCancelledEvent).toBeDefined()
+    expect(subscriptionCancelledEvent!.payload).toEqual({
+      id: subscription.id,
+      object: EventNoun.Subscription,
+      customer: {
+        id: customer.id,
+        externalId: customer.externalId,
+      },
+    })
+  })
+})

--- a/platform/flowglad-next/src/utils/events.ts
+++ b/platform/flowglad-next/src/utils/events.ts
@@ -79,6 +79,11 @@ export const commitPaymentSucceededEvent = async (
     payment.customerId,
     transaction
   )
+  
+  if (!customer) {
+    throw new Error(`Customer not found for payment ${payment.id}`)
+  }
+  
   return commitEvent(
     {
       type: FlowgladEventType.PaymentSucceeded,
@@ -87,12 +92,10 @@ export const commitPaymentSucceededEvent = async (
       payload: {
         id: payment.id,
         object: EventNoun.Payment,
-        customer: customer
-          ? {
-              id: customer.id,
-              externalId: customer.externalId,
-            }
-          : undefined,
+        customer: {
+          id: customer.id,
+          externalId: customer.externalId,
+        },
       },
       organizationId: payment.organizationId,
       livemode: payment.livemode,
@@ -109,6 +112,11 @@ export const commitPaymentCanceledEvent = async (
     payment.customerId,
     transaction
   )
+  
+  if (!customer) {
+    throw new Error(`Customer not found for payment ${payment.id}`)
+  }
+  
   return commitEvent(
     {
       type: FlowgladEventType.PaymentFailed,
@@ -117,12 +125,10 @@ export const commitPaymentCanceledEvent = async (
       payload: {
         id: payment.id,
         object: EventNoun.Payment,
-        customer: customer
-          ? {
-              id: customer.id,
-              externalId: customer.externalId,
-            }
-          : undefined,
+        customer: {
+          id: customer.id,
+          externalId: customer.externalId,
+        },
       },
       organizationId: payment.organizationId,
       livemode: payment.livemode,
@@ -187,6 +193,11 @@ export const commitPurchaseCompletedEvent = async (
     purchase.customerId,
     transaction
   )
+  
+  if (!customer) {
+    throw new Error(`Customer not found for purchase ${purchase.id}`)
+  }
+  
   return commitEvent(
     {
       type: FlowgladEventType.PurchaseCompleted,
@@ -195,12 +206,10 @@ export const commitPurchaseCompletedEvent = async (
       payload: {
         id: purchase.id,
         object: EventNoun.Purchase,
-        customer: customer
-          ? {
-              id: customer.id,
-              externalId: customer.externalId,
-            }
-          : undefined,
+        customer: {
+          id: customer.id,
+          externalId: customer.externalId,
+        },
       },
       organizationId: purchase.organizationId,
       livemode: purchase.livemode,
@@ -217,6 +226,11 @@ export const commitSubscriptionCreatedEvent = async (
     subscription.customerId,
     transaction
   )
+  
+  if (!customer) {
+    throw new Error(`Customer not found for subscription ${subscription.id}`)
+  }
+  
   return commitEvent(
     {
       type: FlowgladEventType.SubscriptionCreated,
@@ -225,12 +239,10 @@ export const commitSubscriptionCreatedEvent = async (
       payload: {
         id: subscription.id,
         object: EventNoun.Subscription,
-        customer: customer
-          ? {
-              id: customer.id,
-              externalId: customer.externalId,
-            }
-          : undefined,
+        customer: {
+          id: customer.id,
+          externalId: customer.externalId,
+        },
       },
       organizationId: subscription.organizationId,
       livemode: subscription.livemode,
@@ -247,6 +259,11 @@ export const commitSubscriptionUpdatedEvent = async (
     subscription.customerId,
     transaction
   )
+  
+  if (!customer) {
+    throw new Error(`Customer not found for subscription ${subscription.id}`)
+  }
+  
   return commitEvent(
     {
       type: FlowgladEventType.SubscriptionUpdated,
@@ -255,12 +272,10 @@ export const commitSubscriptionUpdatedEvent = async (
       payload: {
         id: subscription.id,
         object: EventNoun.Subscription,
-        customer: customer
-          ? {
-              id: customer.id,
-              externalId: customer.externalId,
-            }
-          : undefined,
+        customer: {
+          id: customer.id,
+          externalId: customer.externalId,
+        },
       },
       organizationId: subscription.organizationId,
       livemode: subscription.livemode,
@@ -277,6 +292,11 @@ export const commitSubscriptionCancelledEvent = async (
     subscription.customerId,
     transaction
   )
+  
+  if (!customer) {
+    throw new Error(`Customer not found for subscription ${subscription.id}`)
+  }
+  
   return commitEvent(
     {
       type: FlowgladEventType.SubscriptionCancelled,
@@ -285,12 +305,10 @@ export const commitSubscriptionCancelledEvent = async (
       payload: {
         id: subscription.id,
         object: EventNoun.Subscription,
-        customer: customer
-          ? {
-              id: customer.id,
-              externalId: customer.externalId,
-            }
-          : undefined,
+        customer: {
+          id: customer.id,
+          externalId: customer.externalId,
+        },
       },
       organizationId: subscription.organizationId,
       livemode: subscription.livemode,

--- a/platform/flowglad-next/src/utils/events.ts
+++ b/platform/flowglad-next/src/utils/events.ts
@@ -105,6 +105,10 @@ export const commitPaymentCanceledEvent = async (
   payment: Payment.Record,
   transaction: DbTransaction
 ) => {
+  const customer = await selectCustomerById(
+    payment.customerId,
+    transaction
+  )
   return commitEvent(
     {
       type: FlowgladEventType.PaymentFailed,
@@ -113,6 +117,12 @@ export const commitPaymentCanceledEvent = async (
       payload: {
         id: payment.id,
         object: EventNoun.Payment,
+        customer: customer
+          ? {
+              id: customer.id,
+              externalId: customer.externalId,
+            }
+          : undefined,
       },
       organizationId: payment.organizationId,
       livemode: payment.livemode,
@@ -133,6 +143,10 @@ export const commitCustomerCreatedEvent = async (
       payload: {
         id: customer.id,
         object: EventNoun.Customer,
+        customer: {
+          id: customer.id,
+          externalId: customer.externalId,
+        },
       },
       organizationId: customer.organizationId,
       livemode: customer.livemode,
@@ -153,6 +167,10 @@ export const commitCustomerUpdatedEvent = async (
       payload: {
         id: customer.id,
         object: EventNoun.Customer,
+        customer: {
+          id: customer.id,
+          externalId: customer.externalId,
+        },
       },
       organizationId: customer.organizationId,
       livemode: customer.livemode,
@@ -165,6 +183,10 @@ export const commitPurchaseCompletedEvent = async (
   purchase: Purchase.Record,
   transaction: DbTransaction
 ) => {
+  const customer = await selectCustomerById(
+    purchase.customerId,
+    transaction
+  )
   return commitEvent(
     {
       type: FlowgladEventType.PurchaseCompleted,
@@ -173,6 +195,12 @@ export const commitPurchaseCompletedEvent = async (
       payload: {
         id: purchase.id,
         object: EventNoun.Purchase,
+        customer: customer
+          ? {
+              id: customer.id,
+              externalId: customer.externalId,
+            }
+          : undefined,
       },
       organizationId: purchase.organizationId,
       livemode: purchase.livemode,
@@ -185,6 +213,10 @@ export const commitSubscriptionCreatedEvent = async (
   subscription: Subscription.Record,
   transaction: DbTransaction
 ) => {
+  const customer = await selectCustomerById(
+    subscription.customerId,
+    transaction
+  )
   return commitEvent(
     {
       type: FlowgladEventType.SubscriptionCreated,
@@ -193,6 +225,12 @@ export const commitSubscriptionCreatedEvent = async (
       payload: {
         id: subscription.id,
         object: EventNoun.Subscription,
+        customer: customer
+          ? {
+              id: customer.id,
+              externalId: customer.externalId,
+            }
+          : undefined,
       },
       organizationId: subscription.organizationId,
       livemode: subscription.livemode,
@@ -205,6 +243,10 @@ export const commitSubscriptionUpdatedEvent = async (
   subscription: Subscription.Record,
   transaction: DbTransaction
 ) => {
+  const customer = await selectCustomerById(
+    subscription.customerId,
+    transaction
+  )
   return commitEvent(
     {
       type: FlowgladEventType.SubscriptionUpdated,
@@ -213,6 +255,12 @@ export const commitSubscriptionUpdatedEvent = async (
       payload: {
         id: subscription.id,
         object: EventNoun.Subscription,
+        customer: customer
+          ? {
+              id: customer.id,
+              externalId: customer.externalId,
+            }
+          : undefined,
       },
       organizationId: subscription.organizationId,
       livemode: subscription.livemode,
@@ -225,6 +273,10 @@ export const commitSubscriptionCancelledEvent = async (
   subscription: Subscription.Record,
   transaction: DbTransaction
 ) => {
+  const customer = await selectCustomerById(
+    subscription.customerId,
+    transaction
+  )
   return commitEvent(
     {
       type: FlowgladEventType.SubscriptionCancelled,
@@ -233,6 +285,12 @@ export const commitSubscriptionCancelledEvent = async (
       payload: {
         id: subscription.id,
         object: EventNoun.Subscription,
+        customer: customer
+          ? {
+              id: customer.id,
+              externalId: customer.externalId,
+            }
+          : undefined,
       },
       organizationId: subscription.organizationId,
       livemode: subscription.livemode,


### PR DESCRIPTION
## What Does this PR Do?

-add customer object with external id and internal id to webhooks
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a customer object to webhook payloads, including both internal id and externalId. This lets integrators reliably map events to their customer records.

- **New Features**
  - Include customer { id, externalId } in payloads for CustomerCreated/Updated, PaymentSucceeded/Failed, PurchaseCompleted, and SubscriptionCreated/Updated/Cancelled.
  - Lookup customer via selectCustomerById in event commit helpers and workflows (createSubscriptionWorkflow, processSetupIntent, processPaymentIntentStatusUpdated).
  - Added tests validating payloads across all event types.

<!-- End of auto-generated description by cubic. -->

