### PR TITLE
show different date depending on trialing status

### DIFF
--- a/platform/flowglad-next/src/email-templates/customer-subscription-upgraded.tsx
+++ b/platform/flowglad-next/src/email-templates/customer-subscription-upgraded.tsx
@@ -29,6 +29,7 @@ export const CustomerSubscriptionUpgradedEmail = ({
   interval,
   nextBillingDate,
   paymentMethodLast4,
+  trialing = false,
 }: {
   customerName: string
   organizationName: string
@@ -45,6 +46,7 @@ export const CustomerSubscriptionUpgradedEmail = ({
   interval?: IntervalUnit
   nextBillingDate?: Date
   paymentMethodLast4?: string
+  trialing?: boolean
 }) => {
   const formattedPrice =
     stripeCurrencyAmountToHumanReadableCurrencyAmount(currency, price)
@@ -104,7 +106,8 @@ export const CustomerSubscriptionUpgradedEmail = ({
         </DetailItem>
         {nextBillingDate && (
           <DetailItem dataTestId="first-charge-date">
-            First charge: {formatDate(nextBillingDate)}
+            {trialing ? 'First charge' : 'Next charge'}:{' '}
+            {formatDate(nextBillingDate)}
           </DetailItem>
         )}
         {paymentMethodLast4 && (
@@ -116,7 +119,8 @@ export const CustomerSubscriptionUpgradedEmail = ({
 
       {nextBillingDate && (
         <Paragraph style={{ marginTop: '24px' }}>
-          Your first charge of {formattedPrice} will be processed on{' '}
+          Your {trialing ? 'first charge' : 'next charge'} of{' '}
+          {formattedPrice} will be processed on{' '}
           {formatDate(nextBillingDate)}.
           {paymentMethodLast4 &&
             ` The payment method ending in ${paymentMethodLast4} will be used.`}

--- a/platform/flowglad-next/src/trigger/notifications/send-customer-subscription-created-notification.ts
+++ b/platform/flowglad-next/src/trigger/notifications/send-customer-subscription-created-notification.ts
@@ -13,6 +13,7 @@ import {
   testSafeTriggerInvoker,
 } from '@/utils/backendCore'
 import { kebabCase } from 'change-case'
+import { SubscriptionStatus } from '@/types'
 
 const sendCustomerSubscriptionCreatedNotificationTask = task({
   id: 'send-customer-subscription-created-notification',
@@ -88,28 +89,31 @@ const sendCustomerSubscriptionCreatedNotificationTask = task({
     if (price.intervalUnit) {
       nextBillingDate = new Date(subscription.createdAt!)
       const intervalCount = price.intervalCount || 1
-
-      switch (price.intervalUnit) {
-        case 'day':
-          nextBillingDate.setDate(
-            nextBillingDate.getDate() + intervalCount
-          )
-          break
-        case 'week':
-          nextBillingDate.setDate(
-            nextBillingDate.getDate() + intervalCount * 7
-          )
-          break
-        case 'month':
-          nextBillingDate.setMonth(
-            nextBillingDate.getMonth() + intervalCount
-          )
-          break
-        case 'year':
-          nextBillingDate.setFullYear(
-            nextBillingDate.getFullYear() + intervalCount
-          )
-          break
+      if (subscription.status === SubscriptionStatus.Trialing) {
+        nextBillingDate = new Date(subscription.trialEnd!)
+      } else {
+        switch (price.intervalUnit) {
+          case 'day':
+            nextBillingDate.setDate(
+              nextBillingDate.getDate() + intervalCount
+            )
+            break
+          case 'week':
+            nextBillingDate.setDate(
+              nextBillingDate.getDate() + intervalCount * 7
+            )
+            break
+          case 'month':
+            nextBillingDate.setMonth(
+              nextBillingDate.getMonth() + intervalCount
+            )
+            break
+          case 'year':
+            nextBillingDate.setFullYear(
+              nextBillingDate.getFullYear() + intervalCount
+            )
+            break
+        }
       }
     }
     const notifUatEmail = core.envVariable('NOTIF_UAT_EMAIL')


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the correct charge date in subscription emails based on trial status. Trialing users see “First charge” on the trial end date; non-trialing users see “Next charge” based on the plan interval.

- **Bug Fixes**
  - Email template: added a trialing flag and switched wording between “First charge” and “Next charge” in both the details and body.
  - Notifications: compute nextBillingDate from trialEnd when status is Trialing; otherwise from interval; pass trialing to the email.
  - Tests: added coverage for trialing and non-trialing scenarios.

<sup>Written for commit 97f0fca537b2509bf460b4b9bc11220bdcc262ae. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

