### PR TITLE
fix: switched checkout image styling from object-cover to object-cont…

### DIFF
--- a/platform/flowglad-next/src/components/checkout/billing-header.tsx
+++ b/platform/flowglad-next/src/components/checkout/billing-header.tsx
@@ -128,18 +128,24 @@ export const BillingHeader = React.forwardRef<
       {/* Product Image */}
       {product.imageURL && (
         <div className="w-full">
-          <div className="relative w-full aspect-[760/420] rounded-lg overflow-hidden bg-muted">
+          <div
+            className={cn(
+              'relative w-full rounded-lg overflow-hidden bg-muted',
+              'flex items-center justify-center',
+              'h-56 sm:h-64 md:h-72 lg:h-80 xl:h-96 max-h-[420px]'
+            )}
+          >
             <Image
               src={product.imageURL}
               alt={product.name}
               fill
-              className="object-cover object-center"
-              sizes="(max-width: 768px) 100vw, 448px"
+              className="object-contain"
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 75vw, 50vw"
+              priority
             />
           </div>
         </div>
       )}
-
       {/* Product Description */}
       {product.description && (
         <div


### PR DESCRIPTION

## What Does this PR Do?

On the checkout the image was being cropped and displayed weirdly so I changed the styling in the inner div and the image element. I changed the image from object-cover to object-contain as stated by the ticket. Also I removed the preset aspect ratio.

```typescript
{/* Product Image */}
      {product.imageURL && (
        <div className="w-full">
          <div
            className={cn(
              'relative w-full rounded-lg overflow-hidden bg-muted',
              'flex items-center justify-center',
              'h-56 sm:h-64 md:h-72 lg:h-80 xl:h-96 max-h-[420px]'
            )}
          >
            <Image
              src={product.imageURL}
              alt={product.name}
              fill
              className="object-contain"
              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 75vw, 50vw"
              priority
            />
          </div>
        </div>
      )}
``` 


After:
<img width="1467" height="832" alt="image" src="https://github.com/user-attachments/assets/51ffa4f0-1646-4a01-8bf3-345687af6af6" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes checkout product image cropping by switching to object-contain and centering the image in a responsive container. Images now display fully without stretching or cut-off, aligning with the ticket request.

- **Bug Fixes**
  - Changed Image class from object-cover to object-contain; removed fixed aspect ratio.
  - Added a flex-centered wrapper with responsive heights to maintain layout.
  - Updated sizes and enabled priority loading for better visual stability.

<!-- End of auto-generated description by cubic. -->

