### PR TITLE
refresh router after org switch to update api key shown

### DIFF
--- a/platform/flowglad-next/src/components/navigation/OrganizationSwitcher.tsx
+++ b/platform/flowglad-next/src/components/navigation/OrganizationSwitcher.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from 'react'
 import Image from 'next/image'
+import { useRouter } from 'next/navigation'
 import { trpc } from '@/app/_trpc/client'
 import { useAuthContext } from '@/contexts/authContext'
 import { useIsMobile } from '@/hooks/use-mobile'
@@ -23,6 +24,7 @@ import { Check, ChevronsUpDown, Loader2, Plus } from 'lucide-react'
 import CreateOrganizationModal from '@/components/forms/CreateOrganizationModal'
 
 const OrganizationSwitcher = () => {
+  const router = useRouter()
   const { organization } = useAuthContext()
   const [isOrgMenuOpen, setIsOrgMenuOpen] = useState(false)
   const [
@@ -49,6 +51,7 @@ const OrganizationSwitcher = () => {
       onSuccess: async () => {
         await invalidateTRPC()
         await focusedMembership.refetch()
+        router.refresh()
       },
     })
 


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the router after switching organizations so the onboarding API key updates immediately.
Adds useRouter and calls router.refresh() on org switch success, after TRPC invalidation and membership refetch.

<sup>Written for commit 84752ba622c82a7ab5172987f78428705641ff4f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

