### PR TITLE
fix: prevent duplicate React keys in chart components

### DIFF
--- a/platform/flowglad-next/src/components/charts/AreaChart.tsx
+++ b/platform/flowglad-next/src/components/charts/AreaChart.tsx
@@ -613,6 +613,12 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>(
     >(undefined)
     const categoryColors = constructCategoryColors(categories, colors)
 
+    const dataWithUniqueIds = React.useMemo(
+      () =>
+        data.map((item, index) => ({ ...item, __uniqueId: index })),
+      [data]
+    )
+
     const yAxisDomain = getYAxisDomain(
       autoMinValue,
       minValue,
@@ -744,7 +750,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>(
           <RechartsAreaChart
             width={width || 800}
             height={height || 300}
-            data={data}
+            data={dataWithUniqueIds}
             onClick={
               hasOnValueChange && (activeLegend || activeDot)
                 ? () => {

--- a/platform/flowglad-next/src/components/charts/LineChart.tsx
+++ b/platform/flowglad-next/src/components/charts/LineChart.tsx
@@ -631,6 +631,12 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>(
     >(undefined)
     const categoryColors = constructCategoryColors(categories, colors)
 
+    const dataWithUniqueIds = React.useMemo(
+      () =>
+        data.map((item, index) => ({ ...item, __uniqueId: index })),
+      [data]
+    )
+
     const yAxisDomain = getYAxisDomain(
       autoMinValue,
       minValue,
@@ -708,7 +714,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>(
          */}
         <ResponsiveContainer width={'100%'} height={'100%'}>
           <RechartsLineChart
-            data={data}
+            data={dataWithUniqueIds}
             width={width || 800}
             height={height || 300}
             onClick={


### PR DESCRIPTION

## What Does this PR Do?
Resolves #583

- Add unique identifiers to data points in LineChart and AreaChart
- Fixes issue where multiple data points with same date/value caused duplicate keys
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents duplicate React keys in LineChart and AreaChart by adding unique IDs to each data point. This removes warnings and avoids rendering issues when points share the same date/value.

- **Bug Fixes**
  - Add __uniqueId via useMemo and pass dataWithUniqueIds to Recharts charts.
  - Handle datasets with duplicate x/y values without key collisions.

<!-- End of auto-generated description by cubic. -->

