### PR TITLE
ci: Optimize PR test performance

### DIFF
--- a/platform/flowglad-next/package.json
+++ b/platform/flowglad-next/package.json
@@ -14,7 +14,7 @@
     "install-packages": "pnpm install --ignore-workspace",
     "test": "vitest run --reporter=verbose",
     "test:watch": "vitest --reporter=verbose",
-    "test:setup": "export NODE_ENV=test && docker-compose -f docker-compose.test.yml down --volumes && docker-compose -f docker-compose.test.yml up --build -d && docker-compose -f docker-compose.test.yml ps && pnpm migrations:push",
+    "test:setup": "export NODE_ENV=test && docker-compose -f docker-compose.test.yml down --volumes && docker-compose -f docker-compose.test.yml up -d && docker-compose -f docker-compose.test.yml ps && pnpm migrations:push",
     "test:teardown": "docker-compose -f docker-compose.test.yml down --volumes",
     "test:local": "npm run test:setup && DATABASE_URL=postgresql://test:test@localhost:5432/test_db ./src/scripts/run_subscription_tests.sh && npm run test:teardown",
     "stripe:webhook-dev": "stripe listen --forward-to localhost:3000/api/webhook-stripe",


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Speed up PR test setup by removing --build from docker-compose up in the test:setup script. This reuses cached images instead of rebuilding, keeping behavior the same while reducing CI time.

<!-- End of auto-generated description by cubic. -->

