### PR TITLE
fix: sql optimized available usage credit aggregation calculations

### DIFF
--- a/platform/flowglad-next/src/db/tableMethods/ledgerEntryMethods.test.ts
+++ b/platform/flowglad-next/src/db/tableMethods/ledgerEntryMethods.test.ts
@@ -1956,7 +1956,7 @@ describe('ledgerEntryMethods', () => {
     })
   })
 
-  describe('aggregateAvailableBalanceForUsageCreditt', () => {
+  describe('aggregateAvailableBalanceForUsageCredit', () => {
     let testLedgerTransaction: LedgerTransaction.Record
     let usageCreditId1: string
     // We can add more usageCreditIds here if needed for other tests


### PR DESCRIPTION
## What Does this PR Do?
- adds an SQL-optimized calculation of usage credit aggregation calculations that aggregates in the DB rather than egresses the data out to aggregate in memory
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Aggregate available usage credit balances directly in SQL using a single grouped query to cut DB egress and speed up large accounts. Return shape stays the same, now including expiresAt from a join.

- **Refactors**
  - Replace in-memory reduction with SUM(CASE ...) over ledger entries.
  - Join usage_credits to fetch expiresAt in the same query.
  - Group by sourceUsageCreditId and ledgerAccountId; exclude credit applications from balance.
  - Parse numeric balance from SQL result and return expiresAt in ms.

<!-- End of auto-generated description by cubic. -->

