### PR TITLE
docs data model fixes

### DIFF
--- a/platform/docs/data-model.mdx
+++ b/platform/docs/data-model.mdx
@@ -112,7 +112,8 @@ Subscriptions describe persistent billing relationships between your customers a
 
 Subscriptions can either `renew` or not. Subscriptions created from a `subscription` price type will renew. Renewing subscriptions have billing periods, and can optionally have a trial period at the start of the subscription. When a renewing subscription transitions to the next billing period, by default it will charge:
 - the amount due according to the renewing price(s) associated with the subscription for the forthcoming billing period
-- if you have usage based billing: the amount due for all unsettled usage balances accrued during the previous billing period - based on the usage prices associated with each usage event. Your customers will be charged automatically for overages incurred during the previous billing period. For unused usage credits, there is no automatic refund. They will automatically expire at the end of the billing period they were allocated. 
+- if you have usage based billing: the amount due for all unsettled usage balances accrued during the previous billing period - based on the usage price associated with each usage event. Your customers will be charged automatically for overages incurred during the previous billing period. For unused usage credits, there is no automatic refund. They will automatically expire at the end of the billing period they were allocated. 
+
 
 ## Invariants
 


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the data model docs for usage-based billing. Adds examples for sum and distinct aggregation, explains that credits increase and events deduct from usage balance, details billing-period settlement with automatic overage charges, and confirms unused credits expire with no refunds or rollovers.

<sup>Written for commit 06b5fa68cef8c855057ff511d79470e9adda0e7b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





