### PR TITLE
ci: Run all CI tests in merge queue

### DIFF
--- a/.github/workflows/base-ci-cd.yml
+++ b/.github/workflows/base-ci-cd.yml
@@ -1,9 +1,11 @@
 name: Base CI
 
 on:
-  workflow_call:
   pull_request:
-    branches: [main]
+  merge_group:
+  workflow_call:
+
+permissions: read-all
 
 jobs:
   flowglad-next-lint:


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable Base CI to run in the GitHub merge queue by adding the merge_group trigger, so all tests run before a queued merge. Also set workflow permissions to read-all.

<!-- End of auto-generated description by cubic. -->

