### PR TITLE
Pricing model export

### DIFF
--- a/platform/flowglad-next/src/app/store/pricing-models/[id]/InnerPricingModelDetailsPage.tsx
+++ b/platform/flowglad-next/src/app/store/pricing-models/[id]/InnerPricingModelDetailsPage.tsx
@@ -103,7 +103,6 @@ function InnerPricingModelDetailsPage({
     {
       label: 'Export',
       handler: () => exportPricingModelHandler(),
-      // TODO icon:
       helperText: 'Export pricing model as YAML file',
     },
   ]

--- a/platform/flowglad-next/src/server/routers/pricingModelsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/pricingModelsRouter.ts
@@ -315,20 +315,17 @@ const exportPricingModelProcedure = protectedProcedure
         .describe('YAML representation of the pricing model'),
     })
   )
-  .query(async ({ input, ctx }) => {
-    return authenticatedTransaction(
-      async ({ transaction }) => {
+  .query(
+    authenticatedProcedureTransaction(
+      async ({ input, transaction }) => {
         const data = await getPricingModelSetupData(
           input.id,
           transaction
         )
         return { pricingModelYAML: yaml.stringify(data) }
-      },
-      {
-        apiKey: ctx.apiKey,
       }
     )
-  })
+  )
 
 export const pricingModelsRouter = router({
   list: listPricingModelsProcedure,


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enables exporting a pricing model to a YAML file from the Pricing Model details page. Adds a server endpoint that builds a validated YAML from the model and its related data.

- **New Features**
  - API: Added trpc.pricingModels.export that returns pricingModelYAML built via getPricingModelSetupData and json-to-pretty-yaml.
  - UI: Added “Export” in the More (ellipsis) popover to download pricing-<id>.yaml with success/error toasts.
  - Data: New getPricingModelSetupData aggregates usage meters, features, products, and prices; converts IDs to slugs; validates against setupPricingModelSchema; throws on missing slugs or invalid links.
  - Tests: Added Vitest coverage for full, minimal, and not-found cases to ensure correct transformation and validation.

<!-- End of auto-generated description by cubic. -->

