### PR TITLE
fix: frontend validate fields to provide clearer error messages

### DIFF
--- a/platform/flowglad-next/src/components/PaymentForm.tsx
+++ b/platform/flowglad-next/src/components/PaymentForm.tsx
@@ -307,7 +307,7 @@ const PaymentForm = () => {
         const { error: submitError } = submitResult
         if (submitError) {
           if (submitError.message === 'This field is incomplete.') {
-            setErrorMessage('Please complete all required fields')
+            setErrorMessage('Please complete all required fields.')
           } else {
             setErrorMessage(submitError.message)
           }


### PR DESCRIPTION
Added frontend validation to check if address fields or name field is missing, if so give a human readable error message
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added client-side validation in PaymentForm to check missing name and address fields and show clear, human-readable errors before submit. Also uses the latest AddressElement value for billing_details.name to prevent failed confirmations.

- **Bug Fixes**
  - Validate name, address line1, city, state, postal code, and country with specific messages (e.g., “Please provide your name and city”).
  - Capture AddressElement value on change and use it when confirming setup/payment for billing_details.name.
  - Block submission and server calls when required fields are missing to avoid confusing Stripe errors.

<!-- End of auto-generated description by cubic. -->

