### PR TITLE
filter product features by expiration date in selectFeaturesByProductFeatureWhere

### DIFF
--- a/platform/flowglad-next/src/db/tableMethods/productFeatureMethods.ts
+++ b/platform/flowglad-next/src/db/tableMethods/productFeatureMethods.ts
@@ -20,7 +20,7 @@ import {
   productFeaturesUpdateSchema,
   ProductFeature,
 } from '@/db/schema/productFeatures'
-import { and, eq, inArray, isNotNull } from 'drizzle-orm'
+import { and, eq, inArray, isNotNull, isNull, or, gt } from 'drizzle-orm'
 import { features, featuresSelectSchema } from '../schema/features'
 import { detachSubscriptionItemFeaturesFromProductFeature } from './subscriptionItemFeatureMethods'
 import { Product } from '../schema/products'
@@ -134,7 +134,15 @@ export const selectFeaturesByProductFeatureWhere = async (
       feature: features,
     })
     .from(productFeatures)
-    .where(whereClauseFromObject(productFeatures, where))
+    .where(
+      and(
+        whereClauseFromObject(productFeatures, where),
+        or(
+          isNull(productFeatures.expiredAt),
+          gt(productFeatures.expiredAt, Date.now())
+        )
+      )
+    )
     .innerJoin(features, eq(productFeatures.featureId, features.id))
   return result.map(({ productFeature, feature }) => ({
     productFeature: productFeaturesSelectSchema.parse(productFeature),


### PR DESCRIPTION
## What Does this PR Do?

- filter product features by expiration date in selectFeaturesByProductFeatureWhere
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated selectFeaturesByProductFeatureWhere to return only active product features, excluding ones expired in the past. Addresses Linear FG-207 by preventing expired features from being returned.

- **Bug Fixes**
  - Filter: include features where expiredAt is null or in the future; exclude past expirations.
  - Tests: cover active, future-expiring, already-expired, mixed states, and specific feature queries.

<!-- End of auto-generated description by cubic. -->

