### PR TITLE
docs: add star history section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,3 +398,15 @@ We're building a payments layer that lets you:
 - Unlock more payment providers from a single integration
 
 Achieving this mission will take time. It will be hard. It might even make some people unhappy. But with AI bringing more and more developers on line and exploding the complexity of startup billing, the need is more urgent than ever.
+
+
+
+## ⭐ Star History
+
+<a href="https://www.star-history.com/#flowglad/flowglad&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=flowglad/flowglad&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=flowglad/flowglad&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=flowglad/flowglad&type=Date" />
+ </picture>
+</a>


### PR DESCRIPTION
## What Does this PR Do?
## Description
Add a star history chart to the README to showcase repository growth and community engagement over time.

Fix: #577 

## SS
<img width="1001" height="663" alt="Screenshot 2025-10-11 at 11 32 00 PM" src="https://github.com/user-attachments/assets/e38b6765-e8ac-4b38-aa58-78fec847619c" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a Star History chart to the README to visualize star growth over time and highlight community engagement. Closes #577.

<!-- End of auto-generated description by cubic. -->

