### PR TITLE
docs pricing model page fixes & nav bar ordering

### DIFF
--- a/platform/docs/docs.json
+++ b/platform/docs/docs.json
@@ -37,10 +37,10 @@
           {
             "group": "Features",
             "pages": [
+              "features/pricing-models",
               "features/products",
               "features/prices",
               "features/discounts",
-              "features/pricing-models",
               "features/subscriptions",
               "features/checkout-sessions",
               "features/invoices",

--- a/platform/docs/features/pricing-models.mdx
+++ b/platform/docs/features/pricing-models.mdx
@@ -46,10 +46,12 @@ You can create and manage your pricing models through the Flowglad dashboard (un
 
 ### Creating Pricing Models
 
-You have two options when creating a new pricing model:
+You have four options when creating a new pricing model:
 
 1.  **From Scratch:** Start with an empty pricing model and add products and prices as needed.
 2.  **Duplicate an Existing Pricing Model:** Create an exact copy of an existing pricing model, including all its products and prices. This is highly useful for creating variations or bespoke versions (like the enterprise example) without rebuilding everything. The duplicated pricing model is entirely independent, so modifications won't impact the original.
+3.  **Import from pricing.yaml:** Import a pricing model yaml file in the dashboard to instantly recreate a pricing model setup for your organization.
+4.  **Create from Template:** Browse popular pricing models in the dashboard and instantly create a pricing model from a template.
 
 ### Default Pricing Models
 


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Pricing Models docs to list four creation options, adding “Import from pricing.yaml” and “Create from Template.” Reordered the docs sidebar so Pricing Models appears before Products for clearer navigation.

<sup>Written for commit 9f81578c130e4d7cdf3e496c5fa97046f6811202. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

