### PR TITLE
fix: payment method type error on us_bank_account

### DIFF
--- a/platform/flowglad-next/src/utils/stripe.ts
+++ b/platform/flowglad-next/src/utils/stripe.ts
@@ -1048,6 +1048,8 @@ export const paymentMethodFromStripeCharge = (
       return PaymentMethodType.Card
     case 'ach_debit':
       return PaymentMethodType.USBankAccount
+    case 'us_bank_account':
+      return PaymentMethodType.USBankAccount
     case 'sepa_debit':
       return PaymentMethodType.SEPADebit
     case 'link':


### PR DESCRIPTION
## What Does this PR Do?
- unknown payment method us_bank_account
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Map Stripe’s us_bank_account payment method to PaymentMethodType.USBankAccount to fix “unknown payment method” errors. US bank account charges are now recognized consistently, same as ach_debit.

<!-- End of auto-generated description by cubic. -->

