### PR TITLE
fix: toggle webhook active state in svix

### DIFF
--- a/platform/flowglad-next/src/db/schema/webhooks.ts
+++ b/platform/flowglad-next/src/db/schema/webhooks.ts
@@ -6,12 +6,9 @@ import {
   notNullStringForeignKey,
   constructIndex,
   livemodePolicy,
-  ommittedColumnsForInsertSchema,
   merchantPolicy,
-  hiddenColumnsForClientSchema,
 } from '@/db/tableUtils'
 import { organizations } from '@/db/schema/organizations'
-import { createSelectSchema, createInsertSchema } from 'drizzle-zod'
 import { FlowgladEventType } from '@/types'
 import { buildSchemas } from '../createZodSchemas'
 

--- a/platform/flowglad-next/src/utils/svix.ts
+++ b/platform/flowglad-next/src/utils/svix.ts
@@ -135,12 +135,14 @@ export async function updateSvixEndpoint(params: {
     webhook,
     livemode: webhook.livemode,
   })
+
   const endpoint = await svix().endpoint.patch(
     application.id,
     endpointId,
     {
       url: webhook.url,
       filterTypes: webhook.filterTypes,
+      disabled: !webhook.active,
     }
   )
   return endpoint


### PR DESCRIPTION
## What Does this PR Do?
- ensures that webhook active state is changed when deactivated

To test:
- create a new webhook in /settings > API
- Edit it to set it inactive
- Go to Svix and search the organization id in the search bar (make sure you're in dev env). Select the organization you're testing from
<img width="774" height="402" alt="CleanShot 2025-11-14 at 18 07 12@2x" src="https://github.com/user-attachments/assets/c8659f8a-695a-4fe1-8901-931dac94c7c9" />
- Go to "Preview App Portal"
- The webhook you deactivated should show as disabled:
<img width="3458" height="532" alt="CleanShot 2025-11-14 at 18 08 13@2x" src="https://github.com/user-attachments/assets/c7e159ea-5567-4b58-b375-2dd03b115aff" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes webhook activation toggling in Svix so the endpoint disabled state matches our webhook’s active flag. Deactivating a webhook now disables the Svix endpoint; reactivating enables it.

- **Bug Fixes**
  - Set disabled: !webhook.active in updateSvixEndpoint when patching Svix endpoints.

- **Refactors**
  - Removed unused schema imports in webhooks.ts.

<sup>Written for commit 7ea3e45c4e7919f8c67358d27d043a21666ec667. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

