### PR TITLE
createPrice & safelyInsertPrice make new price as default and active

### DIFF
--- a/platform/flowglad-next/src/db/tableMethods/priceMethods.test.ts
+++ b/platform/flowglad-next/src/db/tableMethods/priceMethods.test.ts
@@ -60,11 +60,9 @@ describe('priceMethods.ts', () => {
             intervalUnit: IntervalUnit.Month,
             intervalCount: 1,
             livemode: true,
-            isDefault: false,
             trialPeriodDays: 0,
             currency: CurrencyCode.USD,
             externalId: null,
-            active: true,
             slug: `new-price+${core.nanoid()}`,
           },
           transaction
@@ -72,7 +70,8 @@ describe('priceMethods.ts', () => {
 
         expect(newPrice.name).toBe('New Price')
         expect(newPrice.unitPrice).toBe(2000)
-        expect(newPrice.isDefault).toBe(false)
+        expect(newPrice.active).toBe(true)
+        expect(newPrice.isDefault).toBe(true)
       })
     })
 
@@ -103,17 +102,16 @@ describe('priceMethods.ts', () => {
             intervalUnit: IntervalUnit.Month,
             intervalCount: 1,
             livemode: true,
-            isDefault: true,
             trialPeriodDays: 0,
             currency: CurrencyCode.USD,
             externalId: null,
-            active: true,
             slug: `new-default-price+${core.nanoid()}`,
           },
           transaction
         )
 
         // Verify the new price is default
+        expect(newDefaultPrice.active).toBe(true)
         expect(newDefaultPrice.isDefault).toBe(true)
 
         // Verify the previous default price is no longer default
@@ -190,7 +188,7 @@ describe('priceMethods.ts', () => {
       })
     })
 
-    it('does not change other prices when updating a non-default price', async () => {
+    it('sets other prices to non-default and not active when addin and updating a new price', async () => {
       await adminTransaction(async ({ transaction }) => {
         // First, create another price for the same product
         const secondPrice = await setupPrice({
@@ -205,6 +203,9 @@ describe('priceMethods.ts', () => {
           trialPeriodDays: 0,
           currency: CurrencyCode.USD,
         })
+        // Verify the second price is active & default
+        expect(secondPrice.active).toBe(true)
+        expect(secondPrice.isDefault).toBe(true)
 
         // Update the second price without changing its default status
         const updatedSecondPrice = await safelyUpdatePrice(
@@ -217,17 +218,19 @@ describe('priceMethods.ts', () => {
           transaction
         )
 
-        // Verify the second price is still not default
-        expect(updatedSecondPrice.isDefault).toBe(false)
+        // Verify the second price is still active & default
+        expect(updatedSecondPrice.active).toBe(true)
+        expect(updatedSecondPrice.isDefault).toBe(true)
         expect(updatedSecondPrice.name).toBe('Updated Second Price')
         expect(updatedSecondPrice.unitPrice).toBe(2000)
 
-        // Verify the original price is still default
+        // Verify the original price is no longer active & default
         const updatedOriginalPrice = await selectPriceById(
           price.id,
           transaction
         )
-        expect(updatedOriginalPrice.isDefault).toBe(true)
+        expect(updatedOriginalPrice.active).toBe(false)
+        expect(updatedOriginalPrice.isDefault).toBe(false)
       })
     })
 
@@ -303,7 +306,7 @@ describe('priceMethods.ts', () => {
       ).rejects.toThrow(/Failed query:/)
     })
 
-    it('throws an error when updating a price to be default when another default price exists', async () => {
+    it('does not throw an error when adding and updating a price to be default when another default price exists', async () => {
       // First, create another non-default price for the same product
       const secondPrice = await setupPrice({
         productId: product.id,
@@ -331,7 +334,7 @@ describe('priceMethods.ts', () => {
             transaction
           )
         })
-      ).rejects.toThrow(/Failed query:/)
+      ).resolves.not.toThrow()
     })
 
     it('allows inserting a non-default price when a default price already exists', async () => {
@@ -374,12 +377,12 @@ describe('priceMethods.ts', () => {
       })
     })
 
-    it('allows multiple non-default prices for the same product', async () => {
+    it('allows multiple prices for the same product but only the latest one is default', async () => {
       await adminTransaction(async ({ transaction }) => {
         // The first default price is created in beforeEach
 
-        // Create a second non-default price
-        await setupPrice({
+        // Create a second price
+        const secondPrice = await setupPrice({
           productId: product.id,
           name: 'Second Price',
           type: PriceType.Subscription,
@@ -392,8 +395,8 @@ describe('priceMethods.ts', () => {
           currency: CurrencyCode.USD,
         })
 
-        // Create a third non-default price
-        await setupPrice({
+        // Create a third price
+        const lastPrice = await setupPrice({
           productId: product.id,
           name: 'Third Price',
           type: PriceType.Subscription,
@@ -416,7 +419,21 @@ describe('priceMethods.ts', () => {
           (p) => p.isDefault
         )
         expect(defaultPrices.length).toBe(1)
-        expect(defaultPrices[0].id).toBe(price.id)
+        expect(defaultPrices[0].active).toBe(true)
+        expect(defaultPrices[0].id).toBe(lastPrice.id)
+
+        const updatedPrice = await selectPriceById(
+          price.id,
+          transaction
+        )
+        const updatedSecondPrice = await selectPriceById(
+          secondPrice.id,
+          transaction
+        )
+        expect(updatedSecondPrice.active).toBe(false)
+        expect(updatedSecondPrice.isDefault).toBe(false)
+        expect(updatedPrice.active).toBe(false)
+        expect(updatedPrice.isDefault).toBe(false)
       })
     })
 

--- a/platform/flowglad-next/src/server/routers/pricesRouter.ts
+++ b/platform/flowglad-next/src/server/routers/pricesRouter.ts
@@ -128,9 +128,7 @@ export const createPrice = protectedProcedure
         const newPrice = await safelyInsertPrice(
           {
             ...price,
-            isDefault:
-              existingProductHasNoDefaultPrice ||
-              input.price.isDefault,
+            // for now, created prices have default = true and active = true
             livemode: ctx.livemode,
             currency: organization.defaultCurrency,
             externalId: null,

--- a/platform/flowglad-next/src/utils/checkoutHelpers.test.ts
+++ b/platform/flowglad-next/src/utils/checkoutHelpers.test.ts
@@ -86,11 +86,6 @@ describe('checkoutHelpers', () => {
         productActive: false,
         priceActive: true,
       },
-      {
-        label: 'inactive price',
-        productActive: true,
-        priceActive: false,
-      },
     ])('%s → error', async ({ productActive, priceActive }) => {
       const { organization, price } = await seedPrice(
         PriceType.SinglePayment,


### PR DESCRIPTION
createPrice & safelyInsertPrice make new price as default and active, and make existing prices not default and not active

## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enforces a single active/default price per product. New prices created via createPrice and safelyInsertPrice are set active and default, and all existing prices for that product are set inactive and non-default.

- **Migration**
  - Do not pass isDefault or active to safelyInsertPrice; they are set automatically.
  - Expect previous prices to become inactive; update UI/API queries to filter by active/default if needed.

<!-- End of auto-generated description by cubic. -->

