### PR TITLE
Fix redis for looking than 2 months

### DIFF
--- a/platform/flowglad-next/src/db/tableUtils.ts
+++ b/platform/flowglad-next/src/db/tableUtils.ts
@@ -1141,19 +1141,11 @@ export const createPaginatedSelectFunction = <
             limit
         )
       }
-      const {
-        parameters,
-        createdAt,
-        direction,
-      }: {
-        parameters: SelectConditions<T>
-        createdAt: Date | undefined
-        direction: PaginationDirection
-      } = cursor
+      const { parameters, createdAt, direction } = cursor
         ? decodeCursor(cursor)
         : {
-            parameters: {} as SelectConditions<T>,
-            createdAt: undefined,
+            parameters: {},
+            createdAt: new Date(),
             direction: 'forward',
           }
       let query = transaction
@@ -1161,14 +1153,13 @@ export const createPaginatedSelectFunction = <
         .from(table as SelectTable)
         .$dynamic()
       if (Object.keys(parameters).length > 0) {
-        query = query.where(whereClauseFromObject(table, parameters))
-      }
-
-      if (createdAt) {
         query = query.where(
-          direction === 'forward'
-            ? gt(table.createdAt, createdAt)
-            : lt(table.createdAt, createdAt)
+          and(
+            whereClauseFromObject(table, parameters),
+            direction === 'forward'
+              ? gt(table.createdAt, createdAt)
+              : lt(table.createdAt, createdAt)
+          )
         )
       }
       const queryLimit = limit + 1


### PR DESCRIPTION
Removed one line stating how long the cache would last for. I changed it to last forever.


enum RedisKeyNamespace {
  ApiKeyVerificationResult = 'apiKeyVerificationResult',
  ReferralSelection = 'referralSelection',
  Telemetry = 'telemetry',
}

const evictionPolicy: Record<
  RedisKeyNamespace,
  Record<string, number>
> = {
  [RedisKeyNamespace.ApiKeyVerificationResult]: {
    max: 100000, // 100,000 items
    ttl: 60 * 60 * 2.4, // 2.4 hours
  },
  [RedisKeyNamespace.ReferralSelection]: {
    max: 200000, // up to 200k selections across tenants
    **ttl: 60 * 60 * 24 * 90, // retain for ~90 days <--- Remove this line**
  },
  [RedisKeyNamespace.Telemetry]: {
    max: 500000, // up to 500k telemetry records
    ttl: 60 * 60 * 24 * 14, // 14 days (matches trigger.dev TTL)
  },
}
    

