### PR TITLE
Product modal remove features from usage price

### DIFF
--- a/platform/flowglad-next/src/components/forms/ProductFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/ProductFormFields.tsx
@@ -143,19 +143,6 @@ export const ProductFormFields = ({
                 />
               </div>
             )}
-            <div className="w-full">
-              {priceType !== PriceType.Usage && (
-                <ProductFeatureMultiSelect
-                  pricingModelId={product.pricingModelId}
-                  productId={
-                    editProduct
-                      ? (product as unknown as Product.ClientUpdate)
-                          .id
-                      : undefined
-                  }
-                />
-              )}
-            </div>
             {editProduct && (
               <FormField
                 control={form.control}
@@ -192,7 +179,19 @@ export const ProductFormFields = ({
           <div className="w-full mt-6">
             <PriceFormFields edit={editProduct} />
           </div>
-          <div className="w-full mt-6">
+          {priceType !== PriceType.Usage && (
+            <div className="w-full mt-6">
+              <ProductFeatureMultiSelect
+                pricingModelId={product.pricingModelId}
+                productId={
+                  editProduct
+                    ? (product as unknown as Product.ClientUpdate).id
+                    : undefined
+                }
+              />
+            </div>
+          )}
+          <div className="w-full mt-12">
             <FileInput
               directory="products"
               onUploadComplete={({ publicURL }) => {


### PR DESCRIPTION
hide features when selected price type is usage, clear existing features when creating product and price type is usage
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Hides feature selection in the product modal when the price type is Usage and clears features for new products to prevent invalid setups. Keeps existing features untouched when editing.

- **Bug Fixes**
  - Hide ProductFeatureMultiSelect when price.type is Usage.
  - Clear featureIds on create for Usage price type; do not clear on edit.

<!-- End of auto-generated description by cubic. -->

