### PR TITLE
fix: typo in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,4 +2,4 @@ Flowglad is fully open source.
 
 - ./packages: MIT
 - ./playground: MIT
-- ./platform: APGLv3
+- ./platform: AGPLv3


### PR DESCRIPTION
The license was previously `APGLv3` which I think is a typo?
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a typo in the LICENSE file: ./platform is AGPLv3 (not APGLv3). Ensures accurate licensing information across the repo.

<!-- End of auto-generated description by cubic. -->

