### PR TITLE
apply discount properly to total after trial section on checkout page

### DIFF
--- a/platform/flowglad-next/src/components/checkout/total-billing-details.tsx
+++ b/platform/flowglad-next/src/components/checkout/total-billing-details.tsx
@@ -168,13 +168,6 @@ export const TotalBillingDetails = React.forwardRef<
     return null
   }
 
-  let afterwardsTotal: number | null = null
-  let afterwardsTotalLabel = ''
-  if (subscriptionDetails?.trialPeriodDays) {
-    afterwardsTotalLabel = 'Total After Trial'
-    afterwardsTotal = subscriptionDetails.pricePerBillingCycle
-  }
-
   const isInvoiceFlow = flowType === CheckoutFlowType.Invoice
   const totalBillingDetailsParams: TotalBillingDetailsParams =
     isInvoiceFlow
@@ -198,6 +191,15 @@ export const TotalBillingDetails = React.forwardRef<
 
   const { discountAmount, taxAmount, baseAmount, totalDueAmount } =
     calculateTotalBillingDetails(totalBillingDetailsParams)
+
+  let afterwardsTotal: number | null = null
+  let afterwardsTotalLabel = ''
+  if (subscriptionDetails?.trialPeriodDays) {
+    afterwardsTotalLabel = 'Total After Trial'
+    // Calculate the actual price after trial (with discount applied)
+    const priceAfterTrial = subscriptionDetails.pricePerBillingCycle - (discountAmount ?? 0)
+    afterwardsTotal = Math.max(0, priceAfterTrial) // Ensure it's not negative
+  }
   const hideTotalLabels =
     flowType === CheckoutFlowType.Subscription &&
     checkoutPageContext.price.type === PriceType.Usage
@@ -239,7 +241,7 @@ export const TotalBillingDetails = React.forwardRef<
         />
       )}
 
-      {afterwardsTotal != null && afterwardsTotal > 0 && (
+      {afterwardsTotal != null && (
         <BillingLine
           label={afterwardsTotalLabel}
           amount={afterwardsTotal}


### PR DESCRIPTION
## What Does this PR Do?

- apply discount properly to total after trial section on checkout page
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the "Total After Trial" on the checkout page to correctly apply discounts and display a zero total when the discount fully covers the price. The amount after trial is never negative and is shown even when zero.

<!-- End of auto-generated description by cubic. -->

