### PR TITLE
Removing the description from the usage line item insert

### DIFF
--- a/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
+++ b/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
@@ -325,9 +325,7 @@ export const billingPeriodItemsAndUsageOveragesToInvoiceLineItemInserts =
         ledgerAccountId: usageOverage!.ledgerAccountId,
         livemode: usageOverage.livemode,
         price: usageOverage.unitPrice,
-        description: `${usageOverage.name ?? ''} ${
-          usageOverage.description && ` - ${usageOverage.description}`
-        }`,
+        description: `${usageOverage.name ?? ''}`,
       }
       return insert
     })


### PR DESCRIPTION
Email notifications for usage events contained raw text that should be excluded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the usage overage description from invoice line item inserts so emails no longer include raw description text. Line items now use only the usage overage name.

<sup>Written for commit 0d4313115121d5a98844272de55a9aa7cf0a97d2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

