### PR TITLE
fix: extend usageCreditGrantSubscriptionItemFeatureClient...Schema…

### DIFF
--- a/platform/flowglad-next/bun.lock
+++ b/platform/flowglad-next/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "flowglad-next",
@@ -198,10 +199,10 @@
     },
   },
   "overrides": {
-    "esbuild": "0.25.0",
-    "chromium-bidi": "2.1.2",
-    "zod": "4.1.5",
     "@react-email/render": "0.0.17",
+    "chromium-bidi": "2.1.2",
+    "esbuild": "0.25.0",
+    "zod": "4.1.5",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],

--- a/platform/flowglad-next/seedDatabase.ts
+++ b/platform/flowglad-next/seedDatabase.ts
@@ -884,7 +884,7 @@ const setupPriceInputSchema = z.discriminatedUnion('type', [
 
 /**
  * This schema is used to validate the input for the setupPrice function.
- * 
+ *
  * prices.ts currently has a schema called pricesInsertSchema, which is similar to this but more permissive.
  * We should consider making that schema more strict and using it here instead of creating this one.
  */
@@ -910,10 +910,20 @@ export const setupPrice = async (
     slug,
   } = validatedInput
 
-  const intervalUnit = type !== PriceType.SinglePayment ? validatedInput.intervalUnit : undefined
-  const intervalCount = type !== PriceType.SinglePayment ? validatedInput.intervalCount : undefined
-  const trialPeriodDays = type === PriceType.Subscription ? validatedInput.trialPeriodDays : undefined
-  const usageMeterId = type === PriceType.Usage ? validatedInput.usageMeterId : undefined
+  const intervalUnit =
+    type !== PriceType.SinglePayment
+      ? validatedInput.intervalUnit
+      : undefined
+  const intervalCount =
+    type !== PriceType.SinglePayment
+      ? validatedInput.intervalCount
+      : undefined
+  const trialPeriodDays =
+    type === PriceType.Subscription
+      ? validatedInput.trialPeriodDays
+      : undefined
+  const usageMeterId =
+    type === PriceType.Usage ? validatedInput.usageMeterId : undefined
 
   return adminTransaction(async ({ transaction }) => {
     const basePrice = {
@@ -2412,9 +2422,9 @@ export const setupSubscriptionItemFeatureUsageCreditGrant = async (
     featureId: string
     productFeatureId: string
   }
-): Promise<SubscriptionItemFeature.UsageCreditGrantClientRecord> => {
+): Promise<SubscriptionItemFeature.UsageCreditGrantRecord> => {
   return adminTransaction(async ({ transaction }) => {
-    return insertSubscriptionItemFeature(
+    const result = await insertSubscriptionItemFeature(
       {
         livemode: true,
         type: FeatureType.UsageCreditGrant,
@@ -2424,7 +2434,11 @@ export const setupSubscriptionItemFeatureUsageCreditGrant = async (
         ...params,
       },
       transaction
-    ) as Promise<SubscriptionItemFeature.UsageCreditGrantClientRecord>
+    )
+    if (result.type !== FeatureType.UsageCreditGrant) {
+      throw new Error('Expected UsageCreditGrant feature')
+    }
+    return result
   })
 }
 
@@ -2478,7 +2492,8 @@ export const setupUsageLedgerScenario = async (params: {
     pricingModelId: pricingModel.id,
   })
   // Build price params for Usage type, excluding incompatible fields from priceArgs
-  const { trialPeriodDays: _, ...compatiblePriceArgs } = params.priceArgs ?? {}
+  const { trialPeriodDays: _, ...compatiblePriceArgs } =
+    params.priceArgs ?? {}
   const price = await setupPrice({
     productId: product.id,
     name: 'Test Price',

--- a/platform/flowglad-next/src/app/finance/subscriptions/[id]/SubscriptionFeaturesTable.tsx
+++ b/platform/flowglad-next/src/app/finance/subscriptions/[id]/SubscriptionFeaturesTable.tsx
@@ -61,10 +61,8 @@ export const SubscriptionFeaturesTable = ({
         <TableBody>
           {featureItems.length ? (
             featureItems.map((feature) => {
-              const featureName =
-                'name' in feature ? feature.name : '—'
-              const featureSlug =
-                'slug' in feature ? feature.slug : feature.featureId
+              const featureName = feature.name
+              const featureSlug = feature.slug
 
               return (
                 <TableRow key={feature.id}>

--- a/platform/flowglad-next/src/db/ledgerManager/billingPeriodTransitionLedgerCommand/grantEntitlementUsageCredits.test.ts
+++ b/platform/flowglad-next/src/db/ledgerManager/billingPeriodTransitionLedgerCommand/grantEntitlementUsageCredits.test.ts
@@ -100,7 +100,7 @@ describe('grantEntitlementUsageCredits', () => {
   let baseSubscriptionItem: SubscriptionItem.Record
   let baseFeature: Feature.Record
   let baseProductFeature: ProductFeature.Record
-  let baseSubscriptionItemFeature: SubscriptionItemFeature.UsageCreditGrantClientRecord
+  let baseSubscriptionItemFeature: SubscriptionItemFeature.UsageCreditGrantRecord
   let command: BillingPeriodTransitionLedgerCommand
   let commandPayload: BillingPeriodTransitionLedgerCommand['payload']
 
@@ -512,8 +512,7 @@ describe('grantEntitlementUsageCredits', () => {
       name: 'Test SIF Without Meter',
       // The nested productFeature and feature can be from baseSubscriptionItemFeature
       // as the function under test should primarily operate on top-level SIF properties.
-    } as SubscriptionItemFeature.UsageCreditGrantClientRecord // Still cast to the expected type
-
+    } as SubscriptionItemFeature.UsageCreditGrantRecord // Still cast to the expected type
     command.payload.subscriptionFeatureItems = [
       itemWithMeter,
       itemWithoutMeter,
@@ -593,7 +592,7 @@ describe('grantEntitlementUsageCredits', () => {
       featureId: 'feature_id_for_only_no_meter_sif',
       productFeatureId: 'product_feature_id_for_only_no_meter_sif',
       name: 'Test SIF Only Without Meter',
-    } as SubscriptionItemFeature.UsageCreditGrantClientRecord
+    } as SubscriptionItemFeature.UsageCreditGrantRecord
 
     command.payload.subscriptionFeatureItems = [itemWithoutMeterOnly]
 

--- a/platform/flowglad-next/src/db/ledgerManager/billingPeriodTransitionLedgerCommand/index.test.ts
+++ b/platform/flowglad-next/src/db/ledgerManager/billingPeriodTransitionLedgerCommand/index.test.ts
@@ -92,7 +92,7 @@ describe('processBillingPeriodTransitionLedgerCommand', () => {
   let billingRun: BillingRun.Record
   let feature: Feature.Record
   let productFeature: ProductFeature.Record
-  let subscriptionFeatureItem: SubscriptionItemFeature.UsageCreditGrantClientRecord
+  let subscriptionFeatureItem: SubscriptionItemFeature.UsageCreditGrantRecord
   let command: BillingPeriodTransitionLedgerCommand
 
   beforeEach(async () => {
@@ -729,8 +729,8 @@ describe('processBillingPeriodTransitionLedgerCommand', () => {
     let recurringFeature: Feature.Record
     let productFeatureOnce: ProductFeature.Record
     let productFeatureRecurring: ProductFeature.Record
-    let subscriptionItemFeatureOnce: SubscriptionItemFeature.UsageCreditGrantClientRecord
-    let subscriptionItemFeatureRecurring: SubscriptionItemFeature.UsageCreditGrantClientRecord
+    let subscriptionItemFeatureOnce: SubscriptionItemFeature.UsageCreditGrantRecord
+    let subscriptionItemFeatureRecurring: SubscriptionItemFeature.UsageCreditGrantRecord
     let nonRenewingCommand: BillingPeriodTransitionLedgerCommand
     let nonRenewingSubscriptionItem: SubscriptionItem.Record
     let ledgerAccountNonRenewing1: LedgerAccount.Record

--- a/platform/flowglad-next/src/db/ledgerManager/ledgerManagerTypes.ts
+++ b/platform/flowglad-next/src/db/ledgerManager/ledgerManagerTypes.ts
@@ -7,7 +7,7 @@ import { usageCreditsSelectSchema } from '@/db/schema/usageCredits'
 import { usageCreditBalanceAdjustmentsSelectSchema } from '@/db/schema/usageCreditBalanceAdjustments'
 import { refundsSelectSchema } from '@/db/schema/refunds'
 import { subscriptionMeterPeriodCalculationSelectSchema } from '@/db/schema/subscriptionMeterPeriodCalculations'
-import { usageCreditGrantSubscriptionItemFeatureClientSelectSchema } from '@/db/schema/subscriptionItemFeatures'
+import { usageCreditGrantSubscriptionItemFeatureSelectSchema } from '@/db/schema/subscriptionItemFeatures'
 import { subscriptionsSelectSchema } from '@/db/schema/subscriptions'
 import { billingPeriodsSelectSchema } from '@/db/schema/billingPeriods'
 import { LedgerEntry } from '@/db/schema/ledgerEntries'
@@ -77,7 +77,7 @@ const standardBillingPeriodTransitionPayloadSchema = z.object({
     ),
   newBillingPeriod: billingPeriodsSelectSchema,
   subscriptionFeatureItems:
-    usageCreditGrantSubscriptionItemFeatureClientSelectSchema
+    usageCreditGrantSubscriptionItemFeatureSelectSchema
       .array()
       .describe(
         'The subscription feature items that were active during this billing run for the given subscription.'

--- a/platform/flowglad-next/src/db/schema/subscriptionItemFeatures.ts
+++ b/platform/flowglad-next/src/db/schema/subscriptionItemFeatures.ts
@@ -187,8 +187,10 @@ export const {
   select: usageCreditGrantSubscriptionItemFeatureSelectSchema,
   update: usageCreditGrantSubscriptionItemFeatureUpdateSchema,
   client: {
-    insert: usageCreditGrantSubscriptionItemFeatureClientInsertSchema,
-    select: usageCreditGrantSubscriptionItemFeatureClientSelectSchema,
+    insert:
+      baseUsageCreditGrantSubscriptionItemFeatureClientInsertSchema,
+    select:
+      baseUsageCreditGrantSubscriptionItemFeatureClientSelectSchema,
     update: usageCreditGrantSubscriptionItemFeatureClientUpdateSchema,
   },
 } = buildSchemas(subscriptionItemFeatures, {
@@ -246,6 +248,16 @@ export const toggleSubscriptionItemFeatureClientInsertSchema =
   baseToggleSubscriptionItemFeatureClientInsertSchema
     .extend(clientSelectWithFeatureFieldRefinements)
     .meta({ id: 'ToggleSubscriptionItemFeatureInsert' })
+
+export const usageCreditGrantSubscriptionItemFeatureClientSelectSchema =
+  baseUsageCreditGrantSubscriptionItemFeatureClientSelectSchema
+    .extend(clientSelectWithFeatureFieldRefinements)
+    .meta({ id: 'UsageCreditGrantSubscriptionItemFeatureRecord' })
+
+export const usageCreditGrantSubscriptionItemFeatureClientInsertSchema =
+  baseUsageCreditGrantSubscriptionItemFeatureClientInsertSchema
+    .extend(clientSelectWithFeatureFieldRefinements)
+    .meta({ id: 'UsageCreditGrantSubscriptionItemFeatureInsert' })
 
 /*
  * Combined client-facing discriminated union schemas


### PR DESCRIPTION
Fixed an issue where usage credit grant type features don't display properly in new table on subscription detail page due to them not being properly extended with clientSelectWithFeatureFieldRefinements (matched pattern we use for toggle subscriptionItemFeatureClient...Schemas)

This caused lint errors in a number of places where we are using usageCreditGrantSubscriptionItemFeatureClient...Schema since now they include name and slug, i opted to use the non client schemas since they are all backend usages.

before:

<img width="1468" height="260" alt="Screenshot 2025-11-15 at 11 45 04 AM" src="https://github.com/user-attachments/assets/0dae51b8-8972-4fa5-ab1e-d8a5ab6bbd41" />

after:

<img width="1493" height="276" alt="Screenshot 2025-11-15 at 11 46 11 AM" src="https://github.com/user-attachments/assets/b3e88b8f-d0e1-4ac8-bd18-56ccb969a8c7" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed display of Usage Credit Grant features on the subscription detail page by extending the client schemas to include name and slug. The table now shows correct labels, and backend code uses server schemas to avoid lint/type issues.

- **Bug Fixes**
  - Extended usageCreditGrant client select/insert schemas with clientSelectWithFeatureFieldRefinements.
  - Updated SubscriptionFeaturesTable to render feature.name and feature.slug directly.

- **Refactors**
  - Switched types from UsageCreditGrantClientRecord to UsageCreditGrantRecord in tests and ledger manager payload.
  - Updated setupSubscriptionItemFeatureUsageCreditGrant to return server record and added a type guard.

<sup>Written for commit fa82c6720bc0049c77551f7bc818601a5102a2d5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

