### PR TITLE
Fix link formatting for Portuguese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,4 +401,4 @@ Achieving this mission will take time. It will be hard. It might even make some 
 
 ## Other languages
 
-This README is also [available in Brazillian Portuguese](README.pt-BR.md).
+This README is also [available in Brazilian Portuguese](README.pt-BR.md).


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Corrected Markdown link syntax for the Brazilian Portuguese README so the link renders and navigates correctly in GitHub and other Markdown viewers.

<!-- End of auto-generated description by cubic. -->

