### PR TITLE
fix: post build in CI

### DIFF
--- a/platform/flowglad-next/package.json
+++ b/platform/flowglad-next/package.json
@@ -147,7 +147,7 @@
     "playwright": "^1.46.1",
     "playwright-core": "1.47.0",
     "postgres": "^3.4.4",
-    "posthog-js": "^1.157.2",
+    "posthog-js": "1.261.0",
     "posthog-node": "^4.1.1",
     "puppeteer": "^24.4.0",
     "query-string": "^9.1.1",

--- a/platform/flowglad-next/pnpm-lock.yaml
+++ b/platform/flowglad-next/pnpm-lock.yaml
@@ -359,8 +359,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.5
       posthog-js:
-        specifier: ^1.157.2
-        version: 1.179.0
+        specifier: 1.261.0
+        version: 1.261.0
       posthog-node:
         specifier: ^4.1.1
         version: 4.2.1
@@ -2746,6 +2746,9 @@ packages:
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  '@posthog/core@1.0.2':
+    resolution: {integrity: sha512-hWk3rUtJl2crQK0WNmwg13n82hnTwB99BT99/XI5gZSvIlYZ1TPmMZE8H2dhJJ98J/rm9vYJ/UXNzw3RV5HTpQ==}
 
   '@prisma/instrumentation@5.19.1':
     resolution: {integrity: sha512-VLnzMQq7CWroL5AeaW0Py2huiNKeoMfCH3SUxstdzPrlWQi6UQ9UrfcbUkNHlVFqOMacqy8X/8YtE0kuKDpD9w==}
@@ -5879,8 +5882,8 @@ packages:
   core-js-compat@3.39.0:
     resolution: {integrity: sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==}
 
-  core-js@3.39.0:
-    resolution: {integrity: sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==}
+  core-js@3.46.0:
+    resolution: {integrity: sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -8342,8 +8345,16 @@ packages:
     resolution: {integrity: sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg==}
     engines: {node: '>=12'}
 
-  posthog-js@1.179.0:
-    resolution: {integrity: sha512-TLmDA3oDdjZfOaNCueXBdlWD+kTzBGvz2QpOY/zdzljbazXXl25xzXBINLIC7IxIS2gNAfCDRuOUosSZALOyUQ==}
+  posthog-js@1.261.0:
+    resolution: {integrity: sha512-jyiXqyrCU+VlpbNNVRA6OQYAVut0XZMYNELCZH+XvTd981VqbE4jXn4XCBreo7XCL2gdPgDVxUVOuzNvEuKcmw==}
+    peerDependencies:
+      '@rrweb/types': 2.0.0-alpha.17
+      rrweb-snapshot: 2.0.0-alpha.17
+    peerDependenciesMeta:
+      '@rrweb/types':
+        optional: true
+      rrweb-snapshot:
+        optional: true
 
   posthog-node@4.2.1:
     resolution: {integrity: sha512-l+fsjYEkTik3m/G0pE7gMr4qBJP84LhK779oQm6MBzhBGpd4By4qieTW+4FUAlNCyzQTynn3Nhsa50c0IELSxQ==}
@@ -12816,6 +12827,8 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
+  '@posthog/core@1.0.2': {}
+
   '@prisma/instrumentation@5.19.1':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -16389,7 +16402,7 @@ snapshots:
     dependencies:
       browserslist: 4.24.2
 
-  core-js@3.39.0: {}
+  core-js@3.46.0: {}
 
   core-util-is@1.0.3: {}
 
@@ -19084,9 +19097,10 @@ snapshots:
 
   postgres@3.4.5: {}
 
-  posthog-js@1.179.0:
+  posthog-js@1.261.0:
     dependencies:
-      core-js: 3.39.0
+      '@posthog/core': 1.0.2
+      core-js: 3.46.0
       fflate: 0.4.8
       preact: 10.24.3
       web-vitals: 4.2.4

--- a/platform/flowglad-next/public/preview/manifest.json
+++ b/platform/flowglad-next/public/preview/manifest.json
@@ -1,6 +1,6 @@
 {
-  "hash": "c5a13ba5",
+  "hash": "9a0608a3",
   "path": "/preview/preview.css",
-  "size": 86443,
-  "generatedAt": "2025-10-05T16:51:38.126Z"
+  "size": 86478,
+  "generatedAt": "2025-10-21T16:18:38.965Z"
 }


### PR DESCRIPTION
## What Does this PR Do?
Fixes this error caused, it seems, by posthog package.json <> pnpm-lock.yaml version drift in CI
<img width="2322" height="830" alt="CleanShot 2025-10-21 at 12 53 09@2x" src="https://github.com/user-attachments/assets/eff60585-51a3-4fe6-8034-9cc612918ce3" />
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes CI post-build failures by pinning posthog-js to 1.261.0 for consistent dependency resolution. Ensures stable builds across environments.

- **Bug Fixes**
  - Lock posthog-js to 1.261.0 to prevent version drift breaking CI.

- **Dependencies**
  - Updated pnpm-lock with @posthog/core and core-js 3.46.0 pulled in by posthog-js 1.261.0.
  - Regenerated preview manifest.

<!-- End of auto-generated description by cubic. -->

