### PR TITLE
fix broken routes to terms and privacy policies

### DIFF
--- a/platform/flowglad-next/src/components/PaymentForm.tsx
+++ b/platform/flowglad-next/src/components/PaymentForm.tsx
@@ -611,14 +611,14 @@ const PaymentForm = () => {
             <PoweredByFlowglad />
             <div className="flex items-center gap-2.5 text-[13px] text-gray-600">
               <a
-                href="/terms"
+                href="https://www.flowglad.com/terms-of-service"
                 className="hover:text-gray-800 transition-colors"
               >
                 Terms
               </a>
               <span>·</span>
               <a
-                href="/privacy"
+                href="https://www.flowglad.com/privacy-policy"
                 className="hover:text-gray-800 transition-colors"
               >
                 Privacy

--- a/platform/flowglad-next/src/components/SignupLayout.tsx
+++ b/platform/flowglad-next/src/components/SignupLayout.tsx
@@ -16,7 +16,7 @@ const SignupLayout = ({
             <div className="flex flex-col justify-center items-center w-full">
               {children}
               <Link
-                href="https://flowglad.com/privacy-policy"
+                href="https://www.flowglad.com/privacy-policy"
                 className="text-sm text-muted-foreground mt-8"
               >
                 Privacy Policy


### PR DESCRIPTION
## What Does this PR Do?

- fix broken routes to terms and privacy policies
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes broken Terms and Privacy links by pointing to the correct Flowglad URLs, so users can access policies during checkout and signup. Aligns with Linear FG-172 by ensuring legal links work across support-related flows.

- **Bug Fixes**
  - PaymentForm: replaced /terms and /privacy with https://www.flowglad.com/terms-of-service and https://www.flowglad.com/privacy-policy.
  - SignupLayout: updated Privacy Policy link to use https://www.flowglad.com/privacy-policy.

<!-- End of auto-generated description by cubic. -->

