### PR TITLE
fix: hide `PricingModelSelect` on `ProductFormFields` when opened in pricing model details

### DIFF
--- a/platform/flowglad-next/src/app/store/pricing-models/[id]/InnerPricingModelDetailsPage.tsx
+++ b/platform/flowglad-next/src/app/store/pricing-models/[id]/InnerPricingModelDetailsPage.tsx
@@ -187,6 +187,7 @@ function InnerPricingModelDetailsPage({
         isOpen={isCreateProductModalOpen}
         setIsOpen={setIsCreateProductModalOpen}
         defaultPricingModelId={pricingModel.id}
+        hidePricingModelSelect={true}
       />
       <CreateCustomerFormModal
         isOpen={isCreateCustomerModalOpen}

--- a/platform/flowglad-next/src/components/forms/CreateProductModal.tsx
+++ b/platform/flowglad-next/src/components/forms/CreateProductModal.tsx
@@ -38,6 +38,7 @@ export const CreateProductModal = ({
   onSubmitStart,
   onSubmitSuccess,
   defaultPricingModelId,
+  hidePricingModelSelect,
 }: {
   isOpen: boolean
   setIsOpen: (isOpen: boolean) => void
@@ -46,6 +47,7 @@ export const CreateProductModal = ({
   onSubmitSuccess?: () => void
   onSubmitError?: (error: Error) => void
   defaultPricingModelId: string
+  hidePricingModelSelect?: boolean
 }) => {
   const { organization } = useAuthenticatedContext()
   const createProduct = trpc.products.create.useMutation()
@@ -100,7 +102,9 @@ export const CreateProductModal = ({
       setIsOpen={setIsOpen}
       mode="drawer"
     >
-      <ProductFormFields />
+      <ProductFormFields
+        hidePricingModelSelect={hidePricingModelSelect}
+      />
     </FormModal>
   )
 }

--- a/platform/flowglad-next/src/components/forms/ProductFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/ProductFormFields.tsx
@@ -27,8 +27,10 @@ import { PriceType } from '@/types'
 
 export const ProductFormFields = ({
   editProduct = false,
+  hidePricingModelSelect = false,
 }: {
   editProduct?: boolean
+  hidePricingModelSelect?: boolean
 }) => {
   const form = useFormContext<CreateProductSchema>()
   const priceForm = usePriceFormContext()
@@ -138,7 +140,7 @@ export const ProductFormFields = ({
                 </FormItem>
               )}
             />
-            {!editProduct && (
+            {!editProduct && !hidePricingModelSelect && (
               <div className="w-full relative flex flex-col gap-3">
                 <PricingModelSelect
                   name="product.pricingModelId"


### PR DESCRIPTION
## What Does this PR Do?
- hides the pricing model select component when 
<img width="2496" height="1100" alt="CleanShot 2025-11-17 at 23 50 41@2x" src="https://github.com/user-attachments/assets/5230c87d-177c-4519-ba59-29ac858c77e3" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the PricingModelSelect in ProductFormFields when the CreateProductModal is opened from a Pricing Model details page. This uses the provided defaultPricingModelId and prevents changing it in that context.

- CreateProductModal and ProductFormFields now accept an optional hidePricingModelSelect prop; set to true in InnerPricingModelDetailsPage.

<sup>Written for commit 693707f9235c29fd899f775f0108c64a9935633c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

