### PR TITLE
feat(ci): add scorecard.yml

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,11 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
-    if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
+    if: |
+      github.event_name == 'pull_request' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'branch_protection_rule' ||
+      (github.event.repository && github.event.repository.default_branch == github.ref_name)
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
@@ -73,6 +77,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@755f44910c12a3d7ca0d8c6e42c048b3362f7cec # v3.30.8
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Add Openssf scorecard testing
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds an OpenSSF Scorecard workflow to CI to run supply-chain security checks. Results are published to OpenSSF and GitHub Code Scanning for visibility.

- **New Features**
  - New workflow at .github/workflows/scorecard.yml.
  - Triggers on push to main, weekly cron, and branch protection events.
  - Uses ossf/scorecard-action v2.4.1 with SARIF output.
  - Publishes results to OpenSSF and uploads to GitHub Code Scanning.
  - Saves SARIF artifact for 5 days; defaults to read-only permissions with required writes.

<!-- End of auto-generated description by cubic. -->

