### PR TITLE
fix: fallback url to pass test mode

### DIFF
--- a/platform/flowglad-next/src/utils/core.ts
+++ b/platform/flowglad-next/src/utils/core.ts
@@ -486,17 +486,22 @@ export const gitCommitId = () => {
   }
   return commitId
 }
+const LOCALHOST_URL = 'http://localhost:3000'
+
 export const emailBaseUrl =
-  envVariable('NEXT_PUBLIC_APP_URL') ?? 'http://localhost:3000'
+  envVariable('NEXT_PUBLIC_APP_URL') || LOCALHOST_URL
 
 export const customerBillingPortalURL = (params: {
   organizationId: string
   customerId?: string
 }) => {
   const { organizationId, customerId } = params
+  const baseUrl = IS_TEST
+    ? LOCALHOST_URL
+    : process.env.NEXT_PUBLIC_APP_URL || LOCALHOST_URL
   return safeUrl(
-    `/billing-portal/${organizationId}/${customerId ?? ''}`,
-    process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
+    `/billing-portal/${organizationId}/${customerId || ''}`,
+    baseUrl
   )
 }
 
@@ -504,10 +509,10 @@ export const organizationBillingPortalURL = (params: {
   organizationId: string
 }) => {
   const { organizationId } = params
-  return safeUrl(
-    `/billing-portal/${organizationId}`,
-    process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
-  )
+  const baseUrl = IS_TEST
+    ? LOCALHOST_URL
+    : process.env.NEXT_PUBLIC_APP_URL || LOCALHOST_URL
+  return safeUrl(`/billing-portal/${organizationId}`, baseUrl)
 }
 
 export const nowTime = () => Date.now()


### PR DESCRIPTION
## What Does this PR Do?
- Fix the `??` -> `||` bug that was causing tests to fail in test mode for external contributors
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed fallback URL handling to enforce localhost in test mode and replace ?? with || in URL builders, preventing failing tests for external contributors.

- **Bug Fixes**
  - Added LOCALHOST_URL and IS_TEST-based baseUrl in emailBaseUrl, customerBillingPortalURL, and organizationBillingPortalURL.
  - Replaced nullish coalescing with logical OR for customerId and base URL fallbacks.

<!-- End of auto-generated description by cubic. -->

