### PR TITLE
Fix invoice awaiting payment confirmation

### DIFF
--- a/platform/flowglad-next/src/subscriptions/billingRunHelpers.test.ts
+++ b/platform/flowglad-next/src/subscriptions/billingRunHelpers.test.ts
@@ -1136,7 +1136,7 @@ describe('billingRunHelpers', async () => {
         expect(payments[0].stripeChargeId).toBeNull() // No charge ID since payment failed
         expect(payments[0].status).toBe(PaymentStatus.Processing) // Payment created but not yet confirmed
 
-        // Verify invoice is still awaiting payment confirmation (not marked as paid)
+        // Verify invoice is still open (not marked as paid)
         const invoices = await adminTransaction(({ transaction }) =>
           selectInvoices(
             { billingPeriodId: billingPeriod.id },
@@ -1144,9 +1144,7 @@ describe('billingRunHelpers', async () => {
           )
         )
         expect(invoices).toHaveLength(1)
-        expect(invoices[0].status).toBe(
-          InvoiceStatus.AwaitingPaymentConfirmation
-        )
+        expect(invoices[0].status).toBe(InvoiceStatus.Open)
       })
 
       it('should handle payment intent creation success but confirmation API failure', async () => {
@@ -1198,7 +1196,7 @@ describe('billingRunHelpers', async () => {
         expect(payments[0].stripeChargeId).toBeNull() // No charge ID since confirmation failed
         expect(payments[0].status).toBe(PaymentStatus.Processing) // Payment created but confirmation failed
 
-        // Verify invoice is still awaiting payment confirmation (not marked as paid)
+        // Verify invoice is still open (not marked as paid)
         const invoices = await adminTransaction(({ transaction }) =>
           selectInvoices(
             { billingPeriodId: billingPeriod.id },
@@ -1206,9 +1204,7 @@ describe('billingRunHelpers', async () => {
           )
         )
         expect(invoices).toHaveLength(1)
-        expect(invoices[0].status).toBe(
-          InvoiceStatus.AwaitingPaymentConfirmation
-        )
+        expect(invoices[0].status).toBe(InvoiceStatus.Open)
       })
 
       it('should rollback when customer ID validation fails', async () => {
@@ -1355,7 +1351,7 @@ describe('billingRunHelpers', async () => {
         )
         expect(invoice).toBeDefined()
         expect(invoice).toMatchObject({
-          status: InvoiceStatus.AwaitingPaymentConfirmation,
+          status: InvoiceStatus.Open,
           customerId: customer.id,
           organizationId: organization.id,
         })

--- a/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
+++ b/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
@@ -810,7 +810,7 @@ export const executeBillingRun = async (billingRunId: string) => {
             )
             await safelyUpdateInvoiceStatus(
               resultFromSteps.invoice,
-              InvoiceStatus.AwaitingPaymentConfirmation,
+              InvoiceStatus.Open,
               transaction
             )
             await updateBillingRun(


### PR DESCRIPTION
## What Does this PR Do?
Fix to awaiting payment confirmation state for invoices. We should now only be setting the invoice status to awaiting payment confirmation if the payment intent response is "processing" otherwise we can just keep the invoice as open. This fix also applies to stale payment failures as well. 