### PR TITLE
always display default active price for each product

### DIFF
--- a/platform/flowglad-next/src/components/PricingCellView.tsx
+++ b/platform/flowglad-next/src/components/PricingCellView.tsx
@@ -11,38 +11,33 @@ const PricingCellView = ({
     return <div>-</div>
   }
 
-  if (prices.length === 1) {
-    const price = prices[0]
-
-    // Helper function to shorten time periods
-    const getShortenedIntervalUnit = (intervalUnit: string) => {
-      switch (intervalUnit) {
-        case 'month':
-          return 'mo'
-        case 'year':
-          return 'yr'
-        default:
-          return intervalUnit
-      }
+  // Helper function to shorten time periods
+  const getShortenedIntervalUnit = (intervalUnit: string) => {
+    switch (intervalUnit) {
+      case 'month':
+        return 'mo'
+      case 'year':
+        return 'yr'
+      default:
+        return intervalUnit
     }
-
-    return (
-      <div className="flex items-center gap-3">
-        <div className="w-fit flex flex-col justify-center text-sm font-normal text-foreground">
-          {stripeCurrencyAmountToHumanReadableCurrencyAmount(
-            price.currency,
-            price.unitPrice
-          )}{' '}
-          {price.type === PriceType.Subscription
-            ? `/ ${getShortenedIntervalUnit(price.intervalUnit)}`
-            : null}
-        </div>
-      </div>
-    )
   }
+
+  // Find the default active price for display, or fall back to the first price
+  const price =
+    prices.find((p) => p.isDefault && p.active) || prices[0]
+
   return (
     <div className="flex items-center gap-3">
-      {prices.length} Prices
+      <div className="w-fit flex flex-col justify-center text-sm font-normal text-foreground">
+        {stripeCurrencyAmountToHumanReadableCurrencyAmount(
+          price.currency,
+          price.unitPrice
+        )}{' '}
+        {price.type === PriceType.Subscription
+          ? `/ ${getShortenedIntervalUnit(price.intervalUnit)}`
+          : null}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show the default active price for each product in the pricing cell, with interval shorthand for subscriptions. Replaces the "X Prices" label and ensures consistent display even with multiple prices.

- **Bug Fixes**
  - Selects the default active price, falling back to the first price.
  - Consolidates rendering and removes single-price special case.

<sup>Written for commit 48cfa82a6af62122ad2130d51e665dce9856aec5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

