### PR TITLE
chore: sdk version bump to 0.11.0

### DIFF
--- a/packages/express/CHANGELOG.md
+++ b/packages/express/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @flowglad/express
 
+## 0.11.0
+
+### Minor Changes
+
+- bump @flowglad/node dependency to v0.22, cleanup FlowgladServer methods
+
+### Patch Changes
+
+- Updated dependencies
+  - @flowglad/react@0.11.0
+  - @flowglad/server@0.11.0
+  - @flowglad/shared@0.11.0
+
 ## 0.10.18
 
 ### Patch Changes

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowglad/express",
-  "version": "0.10.18",
+  "version": "0.11.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/nextjs/CHANGELOG.md
+++ b/packages/nextjs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @flowglad/nextjs
 
+## 0.11.0
+
+### Minor Changes
+
+- bump @flowglad/node dependency to v0.22, cleanup FlowgladServer methods
+
+### Patch Changes
+
+- Updated dependencies
+  - @flowglad/react@0.11.0
+  - @flowglad/server@0.11.0
+  - @flowglad/shared@0.11.0
+
 ## 0.10.18
 
 ### Patch Changes

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowglad/nextjs",
-  "version": "0.10.18",
+  "version": "0.11.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @flowglad/react
 
+## 0.11.0
+
+### Minor Changes
+
+- bump @flowglad/node dependency to v0.22, cleanup FlowgladServer methods
+
+### Patch Changes
+
+- Updated dependencies
+  - @flowglad/shared@0.11.0
+
 ## 0.10.18
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowglad/react",
-  "version": "0.10.18",
+  "version": "0.11.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @flowglad/server
 
+## 0.11.0
+
+### Minor Changes
+
+- bump @flowglad/node dependency to v0.22, cleanup FlowgladServer methods
+
+### Patch Changes
+
+- Updated dependencies
+  - @flowglad/shared@0.11.0
+  - @flowglad/types@0.11.0
+
 ## 0.10.18
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowglad/server",
-  "version": "0.10.18",
+  "version": "0.11.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @flowglad/shared
 
+## 0.11.0
+
+### Minor Changes
+
+- bump @flowglad/node dependency to v0.22, cleanup FlowgladServer methods
+
+### Patch Changes
+
+- Updated dependencies
+  - @flowglad/types@0.11.0
+
 ## 0.10.18
 
 ### Patch Changes

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowglad/shared",
-  "version": "0.10.18",
+  "version": "0.11.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @flowglad/types
 
+## 0.11.0
+
+### Minor Changes
+
+- bump @flowglad/node dependency to v0.22, cleanup FlowgladServer methods
+
 ## 0.10.18
 
 ### Patch Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowglad/types",
-  "version": "0.10.18",
+  "version": "0.11.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bumps all SDK packages to 0.11.0 and aligns dependencies with @flowglad/node v0.22. Includes minor cleanup of FlowgladServer methods.

- **Dependencies**
  - Updated versions to 0.11.0 for express, nextjs, react, server, shared, and types.
  - Aligned internal deps across packages; node dependency bumped to v0.22.

- **Refactors**
  - Cleaned up FlowgladServer methods for consistency.

<!-- End of auto-generated description by cubic. -->

