### PR TITLE
Require shell scripts to use `set -euo pipefail`

### DIFF
--- a/.github/workflows/base-ci-cd.yml
+++ b/.github/workflows/base-ci-cd.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Get pnpm store directory
         shell: bash
         run: |
+          set -euo pipefail
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
       - name: Setup pnpm cache
         uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
@@ -59,6 +60,7 @@ jobs:
       - name: Get pnpm store directory
         shell: bash
         run: |
+          set -euo pipefail
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
       - name: Setup pnpm cache
         uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
@@ -116,6 +118,7 @@ jobs:
       - name: Get pnpm store directory
         shell: bash
         run: |
+          set -euo pipefail
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
       - name: Setup pnpm cache
         uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
@@ -147,6 +150,7 @@ jobs:
       - name: Get pnpm store directory
         shell: bash
         run: |
+          set -euo pipefail
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
       - name: Setup pnpm cache
         uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
@@ -169,8 +173,9 @@ jobs:
     steps:
       - name: Install ripgrep
         run: |
-         sudo apt-get update
-         sudo apt-get install ripgrep
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install ripgrep
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Run todo check
         run: ./ci/check_todo.sh

--- a/.github/workflows/build-and-deploy-flowglad-next.yml
+++ b/.github/workflows/build-and-deploy-flowglad-next.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Get pnpm store directory
         shell: bash
         run: |
+          set -euo pipefail
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
       
       - name: Setup pnpm cache
@@ -64,6 +65,7 @@ jobs:
         
       - name: Pull Vercel Environment Variables
         run: |
+          set -euo pipefail
           vercel pull --yes --environment=${{ inputs.environment }} --token=${{ secrets.VERCEL_TOKEN }}
           cp .vercel/.env.${{ inputs.environment }}.local .env.local
           cp .vercel/.env.${{ inputs.environment }}.local platform/flowglad-next/.env.local
@@ -98,6 +100,7 @@ jobs:
       - name: Trigger Update API Reference in Mintlify
         if: ${{ inputs.environment == 'production' }}
         run: |
+          set -euo pipefail
           curl --fail-with-body --request POST \
             --url https://api.mintlify.com/v1/project/update/${{ secrets.MINTLIFY_PROJECT_ID }} \
             --header 'Authorization: Bearer ${{ secrets.MINTLIFY_API_KEY }}'

--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -43,11 +43,13 @@ jobs:
 
       - name: Configure Git
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Rebase stable onto main
         run: |
+          set -euo pipefail
           git fetch origin stable
           git checkout stable
           git pull origin stable

--- a/.github/workflows/flowglad-next-sharded-unit-tests.yml
+++ b/.github/workflows/flowglad-next-sharded-unit-tests.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Get pnpm store directory
         shell: bash
         run: |
+          set -euo pipefail
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
       - name: Setup pnpm cache
         uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
@@ -59,6 +60,7 @@ jobs:
         uses: ndeloof/install-compose-action@v0.0.1
       - name: Setup Docker for tests
         run: |
+          set -euo pipefail
           # Clean up any existing containers and volumes
           docker-compose -f docker-compose.test.yml down --volumes || true
           # Start test services in detached mode
@@ -114,6 +116,7 @@ jobs:
       - name: Get pnpm store directory
         shell: bash
         run: |
+          set -euo pipefail
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
       - name: Setup pnpm cache
         uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -32,3 +32,10 @@ At project root:
 - When you're working on this codebase, you almost always will need platform/flowglad-next running on localhost:3000. So always start by booting up flowglad-next
 - Other projects usually run on localhost:3001 or 3XXX, and will consume flowglad-next via an env variable that tells them where to make Flowglad API calls - to localhost:3000
 - For each project, refer to its root README to get a sense of how the pieces fit together
+
+# Code Review Guardrails
+
+- **Shell scripts**: Ensure every tracked `.sh` file starts with either `#!/bin/bash` or `#!/usr/bin/env bash`, and that the first non-comment, non-empty line is exactly `set -euo pipefail`.
+- **GitHub Actions `run` steps**:
+  - Reject single-line `run:` commands that contain a pipe (`|`).
+  - Require multi-line `run:` blocks to include `set -euo pipefail` as their first executable statement (ignoring comments and blank lines).

--- a/ci/check_job_dependencies.sh
+++ b/ci/check_job_dependencies.sh
@@ -8,7 +8,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-set -eo pipefail
+set -euo pipefail
 which yq > /dev/null
 jobs=$(for i in $(find .github -iname '*.yaml' -or -iname '*.yml')
   do


### PR DESCRIPTION
## Summary
- require `set -euo pipefail` in the reviewer guardrails and associated workflows
- restore shell scripts to use `/usr/bin/env bash` while enabling nounset handling

Closes FG-399

------
https://chatgpt.com/codex/tasks/task_e_68f98abd1c2c83209e2891d53b3270cc
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Tightened shell and CI guardrails by requiring bash shebangs and set -euo pipefail. This makes CI fail fast and prevents silent errors from unset variables or broken pipes.

- **Refactors**
  - Added set -euo pipefail to multi-line run steps across CI workflows (base-ci-cd, flowglad-next deploy, staging deploy, sharded unit tests).
  - Strengthened code review rules: require bash shebang, set -euo pipefail as the first executable line; reject single-line run commands with pipes; require guardrails in multi-line runs.
  - Updated ci/check_job_dependencies.sh to use set -euo pipefail.

<!-- End of auto-generated description by cubic. -->

