### PR TITLE
Edit Usage Meter & Clean Up

### DIFF
--- a/platform/flowglad-next/src/app/customers/columns.tsx
+++ b/platform/flowglad-next/src/app/customers/columns.tsx
@@ -42,7 +42,7 @@ function CustomerActionsMenu({
 
   const actionItems: ActionMenuItem[] = [
     {
-      label: 'Edit Customer',
+      label: 'Edit',
       icon: <Pencil className="h-4 w-4" />,
       handler: () => setIsEditOpen(true),
     },

--- a/platform/flowglad-next/src/app/store/discounts/columns.tsx
+++ b/platform/flowglad-next/src/app/store/discounts/columns.tsx
@@ -68,12 +68,12 @@ function DiscountActionsMenu({
 
   const actionItems: ActionMenuItem[] = [
     {
-      label: 'Edit Discount',
+      label: 'Edit',
       icon: <Pencil className="h-4 w-4" />,
       handler: () => setIsEditOpen(true),
     },
     {
-      label: 'Delete Discount',
+      label: 'Delete',
       icon: <Trash2 className="h-4 w-4" />,
       handler: () => setIsDeleteOpen(true),
     },

--- a/platform/flowglad-next/src/app/store/pricing-models/columns.tsx
+++ b/platform/flowglad-next/src/app/store/pricing-models/columns.tsx
@@ -29,12 +29,12 @@ function PricingModelActionsMenu({
 
   const actionItems: ActionMenuItem[] = [
     {
-      label: 'Edit Pricing Model',
+      label: 'Edit',
       icon: <Pencil className="h-4 w-4" />,
       handler: () => setIsEditOpen(true),
     },
     {
-      label: 'Clone Pricing Model',
+      label: 'Duplicate',
       icon: <Copy className="h-4 w-4" />,
       handler: () => setIsCloneOpen(true),
     },
@@ -42,7 +42,7 @@ function PricingModelActionsMenu({
 
   if (!pricingModel.isDefault) {
     actionItems.push({
-      label: 'Set as Default',
+      label: 'Set Default',
       icon: <Star className="h-4 w-4" />,
       handler: () => setIsSetDefaultOpen(true),
     })

--- a/platform/flowglad-next/src/app/store/products/columns.tsx
+++ b/platform/flowglad-next/src/app/store/products/columns.tsx
@@ -72,7 +72,7 @@ function ProductActionsMenu({
         : undefined,
     },
     {
-      label: product.active ? 'Deactivate' : 'Activate product',
+      label: product.active ? 'Deactivate' : 'Activate',
       icon: product.active ? (
         <Archive className="h-4 w-4" />
       ) : (

--- a/platform/flowglad-next/src/app/store/products/columns.tsx
+++ b/platform/flowglad-next/src/app/store/products/columns.tsx
@@ -58,7 +58,7 @@ function ProductActionsMenu({
 
   const actionItems: ActionMenuItem[] = [
     {
-      label: 'Edit product',
+      label: 'Edit',
       icon: <Pencil className="h-4 w-4" />,
       handler: () => setIsEditOpen(true),
     },
@@ -72,9 +72,7 @@ function ProductActionsMenu({
         : undefined,
     },
     {
-      label: product.active
-        ? 'Deactivate product'
-        : 'Activate product',
+      label: product.active ? 'Deactivate' : 'Activate product',
       icon: product.active ? (
         <Archive className="h-4 w-4" />
       ) : (

--- a/platform/flowglad-next/src/app/store/usage-meters/columns.tsx
+++ b/platform/flowglad-next/src/app/store/usage-meters/columns.tsx
@@ -30,7 +30,7 @@ function UsageMeterActionsMenu({
 
   const actionItems: ActionMenuItem[] = [
     {
-      label: 'Edit Usage Meter',
+      label: 'Edit',
       icon: <Pencil className="h-4 w-4" />,
       handler: () => setIsEditOpen(true),
     },

--- a/platform/flowglad-next/src/app/store/usage-meters/columns.tsx
+++ b/platform/flowglad-next/src/app/store/usage-meters/columns.tsx
@@ -1,10 +1,17 @@
 'use client'
 
+import * as React from 'react'
 import { ColumnDef } from '@tanstack/react-table'
+import { Pencil } from 'lucide-react'
 import { UsageMeter } from '@/db/schema/usageMeters'
 import { formatDate } from '@/utils/core'
 import { DataTableCopyableCell } from '@/components/ui/data-table-copyable-cell'
 import { DataTableLinkableCell } from '@/components/ui/data-table-linkable-cell'
+import {
+  EnhancedDataTableActionsMenu,
+  ActionMenuItem,
+} from '@/components/ui/enhanced-data-table-actions-menu'
+import EditUsageMeterModal from '@/components/components/EditUsageMeterModal'
 
 type UsageMeterTableRowData = {
   usageMeter: UsageMeter.ClientRecord
@@ -12,6 +19,32 @@ type UsageMeterTableRowData = {
     id: string
     name: string
   }
+}
+
+function UsageMeterActionsMenu({
+  usageMeter,
+}: {
+  usageMeter: UsageMeter.ClientRecord
+}) {
+  const [isEditOpen, setIsEditOpen] = React.useState(false)
+
+  const actionItems: ActionMenuItem[] = [
+    {
+      label: 'Edit Usage Meter',
+      icon: <Pencil className="h-4 w-4" />,
+      handler: () => setIsEditOpen(true),
+    },
+  ]
+
+  return (
+    <EnhancedDataTableActionsMenu items={actionItems}>
+      <EditUsageMeterModal
+        isOpen={isEditOpen}
+        setIsOpen={setIsEditOpen}
+        usageMeter={usageMeter}
+      />
+    </EnhancedDataTableActionsMenu>
+  )
 }
 
 export const columns: ColumnDef<UsageMeterTableRowData>[] = [
@@ -97,5 +130,21 @@ export const columns: ColumnDef<UsageMeterTableRowData>[] = [
         </div>
       )
     },
+  },
+  {
+    id: 'actions',
+    enableHiding: false,
+    enableResizing: false,
+    cell: ({ row }) => {
+      const usageMeter = row.original.usageMeter
+      return (
+        <div onClick={(e) => e.stopPropagation()}>
+          <UsageMeterActionsMenu usageMeter={usageMeter} />
+        </div>
+      )
+    },
+    size: 1,
+    minSize: 56,
+    maxSize: 56,
   },
 ]

--- a/platform/flowglad-next/src/components/components/EditUsageMeterModal.tsx
+++ b/platform/flowglad-next/src/components/components/EditUsageMeterModal.tsx
@@ -20,16 +20,28 @@ const EditUsageMeterModal: React.FC<EditUsageMeterModalProps> = ({
   usageMeter,
 }) => {
   const editUsageMeter = trpc.usageMeters.update.useMutation()
+
+  // Explicitly exclude create-only and read-only fields from defaultValues
+  const {
+    pricingModelId,
+    organizationId,
+    livemode,
+    ...editableFields
+  } = usageMeter
+
   return (
     <FormModal
       isOpen={isOpen}
       setIsOpen={setIsOpen}
       title="Edit Usage Meter"
       formSchema={editUsageMeterSchema}
-      defaultValues={{ usageMeter }}
+      defaultValues={{
+        id: usageMeter.id,
+        usageMeter: editableFields,
+      }}
       onSubmit={editUsageMeter.mutateAsync}
     >
-      <UsageMeterFormFields />
+      <UsageMeterFormFields edit={true} />
     </FormModal>
   )
 }

--- a/platform/flowglad-next/src/components/forms/UsageMeterFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/UsageMeterFormFields.tsx
@@ -48,12 +48,14 @@ export default function UsageMeterFormFields({
           </FormItem>
         )}
       />
-      <div className="w-full relative flex flex-col gap-3">
-        <PricingModelSelect
-          name="usageMeter.pricingModelId"
-          control={form.control}
-        />
-      </div>
+      {!edit && (
+        <div className="w-full relative flex flex-col gap-3">
+          <PricingModelSelect
+            name="usageMeter.pricingModelId"
+            control={form.control}
+          />
+        </div>
+      )}
       <div className="w-full relative flex flex-col gap-3">
         <FormField
           control={form.control}


### PR DESCRIPTION
This PR adds edit functionality for usage meters and cleans up related components.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds edit support for usage meters with a table actions menu and modal, and cleans up action labels across related tables. The edit form shows only editable fields to prevent changes to create-only values.

- **New Features**
  - Added an actions column to usage meters with an Edit option.
  - Edit modal pre-fills only editable fields; excludes pricingModelId, organizationId, and livemode.
  - Hides pricing model selection when editing.
  - Prevents row selection when opening the actions menu.

- **Refactors**
  - Shortened action labels across customers, discounts, pricing models, and products (e.g., Edit, Delete, Duplicate, Set Default).
  - Aligned product action labels (Edit, Activate/Deactivate).

<!-- End of auto-generated description by cubic. -->

