### PR TITLE
convert date to time in setupBillingRun and safelyInsertBillingRun testing

### DIFF
--- a/platform/flowglad-next/src/subscriptions/billingRunHelpers.test.ts
+++ b/platform/flowglad-next/src/subscriptions/billingRunHelpers.test.ts
@@ -2393,7 +2393,7 @@ describe('billingRunHelpers', async () => {
           return safelyInsertBillingRun(
             {
               billingPeriodId: billingPeriod.id,
-              scheduledFor: new Date(),
+              scheduledFor: Date.now(),
               status: BillingRunStatus.Scheduled,
               subscriptionId: subscription.id,
               paymentMethodId: paymentMethod.id,
@@ -2411,7 +2411,7 @@ describe('billingRunHelpers', async () => {
             {
               billingPeriod,
               paymentMethod,
-              scheduledFor: new Date(),
+              scheduledFor: Date.now(),
             },
             transaction
           )
@@ -2441,7 +2441,7 @@ describe('billingRunHelpers', async () => {
         return safelyInsertBillingRun(
           {
             billingPeriodId: billingPeriod.id,
-            scheduledFor: new Date(),
+            scheduledFor: Date.now(),
             status: BillingRunStatus.Scheduled,
             subscriptionId: subscription.id,
             paymentMethodId: paymentMethod.id,
@@ -2457,7 +2457,7 @@ describe('billingRunHelpers', async () => {
           {
             billingPeriod,
             paymentMethod,
-            scheduledFor: new Date(),
+            scheduledFor: Date.now(),
           },
           transaction
         )

--- a/platform/flowglad-next/src/subscriptions/cancelSubscription.test.ts
+++ b/platform/flowglad-next/src/subscriptions/cancelSubscription.test.ts
@@ -415,7 +415,7 @@ describe('Subscription Cancellation Test Suite', async () => {
           subscriptionId: subscription.id,
           paymentMethodId: paymentMethod.id,
           status: BillingRunStatus.Scheduled,
-          scheduledFor: new Date(now.getTime() + 30 * 60 * 1000),
+          scheduledFor: now.getTime() + 30 * 60 * 1000,
         })
 
         const billingRun2 = await setupBillingRun({
@@ -423,7 +423,7 @@ describe('Subscription Cancellation Test Suite', async () => {
           subscriptionId: subscription.id,
           paymentMethodId: paymentMethod.id,
           status: BillingRunStatus.Scheduled,
-          scheduledFor: new Date(now.getTime() + 45 * 60 * 1000),
+          scheduledFor: now.getTime() + 45 * 60 * 1000,
         })
 
         // Cancel the subscription
@@ -470,7 +470,7 @@ describe('Subscription Cancellation Test Suite', async () => {
           subscriptionId: subscription.id,
           paymentMethodId: paymentMethod.id,
           status: BillingRunStatus.Scheduled,
-          scheduledFor: new Date(now.getTime() + 30 * 60 * 1000),
+          scheduledFor: now.getTime() + 30 * 60 * 1000,
         })
 
         const succeededRun = await setupBillingRun({
@@ -478,7 +478,7 @@ describe('Subscription Cancellation Test Suite', async () => {
           subscriptionId: subscription.id,
           paymentMethodId: paymentMethod.id,
           status: BillingRunStatus.Succeeded,
-          scheduledFor: new Date(now.getTime() - 30 * 60 * 1000),
+          scheduledFor: now.getTime() - 30 * 60 * 1000,
         })
 
         const failedRun = await setupBillingRun({
@@ -486,7 +486,7 @@ describe('Subscription Cancellation Test Suite', async () => {
           subscriptionId: subscription.id,
           paymentMethodId: paymentMethod.id,
           status: BillingRunStatus.Failed,
-          scheduledFor: new Date(now.getTime() - 15 * 60 * 1000),
+          scheduledFor: now.getTime() - 15 * 60 * 1000,
         })
 
         // Cancel the subscription
@@ -765,7 +765,7 @@ describe('Subscription Cancellation Test Suite', async () => {
           subscriptionId: subscription.id,
           paymentMethodId: paymentMethod.id,
           status: BillingRunStatus.Scheduled,
-          scheduledFor: new Date(now.getTime() + 30 * 60 * 1000),
+          scheduledFor: now.getTime() + 30 * 60 * 1000,
         })
 
         const billingRun2 = await setupBillingRun({
@@ -773,7 +773,7 @@ describe('Subscription Cancellation Test Suite', async () => {
           subscriptionId: subscription.id,
           paymentMethodId: paymentMethod.id,
           status: BillingRunStatus.Scheduled,
-          scheduledFor: new Date(now.getTime() + 45 * 60 * 1000),
+          scheduledFor: now.getTime() + 45 * 60 * 1000,
         })
 
         const params: ScheduleSubscriptionCancellationParams = {
@@ -981,7 +981,7 @@ describe('Subscription Cancellation Test Suite', async () => {
           subscriptionId: subscription.id,
           paymentMethodId: paymentMethod.id,
           status: BillingRunStatus.Scheduled,
-          scheduledFor: new Date(now.getTime() + 30 * 60 * 1000),
+          scheduledFor: now.getTime() + 30 * 60 * 1000,
         })
 
         const billingRun2 = await setupBillingRun({
@@ -989,7 +989,7 @@ describe('Subscription Cancellation Test Suite', async () => {
           subscriptionId: subscription.id,
           paymentMethodId: paymentMethod.id,
           status: BillingRunStatus.Scheduled,
-          scheduledFor: new Date(now.getTime() + 45 * 60 * 1000),
+          scheduledFor: now.getTime() + 45 * 60 * 1000,
         })
 
         // Call the function twice


### PR DESCRIPTION
## What Does this PR Do?

-convert date to time in setupBillingRun and safelyInsertBillingRun testing
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated tests to pass scheduledFor as epoch milliseconds instead of Date objects in setupBillingRun and safelyInsertBillingRun.
This aligns with the helpers’ expected types and prevents type-related test failures.

<!-- End of auto-generated description by cubic. -->

