### PR TITLE
fix: list invoice line items endpoint

### DIFF
--- a/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
+++ b/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
@@ -19,6 +19,7 @@ import { checkoutSessionsRouteConfigs } from '@/server/routers/checkoutSessionsR
 import { discountsRouteConfigs } from '@/server/routers/discountsRouter'
 import { pricesRouteConfigs } from '@/server/routers/pricesRouter'
 import { invoicesRouteConfigs } from '@/server/routers/invoicesRouter'
+import { invoiceLineItemsRouteConfigs } from '@/server/routers/invoiceLineItemsRouter'
 import { paymentMethodsRouteConfigs } from '@/server/routers/paymentMethodsRouter'
 import { purchasesRouteConfigs } from '@/server/routers/purchasesRouter'
 import { usageEventsRouteConfigs } from '@/server/routers/usageEventsRouter'
@@ -73,6 +74,7 @@ const routeConfigs = [
   ...checkoutSessionsRouteConfigs,
   ...pricesRouteConfigs,
   ...invoicesRouteConfigs,
+  ...invoiceLineItemsRouteConfigs,
   ...paymentMethodsRouteConfigs,
   ...paymentsRouteConfigs,
   ...purchasesRouteConfigs,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Connected the invoice line items router to the API v1 router. This fixes the list invoice line items endpoint so it resolves and returns data correctly.

<!-- End of auto-generated description by cubic. -->

