### PR TITLE
emit ledger command depending on usage event properties, add tests

### DIFF
--- a/platform/flowglad-next/seedDatabase.ts
+++ b/platform/flowglad-next/seedDatabase.ts
@@ -59,6 +59,7 @@ import {
   StripeConnectContractType,
   BusinessOnboardingStatus,
   NormalBalanceType,
+  UsageMeterAggregationType,
 } from '@/types'
 import { core, isNil } from '@/utils/core'
 import { sql } from 'drizzle-orm'
@@ -1426,12 +1427,14 @@ export const setupUsageMeter = async ({
   livemode = true,
   pricingModelId,
   slug,
+  aggregationType,
 }: {
   organizationId: string
   name: string
   livemode?: boolean
   pricingModelId?: string
   slug?: string
+  aggregationType?: UsageMeterAggregationType
 }) => {
   return adminTransaction(async ({ transaction }) => {
     let pricingModelToUseId: string | null = null
@@ -1464,6 +1467,7 @@ export const setupUsageMeter = async ({
         livemode,
         pricingModelId: pricingModelToUseId,
         slug: slug ?? `${snakeCase(name)}-${core.nanoid()}`,
+        ...(aggregationType && { aggregationType }),
       },
       transaction
     )

--- a/platform/flowglad-next/src/utils/usage/usageEventHelpers.ts
+++ b/platform/flowglad-next/src/utils/usage/usageEventHelpers.ts
@@ -1,6 +1,10 @@
 import { selectPriceById } from '@/db/tableMethods/priceMethods'
 import { selectCurrentBillingPeriodForSubscription } from '@/db/tableMethods/billingPeriodMethods'
-import { LedgerTransactionType, PriceType } from '@/types'
+import {
+  LedgerTransactionType,
+  PriceType,
+  UsageMeterAggregationType,
+} from '@/types'
 import {
   insertUsageEvent,
   selectUsageEvents,
@@ -10,6 +14,7 @@ import { DbTransaction } from '@/db/types'
 import { CreateUsageEventInput } from '@/db/schema/usageEvents'
 import { TransactionOutput } from '@/db/transactionEnhacementTypes'
 import { UsageEvent } from '@/db/schema/usageEvents'
+import { selectUsageMeterById } from '@/db/tableMethods/usageMeterMethods'
 
 export const ingestAndProcessUsageEvent = async (
   {
@@ -70,6 +75,41 @@ export const ingestAndProcessUsageEvent = async (
     },
     transaction
   )
+
+  // Check if UsageMeter is of type count_distinct_properties
+  // If so, only return a ledgerCommand if
+  // there isn't already a usageEvent for the current billing period with the same properties object
+  const usageMeter = await selectUsageMeterById(
+    usageEvent.usageMeterId,
+    transaction
+  )
+  if (
+    usageMeter.aggregationType ===
+    UsageMeterAggregationType.CountDistinctProperties
+  ) {
+    if (!billingPeriod) {
+      throw new Error(
+        `Billing period is required in ingestAndProcessUsageEvent for usage meter of type "count_distinct_properties".`
+      )
+    }
+    const eventsInPeriod = await selectUsageEvents(
+      {
+        usageMeterId: usageEvent.usageMeterId,
+        ...(usageEvent.properties && {
+          properties: usageEvent.properties,
+        }),
+        billingPeriodId: billingPeriod.id,
+      },
+      transaction
+    )
+    // Filter out the just-inserted event
+    const existingUsageEvent = eventsInPeriod.find(
+      (event) => event.id !== usageEvent.id
+    )
+    if (existingUsageEvent) {
+      return { result: { usageEvent } }
+    }
+  }
 
   return {
     result: { usageEvent },


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit ledger commands only when usage events have distinct properties within the current billing period for meters using count_distinct_properties. Prevents duplicate ledger transactions for repeated property sets; adds tests to validate behavior.

- **Bug Fixes**
  - Added aggregation check in ingestAndProcessUsageEvent for count_distinct_properties.
  - Skip ledger command when an event with the same properties already exists in the billing period.
  - Updated setupUsageMeter to accept aggregationType.
  - Added tests for unique, duplicate, and changed property sets.

<!-- End of auto-generated description by cubic. -->

