### PR TITLE
fix: rm `off_session` from payment intent creation

### DIFF
--- a/platform/flowglad-next/src/utils/stripe.ts
+++ b/platform/flowglad-next/src/utils/stripe.ts
@@ -1287,7 +1287,7 @@ export const createPaymentIntentForBillingRun = async ({
   })
 
   const applicationFeeAmount = livemode ? totalFeeAmount : undefined
-  
+
   // Create payment intent WITHOUT confirming
   return stripe(livemode).paymentIntents.create({
     amount,
@@ -1295,7 +1295,6 @@ export const createPaymentIntentForBillingRun = async ({
     customer: stripeCustomerId,
     payment_method: stripePaymentMethodId,
     confirm: false, // Don't confirm yet
-    off_session: true,
     application_fee_amount: applicationFeeAmount,
     metadata,
     automatic_payment_methods: {
@@ -1311,7 +1310,7 @@ export const confirmPaymentIntentForBillingRun = async (
 ) => {
   // Confirm the payment intent with Stripe
   return stripe(livemode).paymentIntents.confirm(paymentIntentId, {
-    off_session: true
+    off_session: true,
   })
 }
 


### PR DESCRIPTION
## What Does this PR Do?
- remove `off_session` from billing period payment intent creation    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update Stripe PaymentIntent flow to set off_session only at confirmation. This fixes off-session confirmation errors and aligns with Stripe’s manual confirmation flow.

- **Bug Fixes**
  - Removed off_session from createPaymentIntentForBillingRun (PI created with confirm: false).
  - Set off_session: true only in confirmPaymentIntentForBillingRun.

<!-- End of auto-generated description by cubic. -->

