### PR TITLE
ci: Add flowglad-next-integration-tests

### DIFF
--- a/.github/workflows/base-ci-cd.yml
+++ b/.github/workflows/base-ci-cd.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Generate OpenAPI documentation
         run: pnpm tsx src/scripts/openApiDoc.ts --skip-env-pull
 
-  flowglad-next-tests:
+  flowglad-next-unit-tests:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -147,6 +147,28 @@ jobs:
         run: pnpm test
       - name: Run test teardown
         run: pnpm test:teardown
+
+  flowglad-next-integration-tests:
+    # Only run in the merge queue so that we don't slow down the PR development
+    # iteration cycle.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: platform/flowglad-next
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # v2
+      - name: Build Docker image
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
+        with:
+          context: ./platform/flowglad-next
+          load: true
+          tags: flowglad-next:latest
+      - name: Run Docker container
+        run: docker run -d -p 3000:3000 --name flowglad-next-app flowglad-next:latest
 
   packages-build-and-lint:
     runs-on: ubuntu-latest
@@ -265,7 +287,7 @@ jobs:
       # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
       if: failure()
       runs-on: ubuntu-latest
-      needs: [flowglad-next-lint, openapi-check, flowglad-next-tests, packages-build-and-lint, packages-react-tests, check-todo, check-job-dependencies]
+      needs: [flowglad-next-lint, openapi-check, flowglad-next-unit-tests, flowglad-next-integration-tests, packages-build-and-lint, packages-react-tests, check-todo, check-job-dependencies]
       steps:
         - name: Mark the job as failed
           run: exit 1

--- a/platform/flowglad-next/Dockerfile
+++ b/platform/flowglad-next/Dockerfile
@@ -1,0 +1,73 @@
+###############################################
+# Build stage
+###############################################
+FROM node:20-bookworm-slim AS builder
+
+# Avoid prompts from apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /app
+
+# Enable corepack and ensure pnpm is available (uses version from package.json)
+RUN corepack enable
+
+# Increase Node.js heap for build to avoid OOM
+ARG NODE_OPTIONS=--max-old-space-size=6144
+ENV NODE_OPTIONS=${NODE_OPTIONS}
+
+# Install system deps that are commonly needed by Next.js tooling and node-gyp
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  ca-certificates \
+  git \
+  python3 \
+  build-essential && \
+  rm -rf /var/lib/apt/lists/*
+
+# Pre-copy manifest and config files to maximize cache
+COPY package.json pnpm-lock.yaml next.config.mjs ./
+
+# Prepare a minimal env file so prebuild step using dotenvx doesn't fail
+RUN touch .env.local
+
+# Install dependencies (full deps for build)
+RUN pnpm install --frozen-lockfile
+
+# Copy the rest of the source
+COPY . .
+
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+  --mount=type=cache,id=tool-cache,target=/app/node_modules/.cache \
+  --mount=type=cache,id=vite-cache,target=/app/node_modules/.vite \
+  --mount=type=cache,id=next-cache,target=/app/.next/cache \
+  pnpm build
+
+###############################################
+# Runtime stage
+###############################################
+FROM node:20-bookworm-slim AS runtime
+
+ENV VERCEL_ENV=production \
+  NODE_ENV=production \
+  PORT=3000 \
+  HOSTNAME=0.0.0.0
+
+WORKDIR /app
+
+# Create a non-root user for security
+RUN groupadd -r nodejs && useradd -r -g nodejs nodejs
+
+# Copy standalone server and required assets from the builder
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+
+# Optional: copy any additional files your app needs at runtime
+# COPY --from=builder /app/next.config.mjs ./next.config.mjs
+
+# Drop privileges
+USER nodejs
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/platform/flowglad-next/next.config.mjs
+++ b/platform/flowglad-next/next.config.mjs
@@ -3,6 +3,9 @@ import { withLogtail } from '@logtail/next'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // NOTE: Required by `Dockerfile` so that it can copy the `standalone` output
+  // directory in order to run the server.
+  output: 'standalone',
   outputFileTracingIncludes: {
     registry: ['./src/registry/**/*'],
   },

--- a/platform/flowglad-next/package.json
+++ b/platform/flowglad-next/package.json
@@ -82,6 +82,7 @@
     "@react-email/components": "0.0.36",
     "@remixicon/react": "^4.5.0",
     "@sentry/nextjs": "^8",
+    "@sentry/utils": "^8.55.0",
     "@sentry/node": "^8.55.0",
     "@slack/bolt": "^4.0.1",
     "@slack/web-api": "^7.7.0",

--- a/platform/flowglad-next/pnpm-lock.yaml
+++ b/platform/flowglad-next/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       '@sentry/node':
         specifier: ^8.55.0
         version: 8.55.0
+      '@sentry/utils':
+        specifier: ^8.55.0
+        version: 8.55.0
       '@slack/bolt':
         specifier: ^4.0.1
         version: 4.0.1
@@ -4305,6 +4308,10 @@ packages:
 
   '@sentry/utils@8.36.0':
     resolution: {integrity: sha512-oJ3EDPj0I00z+AwC3EWBpSidXYUoKW0Id8MfMQP5Hflniz3gif7UEReblT+FJgPEVo6+6uNzAncY0MuNMxmDKQ==}
+    engines: {node: '>=14.18'}
+
+  '@sentry/utils@8.55.0':
+    resolution: {integrity: sha512-cYcl39+xcOivBpN9d8ZKbALl+DxZKo/8H0nueJZ0PO4JA+MJGhSm6oHakXxLPaiMoNLTX7yor8ndnQIuFg+vmQ==}
     engines: {node: '>=14.18'}
 
   '@sentry/vercel-edge@8.36.0':
@@ -14426,6 +14433,10 @@ snapshots:
   '@sentry/utils@8.36.0':
     dependencies:
       '@sentry/types': 8.36.0
+
+  '@sentry/utils@8.55.0':
+    dependencies:
+      '@sentry/core': 8.55.0
 
   '@sentry/vercel-edge@8.36.0':
     dependencies:


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Dockerize flowglad-next with a multi-stage build and a production runtime to run the Next.js app in a container. Builds a standalone server on Node 20 and runs as a non-root user on port 3000.

- New Features
  - Add Dockerfile with builder/runtime stages using pnpm and Next.js standalone output.
  - Install minimal build deps, set NODE_OPTIONS to prevent OOM, and expose 3000 on 0.0.0.0.
  - Copy standalone server, static assets, and public; start with node server.js as a non-root user.

- Dependencies
  - Add @sentry/utils ^8.55.0 and update pnpm-lock.yaml.

<!-- End of auto-generated description by cubic. -->

