### PR TITLE
feat(telemetry): include stainless sdk header in logging

### DIFF
--- a/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
+++ b/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
@@ -141,6 +141,9 @@ const innerHandler = async (
     `REST ${req.method}`,
     { kind: SpanKind.SERVER },
     async (parentSpan) => {
+      // Extract Stainless SDK version from headers
+      const sdkVersion = req.headers.get('X-Stainless-Package-Version') || undefined
+      
       try {
         // Track request body size for POST/PUT
         let requestBodySize = 0
@@ -199,6 +202,7 @@ const innerHandler = async (
           'user.id': userId,
           'api.environment': req.unkey?.environment || 'unknown',
           'api.key_type': apiKeyType,
+          'stainless.sdk_version': sdkVersion,
         })
 
         logger.info(`[${requestId}] REST API Request Started`, {
@@ -213,6 +217,7 @@ const innerHandler = async (
           environment: req.unkey?.environment,
           api_key_type: apiKeyType,
           body_size_bytes: requestBodySize,
+          stainless_sdk_version: sdkVersion,
         })
 
         // Create a new context with our parent span
@@ -516,6 +521,7 @@ const innerHandler = async (
           response_size_bytes: responseSize,
           endpoint_category: endpointCategory,
           operation_type: operationType,
+          stainless_sdk_version: sdkVersion,
         })
 
         return NextResponse.json(responseData)
@@ -544,6 +550,7 @@ const innerHandler = async (
           method: req.method,
           url: req.url,
           total_duration_ms: totalDuration,
+          stainless_sdk_version: sdkVersion,
         })
 
         return NextResponse.json(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add the Stainless SDK version from the X-Stainless-Package-Version header to REST API telemetry to improve debugging and usage insights.

Included as 'stainless.sdk_version' in trace spans and 'stainless_sdk_version' in structured logs for request start, response, and error events.

<!-- End of auto-generated description by cubic. -->

