### PR TITLE
fix: encode cursor in EditSubscriptionModal payment methods query

### DIFF
--- a/platform/flowglad-next/src/app/finance/subscriptions/[id]/EditSubscriptionPaymentMethodModal.tsx
+++ b/platform/flowglad-next/src/app/finance/subscriptions/[id]/EditSubscriptionPaymentMethodModal.tsx
@@ -25,6 +25,7 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { useFormContext } from 'react-hook-form'
+import { encodeCursor } from '@/db/tableUtils'
 
 interface EditSubscriptionPaymentMethodModalProps
   extends ModalInterfaceProps {
@@ -104,7 +105,7 @@ export function EditSubscriptionPaymentMethodModal({
   // Fetch payment methods for the customer
   const { data: paymentMethodsData, isLoading } =
     trpc.paymentMethods.list.useQuery({
-      where: { customerId },
+      cursor: encodeCursor({ parameters: { customerId } }),
       limit: 100,
     })
 

--- a/platform/flowglad-next/src/db/tableUtils.ts
+++ b/platform/flowglad-next/src/db/tableUtils.ts
@@ -789,10 +789,7 @@ export const createPaginatedSelectSchema = <T extends {}>(
         message: 'Limit must be between 1 and 100',
       })
       .optional(),
-  }) as z.ZodType<{
-    cursor?: string
-    limit?: number
-  }>
+  })
 }
 
 export const createSupabaseWebhookSchema = <T extends PgTableWithId>({

--- a/platform/flowglad-next/src/server/routers/subscriptionsRouter.simple.test.ts
+++ b/platform/flowglad-next/src/server/routers/subscriptionsRouter.simple.test.ts
@@ -85,7 +85,6 @@ describe('Simple Subscriptions Router Test', () => {
     const caller = subscriptionsRouter.createCaller(ctx)
 
     // Make the API call with minimal adjustment
-    console.log('Starting adjust call...')
     const result = await caller.adjust({
       id: subscription.id,
       adjustment: {
@@ -94,7 +93,6 @@ describe('Simple Subscriptions Router Test', () => {
         prorateCurrentBillingPeriod: false,
       },
     })
-    console.log('Adjust call completed')
 
     // Basic verification
     expect(result).toHaveProperty('subscription')


### PR DESCRIPTION
## What Does this PR Do?
- Use `encodeCursor` in EditSubscriptionModal payment methods query