### PR TITLE
fix: sql optimized aggregateBalanceForLedgerAccountFromEntries query

### DIFF
--- a/platform/flowglad-next/README.md
+++ b/platform/flowglad-next/README.md
@@ -5,7 +5,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 ### Prerequisites
 
 - PostgreSQL database (local or remote)
-- Node.js (v20.0.0) and pnpm
+- Node.js (v22.0.0) and pnpm
 
 ### Setup Steps
 


### PR DESCRIPTION
## What Does this PR Do?
- moves aggregation logic for aggregateBalanceForLedgerAccountFromEntries from server memory to DB to improve DB egress

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aggregates ledger balances in SQL to reduce DB egress and speed up aggregateBalanceForLedgerAccountFromEntries.

- **Refactors**
  - Compute signed sum in the database with SUM(CASE) and return a single balance value.
  - Removed per-entry ordering and in-memory reduction to cut query time and data transfer.

- **Migration**
  - Use Node.js v22.0.0 (update local runtime and CI).

<sup>Written for commit 1d81b9163236f83a36c6c6a501e17b07d80ab34a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

