### PR TITLE
Fix issue#539/Generate Dynamic Metadata

### DIFF
--- a/platform/flowglad-next/src/app/price/[priceId]/purchase/page.tsx
+++ b/platform/flowglad-next/src/app/price/[priceId]/purchase/page.tsx
@@ -3,11 +3,39 @@ import core from '@/utils/core'
 import { notFound } from 'next/navigation'
 import { checkoutInfoForPriceWhere } from '@/utils/checkoutHelpers'
 import CheckoutNotValidPage from '@/components/CheckoutNotValidPage'
+import { Metadata } from 'next'
+import { adminTransaction } from '@/db/adminTransaction'
+import { selectPriceProductAndOrganizationByPriceWhere } from '@/db/tableMethods/priceMethods'
 
 interface PurchasePageProps {
   params: Promise<{
     priceId: string
   }>
+}
+
+export async function generateMetadata({
+  params,
+}: PurchasePageProps): Promise<Metadata> {
+  const { priceId } = await params
+  
+  try {
+    const [{ product, organization }] = await adminTransaction(
+      async ({ transaction }) => {
+        return await selectPriceProductAndOrganizationByPriceWhere(
+          { id: priceId },
+          transaction
+        )
+      }
+    )
+
+    return {
+      title: `${organization.name} | ${product.name}`,
+    }
+  } catch (error) {
+    return {
+      title: 'Checkout',
+    }
+  }
 }
 
 const PricePurchasePage = async ({ params }: PurchasePageProps) => {

--- a/platform/flowglad-next/src/app/product/[productId]/purchase/page.tsx
+++ b/platform/flowglad-next/src/app/product/[productId]/purchase/page.tsx
@@ -2,11 +2,39 @@ import CheckoutNotValidPage from '@/components/CheckoutNotValidPage'
 import CheckoutPage from '@/components/CheckoutPage'
 import { checkoutInfoForPriceWhere } from '@/utils/checkoutHelpers'
 import { notFound } from 'next/navigation'
+import { Metadata } from 'next'
+import { adminTransaction } from '@/db/adminTransaction'
+import { selectPriceProductAndOrganizationByPriceWhere } from '@/db/tableMethods/priceMethods'
 
 interface PurchasePageProps {
   params: Promise<{
     productId: string
   }>
+}
+
+export async function generateMetadata({
+  params,
+}: PurchasePageProps): Promise<Metadata> {
+  const { productId } = await params
+  
+  try {
+    const [{ product, organization }] = await adminTransaction(
+      async ({ transaction }) => {
+        return await selectPriceProductAndOrganizationByPriceWhere(
+          { productId, isDefault: true },
+          transaction
+        )
+      }
+    )
+
+    return {
+      title: `${organization.name} | ${product.name}`,
+    }
+  } catch (error) {
+    return {
+      title: 'Checkout',
+    }
+  }
 }
 
 const PurchasePage = async ({ params }: PurchasePageProps) => {


### PR DESCRIPTION
## Dynamic Metadata for Checkout Pages

Fixes #539

### Summary

Implements dynamic page metadata for checkout pages to display seller organization and product names in browser tabs instead of hardcoded platform name.

## Changes

Added `generateMetadata` function to:
- `src/app/price/[priceId]/purchase/page.tsx`
- `src/app/product/[productId]/purchase/page.tsx`

## Testing

I am unable to perform full E2E testing due to database/auth constraints, but I did test the logic through isolated test pages, let me know if there has something needs to fix.



