### PR TITLE
update auth docs

### DIFF
--- a/platform/docs/docs.json
+++ b/platform/docs/docs.json
@@ -80,7 +80,7 @@
             "pages": [
               "sdks/introduction",
               "sdks/setup",
-              "sdks/auth-adaptors",
+              "sdks/auth-adapters",
               "sdks/pricing-models-products",
               "sdks/checkout-sessions",
               "sdks/feature-access-usage",

--- a/platform/docs/quickstart.mdx
+++ b/platform/docs/quickstart.mdx
@@ -87,6 +87,19 @@ export const flowgladServer = new FlowgladServer({
 ```
 
 
+```ts Better Auth
+import { auth } from '@/lib/auth'; // your Better Auth instance in auth.ts
+import { headers } from 'next/headers';
+import { FlowgladServer } from '@flowglad/nextjs/server';
+
+export const flowgladServer = new FlowgladServer({
+  betterAuth: {
+    getSession: async () => auth.api.getSession({ headers: await headers() }),
+  },
+});
+```
+
+
 ```ts Custom Auth
 import { FlowgladServer } from '@flowglad/nextjs/server'
 // or whatever function you use to retrieve your session

--- a/platform/docs/sdks/auth-adapters.mdx
+++ b/platform/docs/sdks/auth-adapters.mdx
@@ -9,10 +9,9 @@ Flowglad provides adapters for these auth providers:
 - Supabase Auth
 - Clerk
 - NextAuth
+- Better Auth
 
 ## Supabase Auth
-
-<CodeGroup>
 
 ```ts
 import { FlowgladServer } from '@flowglad/nextjs/server'
@@ -26,11 +25,7 @@ export const flowgladServer = new FlowgladServer({
 })
 ```
 
-</CodeGroup>
-
 ## Clerk
-
-<CodeGroup>
 
 ```ts
 import { currentUser } from '@clerk/nextjs/server'
@@ -43,11 +38,7 @@ export const flowgladServer = new FlowgladServer({
 })
 ```
 
-</CodeGroup>
-
 ## NextAuth
-
-<CodeGroup>
 
 ```ts
 import { auth } from '@/auth' // your configured NextAuth client
@@ -60,13 +51,23 @@ export const flowgladServer = new FlowgladServer({
 })
 ```
 
-</CodeGroup>
+## Better Auth
+
+```ts
+import { auth } from '@/lib/auth'; // your Better Auth instance in auth.ts
+import { headers } from 'next/headers';
+import { FlowgladServer } from '@flowglad/nextjs/server';
+
+export const flowgladServer = new FlowgladServer({
+  betterAuth: {
+    getSession: async () => auth.api.getSession({ headers: await headers() }),
+  },
+});
+```
 
 ## Custom session loaders
 
 When you already have a helper that returns the signed-in user, pass it through `getRequestingCustomer`.
-
-<CodeGroup>
 
 ```ts
 import { FlowgladServer } from '@flowglad/nextjs/server'
@@ -86,11 +87,7 @@ export const flowgladServer = new FlowgladServer({
 })
 ```
 
-</CodeGroup>
-
 If you need to inspect the incoming request, derive the customer inside a factory that receives the request object.
-
-<CodeGroup>
 
 ```ts
 import { FlowgladServer } from '@flowglad/nextjs/server'
@@ -111,11 +108,7 @@ export const createFlowgladServer = (request: Request) =>
   })
 ```
 
-</CodeGroup>
-
 ## Custom auth example: Firebase
-
-<CodeGroup>
 
 ```ts
 import { FlowgladServer } from '@flowglad/server'
@@ -144,8 +137,6 @@ export const flowgladServer = (request: Request) =>
     }
   })
 ```
-
-</CodeGroup>
 
 ## What happens at runtime?
 

--- a/platform/docs/sdks/nextjs.mdx
+++ b/platform/docs/sdks/nextjs.mdx
@@ -70,7 +70,7 @@ Access billing data and functions. See the [React SDK documentation](/sdks/react
 ## Integration with Authentication
 
 <Info>
-Native constructor params are available for popular auth providers including Supabase Auth, Clerk, Next Auth. Read more about auth adaptors [here](/sdks/auth-adaptors)
+Native constructor params are available for popular auth providers including Supabase Auth, Clerk, NextAuth, Better Auth. Read more about auth adapters [here](/sdks/auth-adapters)
 </Info>
 
 ### Supabase Auth Example

--- a/platform/docs/sdks/server.mdx
+++ b/platform/docs/sdks/server.mdx
@@ -434,7 +434,7 @@ export async function getCustomerPortalData() {
 ## Integration Examples
 
 <Info>
-Native constructor params are available for popular auth providers including Supabase Auth, Clerk, Next Auth. Read more about auth adaptors [here](/sdks/auth-adaptors)
+Native constructor params are available for popular auth providers including Supabase Auth, Clerk, NextAuth, Better Auth. Read more about auth adapters [here](/sdks/auth-adapters)
 </Info>
 
 ### With Supabase Auth

--- a/platform/docs/snippets/setup-nextjs.mdx
+++ b/platform/docs/snippets/setup-nextjs.mdx
@@ -70,7 +70,7 @@ export const flowgladServer = new FlowgladServer({
 </CodeGroup>
 
 <Info>
-Native constructor params are available for popular auth providers including Supabase Auth, Clerk, Next Auth. Read more about auth adaptors [here](/sdks/auth-adaptors)
+Native constructor params are available for popular auth providers including Supabase Auth, Clerk, NextAuth, Better Auth. Read more about auth adapters [here](/sdks/auth-adapters)
 </Info>
 
 <CodeGroup>
@@ -100,7 +100,7 @@ export const flowgladServer = new FlowgladServer({
 ```
 
 
-```ts Next Auth
+```ts NextAuth
 import { auth } from '@/auth' // your initialized, configured NextAuth client
 import { FlowgladServer } from '@flowglad/nextjs/server'
 
@@ -109,6 +109,19 @@ export const flowgladServer = new FlowgladServer({
     auth,
   },
 })
+```
+
+
+```ts Better Auth
+import { auth } from '@/lib/auth'; // your Better Auth instance in auth.ts
+import { headers } from 'next/headers';
+import { FlowgladServer } from '@flowglad/nextjs/server';
+
+export const flowgladServer = new FlowgladServer({
+  betterAuth: {
+    getSession: async () => auth.api.getSession({ headers: await headers() }),
+  },
+});
 ```
 
 

--- a/platform/docs/snippets/setup-server.mdx
+++ b/platform/docs/snippets/setup-server.mdx
@@ -43,7 +43,7 @@ export const flowgladServer = new FlowgladServer({
 ```
 
 <Info>
-Native constructor params are available for popular auth providers including Supabase Auth, Clerk, Next Auth. Read more about auth adaptors [here](/sdks/auth-adaptors)
+Native constructor params are available for popular auth providers including Supabase Auth, Clerk, NextAuth, Better Auth. Read more about auth adapters [here](/sdks/auth-adapters)
 </Info>
 
 <CodeGroup>
@@ -73,7 +73,7 @@ export const flowgladServer = new FlowgladServer({
 ```
 
 
-```ts Next Auth
+```ts NextAuth
 import { auth } from '@/auth' // your initialized, configured NextAuth client
 import { FlowgladServer } from '@flowglad/server'
 
@@ -82,6 +82,19 @@ export const flowgladServer = new FlowgladServer({
     auth,
   },
 })
+```
+
+
+```ts Better Auth
+import { auth } from '@/lib/auth'; // your Better Auth instance in auth.ts
+import { headers } from 'next/headers';
+import { FlowgladServer } from '@flowglad/nextjs/server';
+
+export const flowgladServer = new FlowgladServer({
+  betterAuth: {
+    getSession: async () => auth.api.getSession({ headers: await headers() }),
+  },
+});
 ```
 
 


### PR DESCRIPTION
## What Does this PR Do?
add better auth adapter docs, rename adaptor to adapter and change link

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Better Auth adapter documentation and examples for Next.js and server SDKs. Standardized “adapter” naming and updated links to the new /sdks/auth-adapters page.

- **New Features**
  - Better Auth integration examples in quickstart, Next.js, server, and setup snippets (getSession via auth.api.getSession with headers).
  - Auth adapters page updated to include Better Auth.

- **Bug Fixes**
  - Renamed “adaptor” to “adapter” and updated navigation/links across docs.
  - Corrected provider naming to “NextAuth” and Info notes now list Better Auth.

<sup>Written for commit 08664f148b16c4b9e7401e1e7d9f12632b664de6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

