### PR TITLE
fix to usageEventPaginatedSelectSchema

### DIFF
--- a/platform/flowglad-next/public/preview/manifest.json
+++ b/platform/flowglad-next/public/preview/manifest.json
@@ -1,6 +1,6 @@
 {
-  "hash": "9a0bff84",
+  "hash": "c5a13ba5",
   "path": "/preview/preview.css",
-  "size": 85718,
-  "generatedAt": "2025-09-25T21:19:22.205Z"
+  "size": 86443,
+  "generatedAt": "2025-10-04T20:32:15.808Z"
 }

--- a/platform/flowglad-next/src/db/schema/usageEvents.ts
+++ b/platform/flowglad-next/src/db/schema/usageEvents.ts
@@ -283,15 +283,15 @@ export type BulkInsertUsageEventsInput = z.infer<
 >
 
 // Pagination schemas
-export const usageEventPaginatedSelectSchema = z.object({
-  cursor: z.string().optional(),
-  limit: z.number().min(1).max(100).default(10),
-  customerId: z.string().optional(),
-  usageMeterId: z.string().optional(),
-  subscriptionId: z.string().optional(),
-  dateFrom: z.string().optional(),
-  dateTo: z.string().optional(),
-})
+export const usageEventPaginatedSelectSchema = createPaginatedSelectSchema(
+  z.object({
+    customerId: z.string().optional(),
+    usageMeterId: z.string().optional(),
+    subscriptionId: z.string().optional(),
+    dateFrom: z.string().optional(),
+    dateTo: z.string().optional(),
+  })
+)
 
 export const usageEventPaginatedListSchema = z.object({
   items: z.array(usageEventsClientSelectSchema),

--- a/platform/flowglad-next/src/server/routers/usageEventsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/usageEventsRouter.ts
@@ -173,13 +173,7 @@ const listUsageEventsProcedure = protectedProcedure
   .query(async ({ input, ctx }) => {
     return authenticatedTransaction(
       async ({ transaction }) => {
-        const result = await selectUsageEventsPaginated(
-          {
-            cursor: input.cursor,
-            limit: input.limit,
-          },
-          transaction
-        )
+        const result = await selectUsageEventsPaginated( input, transaction )
         return {
           items: result.data,
           total: result.total,


### PR DESCRIPTION
## What Does this PR Do?

-fix to usageEventPaginatedSelectSchema

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched usageEventPaginatedSelectSchema to use the shared createPaginatedSelectSchema, standardizing pagination (cursor and default limit) while keeping existing filters. This fixes inconsistent pagination in the usage events endpoint and aligns with FG-190 API/OpenAPI route expectations.

<!-- End of auto-generated description by cubic. -->

