### PR TITLE
fix: broken md syntax

### DIFF
--- a/platform/docs/integrate-by-http.mdx
+++ b/platform/docs/integrate-by-http.mdx
@@ -16,7 +16,7 @@ Instead of this webhook approach, Flowglad is designed to be [reactive](https://
 ```mermaid
 graph LR
     A[Flowglad API] --> B[Your Server]
-    B --> C[Your React Frontend via `useBilling`]
+    B --> C[Your React Frontend via useBilling]
 ```
 #### The Write Flow
 ```mermaid


### PR DESCRIPTION
<img width="750" height="203" alt="Screenshot 2025-11-18 at 2 58 25 PM" src="https://github.com/user-attachments/assets/23d30c97-54c2-4e3c-9543-5ea164c9d1d1" />

Fix "Unsupported markdown: codespan"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MDX error “Unsupported markdown: codespan” by removing inline code formatting from a Mermaid node label in integrate-by-http.mdx. The diagram now renders correctly in the docs.

<sup>Written for commit 4636932f0b9ba68ceed337117c03c3947ba2798d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

