### PR TITLE
invalidate cache so create price shows newly created usage meter

### DIFF
--- a/platform/flowglad-next/src/components/components/CreateUsageMeterModal.tsx
+++ b/platform/flowglad-next/src/components/components/CreateUsageMeterModal.tsx
@@ -18,6 +18,7 @@ const CreateUsageMeterModal: React.FC<CreateUsageMeterModalProps> = ({
   defaultPricingModelId,
 }) => {
   const createUsageMeter = trpc.usageMeters.create.useMutation()
+  const trpcContext = trpc.useContext()
   return (
     <FormModal
       isOpen={isOpen}
@@ -33,6 +34,9 @@ const CreateUsageMeterModal: React.FC<CreateUsageMeterModalProps> = ({
         },
       }}
       onSubmit={createUsageMeter.mutateAsync}
+      onSuccess={() => {
+        trpcContext.usageMeters.list.invalidate()
+      }}
     >
       <UsageMeterFormFields />
     </FormModal>


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Invalidate the usageMeters.list cache after successfully creating a usage meter in CreateUsageMeterModal. This ensures the new meter appears immediately in the price creation flow and other views.

<!-- End of auto-generated description by cubic. -->

