### PR TITLE
disallow non-subscription price type in adjust route

### DIFF
--- a/platform/flowglad-next/seedDatabase.ts
+++ b/platform/flowglad-next/seedDatabase.ts
@@ -857,8 +857,8 @@ export const setupPrice = async ({
   name: string
   type: PriceType
   unitPrice: number
-  intervalUnit: IntervalUnit
-  intervalCount: number
+  intervalUnit?: IntervalUnit
+  intervalCount?: number
   livemode: boolean
   isDefault: boolean
   usageMeterId?: string
@@ -924,6 +924,8 @@ export const setupPrice = async ({
             ...basePrice,
             ...priceConfig[PriceType.Subscription],
             type: PriceType.Subscription,
+            intervalUnit: intervalUnit ?? IntervalUnit.Month,
+            intervalCount: intervalCount ?? 1,
           },
           transaction
         )
@@ -934,6 +936,8 @@ export const setupPrice = async ({
             ...priceConfig[PriceType.Usage],
             usageMeterId: usageMeterId!,
             type: PriceType.Usage,
+            intervalUnit: intervalUnit ?? IntervalUnit.Month,
+            intervalCount: intervalCount ?? 1,
           },
           transaction
         )


### PR DESCRIPTION
check price type on new subscription items and throw error on non subscription price type, add test cases
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Block non-recurring prices in adjustSubscription so only subscription (recurring) prices can be added to subscriptions. Adds tests and defaults in seeding to avoid invalid data.

- **Bug Fixes**
  - Validate newSubscriptionItems by loading their prices and enforcing PriceType.Subscription. Throw a clear error if the price is usage or single_payment, or missing.
  - Added integration tests that reject usage-based and single-payment prices during adjustments.
  - Updated seed setupPrice: intervalUnit and intervalCount are optional; default to Month and 1 for Subscription and Usage prices.

<!-- End of auto-generated description by cubic. -->

