### PR TITLE
Fixed Organization Switcher and added truncated name so the org switc…

### DIFF
--- a/platform/flowglad-next/src/components/forms/OrganizationFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/OrganizationFormFields.tsx
@@ -39,10 +39,7 @@ const OrganizationFormFields: React.FC = () => {
         name="organization.name"
         render={({ field }) => (
           <FormItem>
-            <FormLabel>
-              Organization Name{' '}
-              <span className="text-destructive">*</span>
-            </FormLabel>
+            <FormLabel>Organization Name</FormLabel>
             <FormControl>
               <Input placeholder="Your Company" {...field} />
             </FormControl>
@@ -56,9 +53,7 @@ const OrganizationFormFields: React.FC = () => {
         name="organization.countryId"
         render={({ field }) => (
           <FormItem>
-            <FormLabel>
-              Country <span className="text-destructive">*</span>
-            </FormLabel>
+            <FormLabel>Country</FormLabel>
             <FormControl>
               <Select
                 value={field.value ?? undefined}

--- a/platform/flowglad-next/src/components/navigation/OrganizationSwitcher.tsx
+++ b/platform/flowglad-next/src/components/navigation/OrganizationSwitcher.tsx
@@ -73,8 +73,8 @@ const OrganizationSwitcher = () => {
           </Button>
         </PopoverTrigger>
         <PopoverContent
-          className="w-64 p-0 pointer-events-auto"
-          align="start"
+          className="w-64 p-0.5 pointer-events-auto"
+          align="end"
           container={sheetContainer}
           onInteractOutside={(e) => {
             // Prevent closing when clicking on Sheet overlay, but allow normal outside clicks
@@ -84,12 +84,8 @@ const OrganizationSwitcher = () => {
             }
           }}
         >
-          <div className="flex flex-col">
+          <div className="flex flex-col rounded-md overflow-hidden">
             <Command>
-              <CommandInput
-                placeholder="Search organizations..."
-                className="border-none focus:border-none focus:ring-0"
-              />
               <CommandList className="max-h-64 overflow-auto">
                 <CommandEmpty>No organizations found.</CommandEmpty>
                 <CommandGroup>
@@ -98,6 +94,7 @@ const OrganizationSwitcher = () => {
                       key={org.id}
                       value={`${org.id} ${org.name}`}
                       keywords={[org.name]}
+                      className="cursor-pointer px-2 py-2 rounded-sm data-[selected=true]:bg-accent"
                       onSelect={async () => {
                         if (org.id !== organization?.id) {
                           await updateFocusedMembership.mutateAsync({
@@ -122,28 +119,31 @@ const OrganizationSwitcher = () => {
                       <Check
                         className={
                           organization?.id === org.id
-                            ? 'ml-auto opacity-100'
-                            : 'ml-auto opacity-0'
+                            ? 'ml-auto opacity-100 h-4 w-4'
+                            : 'ml-auto opacity-0 h-4 w-4'
                         }
                       />
                     </CommandItem>
                   ))}
+                  <CommandItem
+                    value="create-organization"
+                    className="cursor-pointer px-2 py-2 rounded-sm data-[selected=true]:bg-accent"
+                    onSelect={() => {
+                      setIsOrgMenuOpen(false)
+                      setIsCreateOrganizationModalOpen(true)
+                    }}
+                  >
+                    <div className="flex h-4 w-4 items-center justify-center rounded-full border border-dashed border-muted-foreground/40">
+                      <Plus className="h-3 w-3" />
+                    </div>
+                    <span className="truncate">
+                      Create New Organization
+                    </span>
+                    <Check className="ml-auto h-4 w-4 opacity-0" />
+                  </CommandItem>
                 </CommandGroup>
               </CommandList>
             </Command>
-            <div className="border-t flex justify-center">
-              <Button
-                variant="ghost"
-                className="w-max-content"
-                onClick={() => {
-                  setIsOrgMenuOpen(false)
-                  setIsCreateOrganizationModalOpen(true)
-                }}
-              >
-                <Plus className="h-4 w-4 mr-2" />
-                Create New Organization
-              </Button>
-            </div>
           </div>
         </PopoverContent>
       </Popover>

--- a/platform/flowglad-next/src/components/navigation/SideNavigation.tsx
+++ b/platform/flowglad-next/src/components/navigation/SideNavigation.tsx
@@ -236,17 +236,16 @@ export const SideNavigation = () => {
               : 'max-w-lg opacity-100 flex-1'
           )}
         >
-          <div className="flex items-center gap-3 rounded-md">
+          <div className="flex items-center gap-3 rounded-md min-w-0">
             {maybeLogo}
-            <div className="flex justify-center gap-0.5 whitespace-nowrap items-center">
-              <div className="text-sm font-semibold text-foreground truncate">
-                {organization?.name}
+            <div className="flex flex-1 items-center gap-2 min-w-0">
+              <div className="flex flex-col min-w-0">
+                <span className="text-sm font-semibold text-foreground truncate">
+                  {organization?.name}
+                </span>
               </div>
-              <div className="flex items-center gap-2 text-muted-foreground">
+              <div className="flex-shrink-0 text-muted-foreground">
                 <OrganizationSwitcher />
-              </div>
-              <div className="text-xs font-medium text-muted-foreground truncate">
-                {organization?.tagline}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## What Does this PR Do?

Made UI and styling fixes. 
Truncated org name so it shows up correctly
Fixed popover clipping issue
Fixed alignment issue

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overflow and popover issues in the Organization Switcher and side nav. Long org names now truncate so the switch button stays visible.

- **Bug Fixes**
  - Truncated organization name and tightened side nav layout; removed tagline to prevent overflow.
  - Fixed popover clipping/alignment (rounded content, overflow-hidden, align=end) and standardized item styles and icon sizes.
  - Moved “Create New Organization” into the command list and removed the inline search input for a cleaner, more compact menu.
  - Cleaned up form labels by removing the red asterisk styling.

<sup>Written for commit edb0f75769381420e44e3002ef64f050b07aedbf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

