### PR TITLE
fix: check if no paymentMethodType in PaymentForm

### DIFF
--- a/platform/flowglad-next/src/components/PaymentForm.tsx
+++ b/platform/flowglad-next/src/components/PaymentForm.tsx
@@ -264,6 +264,13 @@ const PaymentForm = () => {
 
         setIsSubmitting(true)
 
+        // Validate payment method before proceeding
+        if (!checkoutSession.paymentMethodType) {
+          setErrorMessage('Please select a payment method')
+          setIsSubmitting(false)
+          return
+        }
+
         // Validate address before proceeding
         if (!checkoutSession.billingAddress) {
           setAddressError('Please fill in your billing address')


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Require a selected payment method before submitting the PaymentForm to prevent checkout errors.

If paymentMethodType is missing, show “Please select a payment method” and cancel submission.

<!-- End of auto-generated description by cubic. -->

