### PR TITLE
docs subscriptions page fixes

### DIFF
--- a/platform/docs/features/subscriptions.mdx
+++ b/platform/docs/features/subscriptions.mdx
@@ -22,6 +22,17 @@ Each `Subscription` record has one or more `SubscriptionItem` records.
 *   **`Subscription` Record:** Holds the core details like the customer (`customerId`), overall status, billing cycle information (`interval`, `intervalCount`, `billingCycleAnchorDate`), trial period (`trialEnd`), and potentially default/backup payment methods. It also has a primary `priceId` which often corresponds to the initial item purchased. But note: the `SubscriptionItem`s define the actual billing components.
 *   **`SubscriptionItem` Record:** Represents a specific product or service line item within the subscription. Each item has its own `priceId`, `quantity`, and `unitPrice`. This allows for subscriptions with multiple components, potentially added or changed over time. The sum of active subscription items determines the amount billed each period (for non-usage-based items).
 
+### Current vs Non-Current Subscriptions
+Depending on its status, a subscription can either be **current** or not. A current subscription will grant feature access and usage credits. A non-current subscription will not.
+Current subscriptions have one of the following statuses:
+- `"active"`
+- `"past_due"`
+- `"trialing"`
+- `"cancellation_scheduled"`
+- `"unpaid"`
+
+Subscriptions in all other statuses will be inactive.
+
 ## Creating a Subscription
 
 There are two primary ways to create a subscription:


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Subscriptions docs for clarity and accuracy. Clarifies default plan behavior and “current” states, updates checkout language, links to create/cancel APIs, adds hosted billing portal details (livemode, billingPortalUrl), moves multi-subscription guidance to dashboard settings, and removes embedded billing page and info note.

<sup>Written for commit 3a63aa2a195e4e39ee6f043d8168f9b4704bea52. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









