### PR TITLE
feat(ci): auto update packages

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,18 @@
+# Copyright 2023 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      # The trailing space instructs dependabot not to insert a colon between
+      # the prefix and the rest of the message.
+      prefix: "[CI] "


### PR DESCRIPTION
Add daily dependabot job to update packages
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add Dependabot to auto-update GitHub Actions daily so our CI stays current. Dependabot commits will use the "[CI] " prefix.

<!-- End of auto-generated description by cubic. -->

