### PR TITLE
createUsageMeterTransaction with default price fields, tests

### DIFF
--- a/platform/flowglad-next/seedDatabase.ts
+++ b/platform/flowglad-next/seedDatabase.ts
@@ -267,6 +267,7 @@ export const setupProduct = async ({
   pricingModelId,
   active = true,
   default: isDefault = false,
+  slug,
 }: {
   organizationId: string
   name: string
@@ -274,6 +275,7 @@ export const setupProduct = async ({
   pricingModelId: string
   active?: boolean
   default?: boolean
+  slug?: string
 }) => {
   return adminTransaction(async ({ transaction }) => {
     return await insertProduct(
@@ -289,7 +291,7 @@ export const setupProduct = async ({
         pricingModelId,
         externalId: null,
         default: isDefault,
-        slug: `flowglad-test-product-price+${core.nanoid()}`,
+        slug: slug ?? `flowglad-test-product-price+${core.nanoid()}`,
       },
       transaction
     )
@@ -884,7 +886,7 @@ const setupPriceInputSchema = z.discriminatedUnion('type', [
 
 /**
  * This schema is used to validate the input for the setupPrice function.
- * 
+ *
  * prices.ts currently has a schema called pricesInsertSchema, which is similar to this but more permissive.
  * We should consider making that schema more strict and using it here instead of creating this one.
  */
@@ -910,10 +912,20 @@ export const setupPrice = async (
     slug,
   } = validatedInput
 
-  const intervalUnit = type !== PriceType.SinglePayment ? validatedInput.intervalUnit : undefined
-  const intervalCount = type !== PriceType.SinglePayment ? validatedInput.intervalCount : undefined
-  const trialPeriodDays = type === PriceType.Subscription ? validatedInput.trialPeriodDays : undefined
-  const usageMeterId = type === PriceType.Usage ? validatedInput.usageMeterId : undefined
+  const intervalUnit =
+    type !== PriceType.SinglePayment
+      ? validatedInput.intervalUnit
+      : undefined
+  const intervalCount =
+    type !== PriceType.SinglePayment
+      ? validatedInput.intervalCount
+      : undefined
+  const trialPeriodDays =
+    type === PriceType.Subscription
+      ? validatedInput.trialPeriodDays
+      : undefined
+  const usageMeterId =
+    type === PriceType.Usage ? validatedInput.usageMeterId : undefined
 
   return adminTransaction(async ({ transaction }) => {
     const basePrice = {
@@ -2478,7 +2490,8 @@ export const setupUsageLedgerScenario = async (params: {
     pricingModelId: pricingModel.id,
   })
   // Build price params for Usage type, excluding incompatible fields from priceArgs
-  const { trialPeriodDays: _, ...compatiblePriceArgs } = params.priceArgs ?? {}
+  const { trialPeriodDays: _, ...compatiblePriceArgs } =
+    params.priceArgs ?? {}
   const price = await setupPrice({
     productId: product.id,
     name: 'Test Price',

--- a/platform/flowglad-next/src/utils/usage.test.ts
+++ b/platform/flowglad-next/src/utils/usage.test.ts
@@ -1,0 +1,425 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { adminTransaction } from '@/db/adminTransaction'
+import {
+  setupOrg,
+  setupProduct,
+  setupPrice,
+  setupUserAndApiKey,
+} from '@/../seedDatabase'
+import { createUsageMeterTransaction } from './usage'
+import { Organization } from '@/db/schema/organizations'
+import { PricingModel } from '@/db/schema/pricingModels'
+import { Product } from '@/db/schema/products'
+import { Price } from '@/db/schema/prices'
+import {
+  PriceType,
+  IntervalUnit,
+  CurrencyCode,
+  UsageMeterAggregationType,
+} from '@/types'
+import { selectUsageMeters } from '@/db/tableMethods/usageMeterMethods'
+import { selectProducts } from '@/db/tableMethods/productMethods'
+import { selectPrices } from '@/db/tableMethods/priceMethods'
+import { UsageMeter } from '@/db/schema/usageMeters'
+
+describe('createUsageMeterTransaction', () => {
+  let organization: Organization.Record
+  let pricingModel: PricingModel.Record
+  let userId: string
+
+  beforeEach(async () => {
+    const orgSetup = await setupOrg()
+    organization = orgSetup.organization
+    pricingModel = orgSetup.pricingModel
+
+    // Create a user for the organization
+    const userSetup = await setupUserAndApiKey({
+      organizationId: organization.id,
+      livemode: false,
+    })
+    userId = userSetup.user.id
+  })
+
+  describe('Successful creation', () => {
+    it('should create usage meter, product, and price with matching slugs', async () => {
+      const result = await adminTransaction(
+        async ({ transaction }) => {
+          return createUsageMeterTransaction(
+            {
+              usageMeter: {
+                name: 'API Calls',
+                slug: 'api-calls',
+                pricingModelId: pricingModel.id,
+              },
+            },
+            {
+              transaction,
+              userId,
+              livemode: false,
+              organizationId: organization.id,
+            }
+          )
+        }
+      )
+
+      // Verify all three records were created
+      expect(result.usageMeter).toBeDefined()
+      expect(result.product).toBeDefined()
+      expect(result.price).toBeDefined()
+
+      // Verify usage meter properties
+      expect(result.usageMeter.name).toBe('API Calls')
+      expect(result.usageMeter.slug).toBe('api-calls')
+      expect(result.usageMeter.pricingModelId).toBe(pricingModel.id)
+      expect(result.usageMeter.organizationId).toBe(organization.id)
+
+      // Verify product properties
+      expect(result.product.name).toBe('API Calls')
+      expect(result.product.slug).toBe('api-calls') // Same slug as usage meter
+      expect(result.product.pricingModelId).toBe(pricingModel.id)
+      // Note: organizationId comes from user's focused membership in createProductTransaction
+      expect(result.product.organizationId).toBeDefined()
+      expect(result.product.default).toBe(false)
+      expect(result.product.active).toBe(true)
+
+      // Verify price properties
+      expect(result.price.slug).toBe('api-calls') // Same slug as usage meter
+      expect(result.price.type).toBe(PriceType.Usage)
+      expect(result.price.unitPrice).toBe(0) // $0.00 as specified
+      expect(result.price.usageMeterId).toBe(result.usageMeter.id)
+      expect(result.price.productId).toBe(result.product.id)
+      expect(result.price.intervalUnit).toBe(IntervalUnit.Month)
+      expect(result.price.intervalCount).toBe(1)
+      expect(result.price.usageEventsPerUnit).toBe(1)
+      expect(result.price.isDefault).toBe(true)
+      expect(result.price.active).toBe(true)
+      expect(result.price.currency).toBe(organization.defaultCurrency)
+    })
+
+    it('should create usage meter with aggregationType', async () => {
+      const result = await adminTransaction(
+        async ({ transaction }) => {
+          return createUsageMeterTransaction(
+            {
+              usageMeter: {
+                name: 'Unique Users',
+                slug: 'unique-users',
+                pricingModelId: pricingModel.id,
+                aggregationType:
+                  UsageMeterAggregationType.CountDistinctProperties,
+              },
+            },
+            {
+              transaction,
+              userId,
+              livemode: false,
+              organizationId: organization.id,
+            }
+          )
+        }
+      )
+
+      expect(result.usageMeter.aggregationType).toBe(
+        UsageMeterAggregationType.CountDistinctProperties
+      )
+    })
+  })
+
+  describe('Product slug collision', () => {
+    it('should fail and rollback when product slug already exists in pricing model', async () => {
+      const slug = 'duplicate-product-slug'
+
+      // Create a product with the slug first
+      await setupProduct({
+        organizationId: organization.id,
+        name: 'Existing Product',
+        slug,
+        pricingModelId: pricingModel.id,
+        livemode: false,
+      })
+
+      // Attempt to create usage meter with the same slug
+      await expect(
+        adminTransaction(async ({ transaction }) => {
+          return createUsageMeterTransaction(
+            {
+              usageMeter: {
+                name: 'New Usage Meter',
+                slug,
+                pricingModelId: pricingModel.id,
+              },
+            },
+            {
+              transaction,
+              userId,
+              livemode: false,
+              organizationId: organization.id,
+            }
+          )
+        })
+      ).rejects.toThrow()
+
+      // Verify no usage meter was created (transaction rolled back)
+      const usageMeters = await adminTransaction(
+        async ({ transaction }) => {
+          return selectUsageMeters(
+            { slug, pricingModelId: pricingModel.id },
+            transaction
+          )
+        }
+      )
+      expect(usageMeters).toHaveLength(0)
+
+      // Verify only the original product exists
+      const products = await adminTransaction(
+        async ({ transaction }) => {
+          return selectProducts(
+            { slug, pricingModelId: pricingModel.id },
+            transaction
+          )
+        }
+      )
+      expect(products).toHaveLength(1)
+      expect(products[0].name).toBe('Existing Product')
+
+      // Verify no usage price was created (the failed transaction tried to create a usage price)
+      const prices = await adminTransaction(
+        async ({ transaction }) => {
+          return selectPrices({ slug }, transaction)
+        }
+      )
+      const usagePrices = prices.filter(
+        (p) => p.type === PriceType.Usage
+      )
+      expect(usagePrices).toHaveLength(0)
+    })
+  })
+
+  describe('Price slug collision', () => {
+    it('should fail and rollback when price slug already exists as an active price in pricing model', async () => {
+      const slug = 'duplicate-price-slug'
+
+      // Create a product and price with the slug first
+      const existingProduct = await setupProduct({
+        organizationId: organization.id,
+        name: 'Existing Product',
+        slug: 'other-product',
+        pricingModelId: pricingModel.id,
+        livemode: false,
+      })
+
+      await setupPrice({
+        productId: existingProduct.id,
+        name: 'Existing Price',
+        slug,
+        unitPrice: 1000,
+        type: PriceType.Subscription,
+        intervalUnit: IntervalUnit.Month,
+        intervalCount: 1,
+        active: true,
+        isDefault: true,
+        livemode: false,
+      })
+
+      // Attempt to create usage meter with the same slug
+      await expect(
+        adminTransaction(async ({ transaction }) => {
+          return createUsageMeterTransaction(
+            {
+              usageMeter: {
+                name: 'New Usage Meter',
+                slug,
+                pricingModelId: pricingModel.id,
+              },
+            },
+            {
+              transaction,
+              userId,
+              livemode: false,
+              organizationId: organization.id,
+            }
+          )
+        })
+      ).rejects.toThrow()
+
+      // Verify no usage meter was created (transaction rolled back)
+      const usageMeters = await adminTransaction(
+        async ({ transaction }) => {
+          return selectUsageMeters(
+            { slug, pricingModelId: pricingModel.id },
+            transaction
+          )
+        }
+      )
+      expect(usageMeters).toHaveLength(0)
+
+      // Verify no new product was created with the usage meter's slug
+      const products = await adminTransaction(
+        async ({ transaction }) => {
+          return selectProducts(
+            { slug, pricingModelId: pricingModel.id },
+            transaction
+          )
+        }
+      )
+      expect(products).toHaveLength(0)
+
+      // Verify the original price still exists and no usage price was created
+      const pricesWithSlug = await adminTransaction(
+        async ({ transaction }) => {
+          return selectPrices({ slug }, transaction)
+        }
+      )
+      // Should have at least the original price
+      expect(pricesWithSlug.length).toBeGreaterThanOrEqual(1)
+      // Verify none of them are usage prices (the failed transaction tried to create a usage price)
+      const usagePrices = pricesWithSlug.filter(
+        (p) => p.type === PriceType.Usage
+      )
+      expect(usagePrices).toHaveLength(0)
+    })
+
+    it('should allow usage meter creation with unique slug even when other slugs exist', async () => {
+      const slug = 'unique-new-slug'
+
+      // Create a product and price with a DIFFERENT slug
+      const existingProduct = await setupProduct({
+        organizationId: organization.id,
+        name: 'Existing Product',
+        slug: 'different-product-slug',
+        pricingModelId: pricingModel.id,
+        livemode: false,
+      })
+
+      await setupPrice({
+        productId: existingProduct.id,
+        name: 'Existing Price',
+        slug: 'different-price-slug',
+        unitPrice: 1000,
+        type: PriceType.Subscription,
+        intervalUnit: IntervalUnit.Month,
+        intervalCount: 1,
+        active: true,
+        isDefault: true,
+        livemode: false,
+      })
+
+      // Should succeed because the slug is unique
+      const result = await adminTransaction(
+        async ({ transaction }) => {
+          return createUsageMeterTransaction(
+            {
+              usageMeter: {
+                name: 'New Usage Meter',
+                slug,
+                pricingModelId: pricingModel.id,
+              },
+            },
+            {
+              transaction,
+              userId,
+              livemode: false,
+              organizationId: organization.id,
+            }
+          )
+        }
+      )
+
+      expect(result.usageMeter.slug).toBe(slug)
+      expect(result.product.slug).toBe(slug)
+      expect(result.price.slug).toBe(slug)
+      expect(result.price.active).toBe(true)
+    })
+  })
+
+  describe('Transaction rollback verification', () => {
+    it('should not create any records when slug collision occurs', async () => {
+      const slug = 'collision-test-slug'
+
+      // Create a product with the slug first
+      const blockingProduct = await setupProduct({
+        organizationId: organization.id,
+        name: 'Blocking Product',
+        slug,
+        pricingModelId: pricingModel.id,
+        livemode: false,
+      })
+
+      // Count records before the failed transaction
+      const beforeCounts = await adminTransaction(
+        async ({ transaction }) => {
+          const usageMeters = await selectUsageMeters(
+            { pricingModelId: pricingModel.id },
+            transaction
+          )
+          const products = await selectProducts(
+            { pricingModelId: pricingModel.id },
+            transaction
+          )
+          const allPrices = await Promise.all(
+            products.map((p) =>
+              selectPrices({ productId: p.id }, transaction)
+            )
+          )
+          const prices = allPrices.flat()
+          return {
+            usageMeters: usageMeters.length,
+            products: products.length,
+            prices: prices.length,
+          }
+        }
+      )
+
+      // Attempt to create usage meter (should fail due to product slug collision)
+      await expect(
+        adminTransaction(async ({ transaction }) => {
+          return createUsageMeterTransaction(
+            {
+              usageMeter: {
+                name: 'Should Not Create',
+                slug,
+                pricingModelId: pricingModel.id,
+              },
+            },
+            {
+              transaction,
+              userId,
+              livemode: false,
+              organizationId: organization.id,
+            }
+          )
+        })
+      ).rejects.toThrow()
+
+      // Count records after the failed transaction
+      const afterCounts = await adminTransaction(
+        async ({ transaction }) => {
+          const usageMeters = await selectUsageMeters(
+            { pricingModelId: pricingModel.id },
+            transaction
+          )
+          const products = await selectProducts(
+            { pricingModelId: pricingModel.id },
+            transaction
+          )
+          const allPrices = await Promise.all(
+            products.map((p) =>
+              selectPrices({ productId: p.id }, transaction)
+            )
+          )
+          const prices = allPrices.flat()
+          return {
+            usageMeters: usageMeters.length,
+            products: products.length,
+            prices: prices.length,
+          }
+        }
+      )
+
+      // Verify no new records were created (transaction rolled back completely)
+      expect(afterCounts.usageMeters).toBe(beforeCounts.usageMeters)
+      expect(afterCounts.products).toBe(beforeCounts.products)
+      expect(afterCounts.prices).toBe(beforeCounts.prices)
+    })
+  })
+})

--- a/platform/flowglad-next/src/utils/usage.ts
+++ b/platform/flowglad-next/src/utils/usage.ts
@@ -1,0 +1,82 @@
+import { AuthenticatedTransactionParams } from '@/db/types'
+import { UsageMeter } from '@/db/schema/usageMeters'
+import { Product } from '@/db/schema/products'
+import { Price } from '@/db/schema/prices'
+import { insertUsageMeter } from '@/db/tableMethods/usageMeterMethods'
+import { createProductTransaction } from '@/utils/pricingModel'
+import { IntervalUnit, PriceType } from '@/types'
+
+/**
+ * Creates a usage meter along with a corresponding product and usage price.
+ * The product and price will have the same slug as the usage meter.
+ * The price will be set to $0.00 per usage event.
+ *
+ * @throws Error if there's a slug collision with existing products or prices in the pricing model
+ */
+export const createUsageMeterTransaction = async (
+  payload: { usageMeter: UsageMeter.ClientInsert },
+  {
+    transaction,
+    livemode,
+    organizationId,
+    userId,
+  }: AuthenticatedTransactionParams
+): Promise<{
+  usageMeter: UsageMeter.Record
+  product: Product.Record
+  price: Price.Record
+}> => {
+  if (!organizationId) {
+    throw new Error(
+      'organizationId is required to create a usage meter'
+    )
+  }
+
+  const { usageMeter: usageMeterInput } = payload
+
+  const usageMeter = await insertUsageMeter(
+    {
+      ...usageMeterInput,
+      organizationId,
+      livemode,
+    },
+    transaction
+  )
+
+  // Create product and price using the same slug as the usage meter
+  // This will throw if there's a slug collision, causing the transaction to rollback
+  const { product, prices } = await createProductTransaction(
+    {
+      product: {
+        name: usageMeter.name,
+        slug: usageMeter.slug,
+        pricingModelId: usageMeter.pricingModelId,
+        default: false,
+        active: true,
+        singularQuantityLabel: 'unit',
+        pluralQuantityLabel: 'units',
+      },
+      prices: [
+        {
+          type: PriceType.Usage,
+          slug: usageMeter.slug,
+          unitPrice: 0, // $0.00 per usage event as specified
+          usageMeterId: usageMeter.id,
+          intervalUnit: IntervalUnit.Month,
+          intervalCount: 1,
+          usageEventsPerUnit: 1,
+          trialPeriodDays: null,
+          isDefault: true,
+          active: true,
+        },
+      ],
+    },
+    { transaction, livemode, organizationId, userId }
+  )
+
+  return {
+    usageMeter,
+    product,
+    price: prices[0],
+  }
+}


### PR DESCRIPTION
## What Does this PR Do?
add `createUsageMeterTransaction` for use in createUsageMeter mutation. creates a usage product and usage price using the same slug as the usage meter as part of the transaction. it will throw when there is a slug collision with an already existing product or price. 
price fields have hardcoded default of unit price 0, interval unit month, interval count 1, usageEventsPerUnit 1. we will soon allow users to modify these fields once we expose price form fields to the create usage meter ui

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add createUsageMeterTransaction to atomically create a usage meter, product, and usage price with the same slug. Updated the createUsageMeter mutation to use this flow with safe rollback on slug collisions.

- **New Features**
  - New createUsageMeterTransaction creates: usage meter + product + usage price in one transaction.
  - Usage price defaults: unitPrice 0, intervalUnit month, intervalCount 1, usageEventsPerUnit 1; set as default and active.
  - Throws on slug collisions (product or price) within the pricing model; entire transaction rolls back.
  - Router createUsageMeter now uses the transaction and organizationId from context.
  - Tests cover success cases, product/price slug collisions, and rollback behavior.

<sup>Written for commit 06a7f4f1b7300ce98a14bce1f0cb60d8e8151098. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

