### PR TITLE
fix: image stretching checkout page

### DIFF
--- a/platform/flowglad-next/src/components/checkout/billing-header.tsx
+++ b/platform/flowglad-next/src/components/checkout/billing-header.tsx
@@ -135,7 +135,7 @@ export const BillingHeader = React.forwardRef<
               width={1200}
               height={800}
               className="w-full h-auto object-contain"
-              sizes="(max-width: 639px) calc(100vw - 2rem), (max-width: 767px) calc(50vw - 4rem), (max-width: 1023px) calc(50vw - 6rem), 374px"
+              sizes="(max-width: 768px) 100vw, 448px"
               priority
             />
           </div>


### PR DESCRIPTION
Fixes an issue where imgs got cropped or stretched on checkout pages

Continuing from #673 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents product images from stretching or getting cropped on the checkout page by using object-contain with explicit dimensions and responsive sizes.

- **Bug Fixes**
  - Switched Next/Image from fill + object-cover to width/height + object-contain.
  - Removed fixed aspect-ratio wrapper to preserve natural image ratios.
  - Updated sizes for breakpoints and set priority for a stable initial render.

<!-- End of auto-generated description by cubic. -->

