### PR TITLE
 multiple subscriptions per customer toggle

### DIFF
--- a/platform/flowglad-next/src/app/settings/OrganizationSettingsTab.tsx
+++ b/platform/flowglad-next/src/app/settings/OrganizationSettingsTab.tsx
@@ -7,10 +7,24 @@ import CopyableTextTableCell from '@/components/CopyableTextTableCell'
 import { PageHeader } from '@/components/ui/page-header'
 import { OrganizationMembersDataTable } from '@/app/settings/teammates/data-table'
 import InviteUserToOrganizationModal from '@/components/forms/InviteUserToOrganizationModal'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
+import { trpc } from '@/app/_trpc/client'
+import { toast } from 'sonner'
 
 const OrganizationSettingsTab = () => {
   const { organization } = useAuthenticatedContext()
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false)
+
+  const updateOrganizationMutation =
+    trpc.organizations.update.useMutation({
+      onSuccess: () => {
+        toast.success('Organization settings updated successfully')
+      },
+      onError: (error) => {
+        toast.error('Failed to update organization settings')
+      },
+    })
 
   if (!organization) {
     return <div>Loading...</div>
@@ -28,6 +42,35 @@ const OrganizationSettingsTab = () => {
             <CopyableTextTableCell copyText={organization.id}>
               {organization.id}
             </CopyableTextTableCell>
+          </div>
+          <div className="flex flex-col gap-0.5">
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="multiple-subscriptions">
+                  Allow Multiple Subscriptions Per Customer
+                </Label>
+                <div className="text-xs text-muted-foreground">
+                  Enable customers to have multiple active
+                  subscriptions simultaneously
+                </div>
+              </div>
+              <Switch
+                id="multiple-subscriptions"
+                checked={
+                  organization.allowMultipleSubscriptionsPerCustomer ??
+                  false
+                }
+                onCheckedChange={(checked) => {
+                  updateOrganizationMutation.mutate({
+                    organization: {
+                      id: organization.id,
+                      allowMultipleSubscriptionsPerCustomer: checked,
+                    },
+                  })
+                }}
+                disabled={updateOrganizationMutation.isPending}
+              />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a toggle in Organization Settings to allow multiple subscriptions per customer, with changes saved via TRPC and success/error toasts. Lets admins control this behavior directly in the UI.

- **New Features**
  - Toggle bound to organization.allowMultipleSubscriptionsPerCustomer.
  - Persists via trpc.organizations.update; disabled while pending; toasts on success/failure.

<sup>Written for commit 10497365487cff8ef0d508e7ba703a702f8b971f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

