### PR TITLE
fix: move FlowgladProvider into client component to properly load state

### DIFF
--- a/examples/generation-based-subscription/src/app/layout.tsx
+++ b/examples/generation-based-subscription/src/app/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
-import { ReactQueryProvider } from '@/components/providers';
+import {
+  ReactQueryProvider,
+  FlowgladProviderWrapper,
+} from '@/components/providers';
 import { Navbar } from '@/components/navbar';
-import { FlowgladProvider } from '@flowglad/nextjs';
 import { PropsWithChildren } from 'react';
-import { auth } from '@/lib/auth';
-import { headers } from 'next/headers';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -24,18 +24,16 @@ export const metadata: Metadata = {
 };
 
 export default async function RootLayout({ children }: PropsWithChildren) {
-  const session = await auth.api.getSession({ headers: await headers() });
-  const user = session?.user;
   return (
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <ReactQueryProvider>
-          <FlowgladProvider loadBilling={!!user}>
+          <FlowgladProviderWrapper>
             <Navbar />
             {children}
-          </FlowgladProvider>
+          </FlowgladProviderWrapper>
         </ReactQueryProvider>
       </body>
     </html>

--- a/examples/generation-based-subscription/src/components/providers.tsx
+++ b/examples/generation-based-subscription/src/components/providers.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { FlowgladProvider } from '@flowglad/nextjs';
+import { authClient } from '@/lib/auth-client';
 
 const createQueryClient = () =>
   new QueryClient({
@@ -30,5 +32,20 @@ export function ReactQueryProvider(props: { children: React.ReactNode }) {
     <QueryClientProvider client={queryClient}>
       {props.children}
     </QueryClientProvider>
+  );
+}
+
+export function FlowgladProviderWrapper(props: { children: React.ReactNode }) {
+  // Use BetterAuth's useSession to watch for session changes reactively
+  const { data: session } = authClient.useSession();
+
+  // Derive loadBilling from session state reactively
+  // This ensures billing loads when session becomes available, even if layout didn't re-render
+  const loadBilling = !!session?.user;
+
+  return (
+    <FlowgladProvider loadBilling={loadBilling}>
+      {props.children}
+    </FlowgladProvider>
   );
 }

--- a/examples/usage-limit-subscription/src/app/layout.tsx
+++ b/examples/usage-limit-subscription/src/app/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
-import { ReactQueryProvider } from '@/components/providers';
+import {
+  ReactQueryProvider,
+  FlowgladProviderWrapper,
+} from '@/components/providers';
 import { Navbar } from '@/components/navbar';
-import { FlowgladProvider } from '@flowglad/nextjs';
 import { PropsWithChildren } from 'react';
-import { auth } from '@/lib/auth';
-import { headers } from 'next/headers';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -24,18 +24,16 @@ export const metadata: Metadata = {
 };
 
 export default async function RootLayout({ children }: PropsWithChildren) {
-  const session = await auth.api.getSession({ headers: await headers() });
-  const user = session?.user;
   return (
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <ReactQueryProvider>
-          <FlowgladProvider loadBilling={!!user}>
+          <FlowgladProviderWrapper>
             <Navbar />
             {children}
-          </FlowgladProvider>
+          </FlowgladProviderWrapper>
         </ReactQueryProvider>
       </body>
     </html>

--- a/examples/usage-limit-subscription/src/components/providers.tsx
+++ b/examples/usage-limit-subscription/src/components/providers.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { FlowgladProvider } from '@flowglad/nextjs';
+import { authClient } from '@/lib/auth-client';
 
 const createQueryClient = () =>
   new QueryClient({
@@ -30,5 +32,20 @@ export function ReactQueryProvider(props: { children: React.ReactNode }) {
     <QueryClientProvider client={queryClient}>
       {props.children}
     </QueryClientProvider>
+  );
+}
+
+export function FlowgladProviderWrapper(props: { children: React.ReactNode }) {
+  // Use BetterAuth's useSession to watch for session changes reactively
+  const { data: session } = authClient.useSession();
+
+  // Derive loadBilling from session state reactively
+  // This ensures billing loads when session becomes available, even if layout didn't re-render
+  const loadBilling = !!session?.user;
+
+  return (
+    <FlowgladProvider loadBilling={loadBilling}>
+      {props.children}
+    </FlowgladProvider>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved FlowgladProvider into a client wrapper that reacts to BetterAuth session changes, so billing loads correctly after sign-up in both example apps.

- **Bug Fixes**
  - Added FlowgladProviderWrapper that uses authClient.useSession to derive loadBilling reactively.
  - Updated app/layout.tsx to use the wrapper and removed server-side session fetching.
  - Ensures billing initializes as soon as the session becomes available (supports the “load billing on sign-up” work).

<sup>Written for commit 80e41983f89d5b1a19cd5c21ec1f999382e4f323. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

