### PR TITLE
fix: usage credit grant

### DIFF
--- a/platform/flowglad-next/src/db/adminTransaction.ts
+++ b/platform/flowglad-next/src/db/adminTransaction.ts
@@ -46,8 +46,25 @@ export async function adminTransaction<T>(
 }
 
 /**
- * New comprehensive admin transaction handler.
- * Takes a function that returns TransactionOutput, and handles event logging and ledger commands.
+ * Executes a function within an admin database transaction and automatically processes
+ * events and ledger commands from the transaction output.
+ *
+ * @param fn - Function that receives admin transaction parameters and returns a TransactionOutput
+ *   containing the result, optional events to insert, and optional ledger commands to process
+ * @param options - Transaction options including livemode flag
+ * @returns Promise resolving to the result value from the transaction function
+ *
+ * @example
+ * ```ts
+ * const result = await comprehensiveAdminTransaction(async (params) => {
+ *   // ... perform operations ...
+ *   return {
+ *     result: someValue,
+ *     eventsToInsert: [event1, event2],
+ *     ledgerCommand: { type: 'credit', amount: 100 }
+ *   }
+ * })
+ * ```
  */
 export async function comprehensiveAdminTransaction<T>(
   fn: (

--- a/platform/flowglad-next/src/utils/bookkeeping/processPaymentIntentStatusUpdated.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/processPaymentIntentStatusUpdated.ts
@@ -465,7 +465,7 @@ export const processPaymentIntentStatusUpdated = async (
     )
   }
   const latestChargeId = stripeIdFromObjectOrId(
-    paymentIntent.latest_charge!
+    paymentIntent.latest_charge
   )
   const latestCharge = await getStripeCharge(latestChargeId)
   if (!latestCharge) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes missing usage credit grants after successful Stripe payments by propagating and executing ledger commands within admin transactions. Also hardens Stripe charge handling to avoid null crashes.

- **Bug Fixes**
  - Use comprehensiveAdminTransaction and execute ledgerCommand from processPaymentIntentStatusUpdated in post-payment and Stripe webhook flows.
  - Return and forward ledgerCommand and eventsToInsert through transaction boundaries to ensure credits are applied.
  - Make latest_charge handling null-safe; remove unused imports and improve comprehensiveAdminTransaction docs.

<sup>Written for commit ba5f00e88d31812caeb548482dce8d08a50af9dc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

