### PR TITLE
fix(telemetry): rename variables, and fix typo

### DIFF
--- a/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
+++ b/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
@@ -141,7 +141,7 @@ const innerHandler = async (
     `REST ${req.method}`,
     { kind: SpanKind.SERVER },
     async (parentSpan) => {
-      // Extract Stainless SDK version from headers
+      // Extract SDK version from headers
       const sdkVersion = req.headers.get('X-Stainless-Package-Version') || undefined
       
       try {
@@ -202,7 +202,7 @@ const innerHandler = async (
           'user.id': userId,
           'api.environment': req.unkey?.environment || 'unknown',
           'api.key_type': apiKeyType,
-          'stainless.sdk_version': sdkVersion,
+          'rest_sdk_version': sdkVersion,
         })
 
         logger.info(`[${requestId}] REST API Request Started`, {
@@ -217,7 +217,7 @@ const innerHandler = async (
           environment: req.unkey?.environment,
           api_key_type: apiKeyType,
           body_size_bytes: requestBodySize,
-          stainless_sdk_version: sdkVersion,
+          rest_sdk_version: sdkVersion,
         })
 
         // Create a new context with our parent span
@@ -521,7 +521,7 @@ const innerHandler = async (
           response_size_bytes: responseSize,
           endpoint_category: endpointCategory,
           operation_type: operationType,
-          stainless_sdk_version: sdkVersion,
+          rest_sdk_version: sdkVersion,
         })
 
         return NextResponse.json(responseData)
@@ -550,7 +550,7 @@ const innerHandler = async (
           method: req.method,
           url: req.url,
           total_duration_ms: totalDuration,
-          stainless_sdk_version: sdkVersion,
+          rest_sdk_version: sdkVersion,
         })
 
         return NextResponse.json(

--- a/platform/flowglad-next/src/scripts/verifyApiContract.ts
+++ b/platform/flowglad-next/src/scripts/verifyApiContract.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 /* 
 run the following in the terminal
-pnpm tsx src/scripts/verfiyApiContract.ts
+pnpm tsx src/scripts/verifyApiContract.ts
 */
 
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js'


### PR DESCRIPTION
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Renamed telemetry attribute to rest_sdk_version in REST API spans and logs to keep naming consistent. Fixed the verifyApiContract.ts run command typo in the script header.

<!-- End of auto-generated description by cubic. -->

