### PR TITLE
feat: setup env user script

### DIFF
--- a/platform/flowglad-next/package.json
+++ b/platform/flowglad-next/package.json
@@ -8,6 +8,7 @@
     "build": "pnpm lint && next build",
     "build:preview-css": "tsx src/scripts/build-preview-css.ts",
     "checkout-fork": "chmod +x ./src/scripts/checkout-fork.sh && ./src/scripts/checkout-fork.sh",
+    "user": "tsx src/scripts/setup-env-user.ts",
     "start": "next start",
     "lint": "next lint && tsc --noEmit && pnpm validate:registry",
     "install-packages": "pnpm install --ignore-workspace",

--- a/platform/flowglad-next/src/scripts/setup-env-user.ts
+++ b/platform/flowglad-next/src/scripts/setup-env-user.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env tsx
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+const main = () => {
+  const userArg = process.argv[2];
+
+  if (!userArg) {
+    return;
+  }
+
+  const upperCaseArg = userArg.toUpperCase();
+  const exampleFilePath = resolve(process.cwd(), '.env_user.example');
+  const targetFilePath = resolve(process.cwd(), '.env_user');
+
+  try {
+    // Read the example file
+    const exampleContent = readFileSync(exampleFilePath, 'utf-8');
+
+    // Replace AGREE with the uppercase argument
+    const modifiedContent = exampleContent.replace(/AGREE/g, upperCaseArg);
+
+    // Write to .env_user
+    writeFileSync(targetFilePath, modifiedContent, 'utf-8');
+
+    console.log(`✓ Created .env_user with LOCAL_USER=${upperCaseArg}`);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`Error setting up .env_user: ${error.message}`);
+    }
+    process.exit(1);
+  }
+};
+
+main();


### PR DESCRIPTION
Created a script that sets up the proper .env_user for Flowglad core developers.
 
 `pnpm user <Flowglad core dev name>` 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a pnpm command to generate .env_user from .env_user.example for Flowglad core developers. Run pnpm user [name] to replace AGREE with your uppercase name and set LOCAL_USER.

<!-- End of auto-generated description by cubic. -->

