### PR TITLE
filter out expired subscriptionItemFeatures

### DIFF
--- a/platform/flowglad-next/src/db/tableMethods/subscriptionItemMethods.ts
+++ b/platform/flowglad-next/src/db/tableMethods/subscriptionItemMethods.ts
@@ -294,7 +294,7 @@ export const selectRichSubscriptionsAndActiveItems = async (
 
   // Step 4: Fetch related data in parallel for better performance
   // Gets features and meter balances in a single Promise.all call
-  const [subscriptionItemFeatures, usageMeterBalances] =
+  const [allSubscriptionItemFeatures, usageMeterBalances] =
     await Promise.all([
       selectSubscriptionItemFeaturesWithFeatureSlug(
         {
@@ -309,6 +309,10 @@ export const selectRichSubscriptionsAndActiveItems = async (
         transaction
       ),
     ])
+  // Filter out expired subscription item features
+  const subscriptionItemFeatures = allSubscriptionItemFeatures.filter(
+    (f) => !f.expiredAt || f.expiredAt > Date.now()
+  )
 
   // Step 5: Group features by subscription ID
   // Creates lookup maps for efficient data access


### PR DESCRIPTION
filter out expired subscriptionItemFeatures in selectRichSubscriptionsAndActiveItems

## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters out expired subscriptionItemFeatures in selectRichSubscriptionsAndActiveItems so consumers only receive active features. Adds test coverage to ensure expired features are excluded.

- **Bug Fixes**
  - Excludes features with expiredAt <= now from experimental.featureItems.
  - Adds unit test verifying only unexpired features are returned.

<sup>Written for commit 1c97dc65ecc085253a9aa2ff25502b2cde7efbfc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

