### PR TITLE
add feature active filter

### DIFF
--- a/platform/flowglad-next/src/db/tableMethods/subscriptionItemFeatureMethods.ts
+++ b/platform/flowglad-next/src/db/tableMethods/subscriptionItemFeatureMethods.ts
@@ -20,7 +20,7 @@ import {
   SubscriptionItem,
   subscriptionItems,
 } from '../schema/subscriptionItems'
-import { eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import { productFeatures } from '../schema/productFeatures'
 import { features } from '../schema/features'
 
@@ -104,7 +104,7 @@ export const selectSubscriptionItemFeaturesWithFeatureSlug = async (
       features,
       eq(subscriptionItemFeatures.featureId, features.id)
     )
-    .where(whereClause)
+    .where(and(whereClause, eq(features.active, true)))
   return result.map((row) => {
     const subscriptionItemFeature =
       subscriptionItemFeaturesSelectSchema.parse(


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure subscription item feature queries only return active features. This prevents inactive features from appearing in results.

- **Bug Fixes**
  - Filtered selectSubscriptionItemFeaturesWithFeatureSlug with features.active = true.
  - Added test that marks a feature inactive and verifies it is not returned.

<sup>Written for commit a56908b8cf2d4c64cb736226e7f9bdae91e07a6b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

