### PR TITLE
fix: trpc invalidation, backend validation, jsdoc comments

### DIFF
--- a/platform/flowglad-next/src/app/finance/subscriptions/[id]/AddSubscriptionFeatureModal.tsx
+++ b/platform/flowglad-next/src/app/finance/subscriptions/[id]/AddSubscriptionFeatureModal.tsx
@@ -17,6 +17,7 @@ import { z } from 'zod'
 
 interface AddSubscriptionFeatureModalProps
   extends ModalInterfaceProps {
+  subscriptionId: string
   subscriptionItems: RichSubscription['subscriptionItems']
   featureItems?: z.infer<
     typeof subscriptionItemFeaturesClientSelectSchema
@@ -26,11 +27,20 @@ interface AddSubscriptionFeatureModalProps
 export const AddSubscriptionFeatureModal = ({
   isOpen,
   setIsOpen,
+  subscriptionId,
   subscriptionItems,
   featureItems = [],
 }: AddSubscriptionFeatureModalProps) => {
+  const utils = trpc.useUtils()
   const addFeatureMutation =
-    trpc.subscriptions.addFeatureToSubscription.useMutation()
+    trpc.subscriptions.addFeatureToSubscription.useMutation({
+      onSuccess: async () => {
+        // Invalidate the subscription query to refresh the UI with the new feature
+        await utils.subscriptions.get.invalidate({
+          id: subscriptionId,
+        })
+      },
+    })
 
   const activeSubscriptionItems = subscriptionItems.filter(
     (item) => !item.expiredAt

--- a/platform/flowglad-next/src/app/finance/subscriptions/[id]/InnerSubscriptionPage.tsx
+++ b/platform/flowglad-next/src/app/finance/subscriptions/[id]/InnerSubscriptionPage.tsx
@@ -138,6 +138,7 @@ const InnerSubscriptionPage = ({
       <AddSubscriptionFeatureModal
         isOpen={isAddFeatureModalOpen}
         setIsOpen={setIsAddFeatureModalOpen}
+        subscriptionId={subscription.id}
         subscriptionItems={subscription.subscriptionItems}
         featureItems={subscription.experimental?.featureItems}
       />

--- a/platform/flowglad-next/src/components/ui/select.tsx
+++ b/platform/flowglad-next/src/components/ui/select.tsx
@@ -125,7 +125,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded py-2 pl-8 pr-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-pointer select-none items-center rounded py-2 pl-8 pr-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved feature addition flow by refreshing the subscription UI after mutation and blocking duplicate toggle features with clear backend validation.

- **Bug Fixes**
  - Invalidate subscriptions.get via tRPC utils on addFeature success to refresh data.
  - Reject duplicate toggle features with an explicit error (removed upsert path).
  - Updated tests to expect the new error behavior.
  - Set SelectItem to use a pointer cursor for better UX.

- **Refactors**
  - Added JSDoc to helper functions and split insert construction into a dedicated utility.
  - Clarified immediate credit grant logic and validation within addFeatureToSubscriptionItem.

<sup>Written for commit dfa4084f4dac8a37949ab32c540fd7451ebd17e8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

