### PR TITLE
fix: use ctx.apiKey in createDiscount procedure

### DIFF
--- a/platform/flowglad-next/src/server/routers/discountsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/discountsRouter.ts
@@ -62,6 +62,9 @@ export const createDiscount = protectedProcedure
           },
           transaction
         )
+      },
+      {
+        apiKey: ctx.apiKey,
       }
     )
     return { discount }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix missing apiKey in createDiscount by passing ctx.apiKey to the service call so requests are authenticated and scoped to the correct tenant.

<sup>Written for commit fcce8b8204d8b221176b0a6485a77074a53dda57. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

