### PR TITLE
Fix rearranging revenue chart

### DIFF
--- a/platform/flowglad-next/src/components/RevenueChart.tsx
+++ b/platform/flowglad-next/src/components/RevenueChart.tsx
@@ -207,8 +207,8 @@ export function RevenueChart({
   }
   return (
     <div className="w-full h-full">
-      <div className="flex flex-row gap-2 justify-between">
-        <div className="text-sm text-muted-foreground w-fit flex items-center flex-row"></div>
+      <div className="flex gap-2 justify-between">
+        <div className="text-sm text-muted-foreground w-fit flex items-center"></div>
         {/*         <Button
           variant="ghost"
           size="sm"
@@ -226,7 +226,7 @@ export function RevenueChart({
         {isLoading ? (
           <Skeleton className="w-36 h-12" />
         ) : (
-          <div className="flex flex-col ">
+          <div className="flex flex-col">
             <p className="text-xl font-semibold text-foreground">
               {formattedRevenueValue}
             </p>


### PR DESCRIPTION
In RevenueChart.tsx, I switched the revenue number and Revenue By text to make it more understandable that they are **NOT** connected.


Before:
<img width="2294" height="1262" alt="image" src="https://github.com/user-attachments/assets/45b089e1-7bc2-4d99-9bfe-8d585467c11a" />


After:
<img width="2306" height="1206" alt="image" src="https://github.com/user-attachments/assets/323f8d8d-3c2e-4ad4-922f-972815627ed9" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes cursor-based pagination so filters and cursors are applied correctly, and updates the RevenueChart header to make the revenue value and “Revenue by” selector clearly separate.

- **Bug Fixes**
  - API: Added searchParamsToObject and merged query params with mapped input so GET/POST requests pass filters/limit/cursor to tRPC.
  - Pagination: In createPaginatedSelectFunction, handle no-cursor correctly, only apply createdAt bounds when present, and apply where clauses only when parameters exist.
  - UI: Moved the revenue value above the “Revenue by” selector and simplified layout to avoid implying they’re linked.

<!-- End of auto-generated description by cubic. -->

