### PR TITLE
fix: support adding credit usage grant features to free plan customers without ledger accounts

### DIFF
--- a/platform/flowglad-next/src/app/finance/subscriptions/[id]/AddSubscriptionFeatureModal.tsx
+++ b/platform/flowglad-next/src/app/finance/subscriptions/[id]/AddSubscriptionFeatureModal.tsx
@@ -29,11 +29,14 @@ export const AddSubscriptionFeatureModal = ({
   subscriptionItems,
   featureItems = [],
 }: AddSubscriptionFeatureModalProps) => {
-  const utils = trpc.useUtils()
   const addFeatureMutation =
     trpc.subscriptions.addFeatureToSubscription.useMutation()
 
-  const defaultSubscriptionItemId = subscriptionItems[0]?.id ?? ''
+  const activeSubscriptionItems = subscriptionItems.filter(
+    (item) => !item.expiredAt
+  )
+  const defaultSubscriptionItemId =
+    activeSubscriptionItems[0]?.id ?? ''
 
   const defaultValues = useMemo(
     () => ({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables adding usage credit grant features for customers on free plans without existing ledger accounts. Selects an active subscription item and creates the needed ledger account when missing.

- **Bug Fixes**
  - Frontend: default selection uses only active subscription items.
  - Backend: require usageMeterId for credit grants and find/create ledger account for the subscription + meter.
  - Backend: set usageMeterId as non-null in the ledger entry.

<sup>Written for commit b26e754a823e05a58da4d63302409166db4f9eff. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

