### PR TITLE
docs: invoices fixes

### DIFF
--- a/platform/docs/features/invoices.mdx
+++ b/platform/docs/features/invoices.mdx
@@ -16,7 +16,7 @@ Invoices are created in two ways within Flowglad:
 
 Each invoice contains essential details like the issue date, due date, customer information, and potentially billing/shipping addresses.
 
-A key part of the invoice is its **Line Items**. When creating invoices manually (via UI or API):
+A key part of the invoice is its **Line Items**:
 
 *   Line items detail specific goods or services being charged for.
 *   Each line item includes a `description`, `quantity`, and `price` (per unit, specified in the currency's smallest unit, e.g., cents for USD).


### PR DESCRIPTION
## What Does this PR Do?
- Clean up invoices docs



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified and corrected the Invoices docs to match current behavior and reduce confusion. Invoices are created only via subscription renewals and one-time purchases; removed manual creation and payment flows, outdated API actions, and tightened “Invoices vs. Payments” wording.

<sup>Written for commit 1e470167917880cb5d95d1bff25fa61fcc436d4e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



