### PR TITLE
Timeout fix v2

### DIFF
--- a/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.integration.test.ts
+++ b/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.integration.test.ts
@@ -415,7 +415,7 @@ describe('Customer Billing Portal Router', () => {
   describe('cancelSubscription', () => {
     test(
       'cancels subscription immediately',
-      { timeout: 18000 },
+      { timeout: 30000 },
       async () => {
         const ctx = createTestContext()
         const input: ScheduleSubscriptionCancellationParams = {
@@ -451,7 +451,7 @@ describe('Customer Billing Portal Router', () => {
 
     test(
       'schedules subscription cancellation at period end',
-      { timeout: 15000 },
+      { timeout: 30000 },
       async () => {
         const ctx = createTestContext()
         const input: ScheduleSubscriptionCancellationParams = {

--- a/platform/flowglad-next/src/server/routers/subscriptionsRouter.integration.test.ts
+++ b/platform/flowglad-next/src/server/routers/subscriptionsRouter.integration.test.ts
@@ -297,7 +297,7 @@ describe('Subscriptions Router - Adjust Endpoint', () => {
       expect(result.subscription.priceId).toBe(expensivePrice.id)
     }, 30000)
 
-    test('should handle downgrade without creating negative charges', async () => {
+    test('should handle downgrade without creating negative charges', { timeout: 45000 }, async () => {
       const caller = createCaller(apiKeyToken)
 
       // For downgrade test, we'll upgrade first then downgrade
@@ -373,7 +373,7 @@ describe('Subscriptions Router - Adjust Endpoint', () => {
       // Verify downgrade was applied
       expect(result.subscription.name).toBe('Basic Plan')
       expect(result.subscription.priceId).toBe(price.id)
-    }, 30000)
+    })
 
     test('should handle removing all items (empty subscription)', async () => {
       const caller = createCaller(apiKeyToken)


### PR DESCRIPTION
## What Does this PR Do?

- Timeout fix v2
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Increase Jest timeouts for subscription cancellation and adjustment integration tests to reduce flakiness in CI. This gives slower environments more time to complete Stripe/DB operations.

- **Bug Fixes**
  - Customer Billing Portal: cancelSubscription timeout to 30s (was 18s).
  - Customer Billing Portal: schedule cancellation timeout to 30s (was 15s).
  - Subscriptions Router: downgrade flow timeout to 45s via test options (removed 30s trailing timeout).

<!-- End of auto-generated description by cubic. -->

