### PR TITLE
feat: include customer email on successful checkout

### DIFF
--- a/platform/flowglad-next/src/app/checkout/[id]/success/ProductCheckoutSuccessPage.tsx
+++ b/platform/flowglad-next/src/app/checkout/[id]/success/ProductCheckoutSuccessPage.tsx
@@ -4,6 +4,7 @@ import { CheckoutSession } from '@/db/schema/checkoutSessions'
 import { PriceType } from '@/types'
 import SuccessPageContainer from '@/components/SuccessPageContainer'
 import SubscriptionCheckoutSuccessPage from './SubscriptionCheckoutSuccessPage'
+import { selectCustomerById } from '@/db/tableMethods/customerMethods'
 
 interface ProductCheckoutSuccessPageProps {
   product: CheckoutSession.Record
@@ -12,12 +13,24 @@ interface ProductCheckoutSuccessPageProps {
 const ProductCheckoutSuccessPage = async ({
   product,
 }: ProductCheckoutSuccessPageProps) => {
+  // Get customer email from customer record (same source the email system uses)
+  let customerEmail: string | null = null
+  if (product.customerId) {
+    const customer = await adminTransaction(
+      async ({ transaction }) => {
+        return selectCustomerById(product.customerId!, transaction)
+      }
+    )
+    customerEmail = customer?.email || null
+  }
+
   // If there's no priceId, just show a generic success message
   if (!product.priceId) {
     return (
       <SuccessPageContainer
         title="Product Purchase Successful"
         message="Thank you for purchase"
+        customerEmail={customerEmail}
       />
     )
   }
@@ -53,6 +66,7 @@ const ProductCheckoutSuccessPage = async ({
     <SuccessPageContainer
       title="Product Purchase Successful"
       message={`Thank you for purchasing from ${organization.name}. Your order has been processed successfully.`}
+      customerEmail={customerEmail}
     />
   )
 }

--- a/platform/flowglad-next/src/app/checkout/[id]/success/PurchaseCheckoutSuccessPage.tsx
+++ b/platform/flowglad-next/src/app/checkout/[id]/success/PurchaseCheckoutSuccessPage.tsx
@@ -4,6 +4,7 @@ import { CheckoutSession } from '@/db/schema/checkoutSessions'
 import { PriceType } from '@/types'
 import SuccessPageContainer from '@/components/SuccessPageContainer'
 import SubscriptionCheckoutSuccessPage from './SubscriptionCheckoutSuccessPage'
+import { selectCustomerById } from '@/db/tableMethods/customerMethods'
 
 interface PurchaseCheckoutSuccessPageProps {
   checkoutSession: CheckoutSession.Record
@@ -12,12 +13,27 @@ interface PurchaseCheckoutSuccessPageProps {
 const PurchaseCheckoutSuccessPage = async ({
   checkoutSession,
 }: PurchaseCheckoutSuccessPageProps) => {
+  // Get customer email from customer record (same source the email system uses)
+  let customerEmail: string | null = null
+  if (checkoutSession.customerId) {
+    const customer = await adminTransaction(
+      async ({ transaction }) => {
+        return selectCustomerById(
+          checkoutSession.customerId!,
+          transaction
+        )
+      }
+    )
+    customerEmail = customer?.email || null
+  }
+
   // If there's no priceId, just show a generic success message
   if (!checkoutSession.priceId) {
     return (
       <SuccessPageContainer
         title="Purchase Successful"
         message="Thank you for your purchase. Your order has been processed successfully."
+        customerEmail={customerEmail}
       />
     )
   }
@@ -53,6 +69,7 @@ const PurchaseCheckoutSuccessPage = async ({
     <SuccessPageContainer
       title="Purchase Successful"
       message={`Thank you for your purchase from ${organization.name}. Your order has been processed successfully.`}
+      customerEmail={customerEmail}
     />
   )
 }

--- a/platform/flowglad-next/src/app/checkout/[id]/success/SubscriptionCheckoutSuccessPage.tsx
+++ b/platform/flowglad-next/src/app/checkout/[id]/success/SubscriptionCheckoutSuccessPage.tsx
@@ -5,7 +5,7 @@ import { Organization } from '@/db/schema/organizations'
 import { Price } from '@/db/schema/prices'
 import SuccessPageContainer from '@/components/SuccessPageContainer'
 import { PriceType } from '@/types'
-import { selectSubscriptions } from '@/db/tableMethods/subscriptionMethods'
+import { selectCustomerById } from '@/db/tableMethods/customerMethods'
 
 interface SubscriptionCheckoutSuccessPageProps {
   checkoutSession: CheckoutSession.Record
@@ -44,11 +44,27 @@ const SubscriptionCheckoutSuccessPage = async ({
       innerPrice = result.price
     }
   }
+
+  // Get customer email from customer record (same source the email system uses)
+  let customerEmail: string | null = null
+  if (checkoutSession.customerId) {
+    const customer = await adminTransaction(
+      async ({ transaction }) => {
+        return selectCustomerById(
+          checkoutSession.customerId!,
+          transaction
+        )
+      }
+    )
+    customerEmail = customer?.email || null
+  }
+
   if (innerPrice?.type === PriceType.Usage) {
     return (
       <SuccessPageContainer
         title="Thanks for subscribing"
         message={`A payment to ${innerOrganization.name} will appear on your statement, based on your usage.`}
+        customerEmail={customerEmail}
       />
     )
   }
@@ -56,6 +72,7 @@ const SubscriptionCheckoutSuccessPage = async ({
     <SuccessPageContainer
       title="Thanks for subscribing"
       message={`A payment to ${innerOrganization.name} will appear on your statement.`}
+      customerEmail={customerEmail}
     />
   )
 }

--- a/platform/flowglad-next/src/components/SuccessPageContainer.tsx
+++ b/platform/flowglad-next/src/components/SuccessPageContainer.tsx
@@ -3,22 +3,40 @@ import { CheckCircleIcon } from 'lucide-react'
 interface SuccessPageContainerProps {
   title: string
   message: string
+  customerEmail?: string | null
 }
 
 const SuccessPageContainer = ({
   title,
   message,
+  customerEmail,
 }: SuccessPageContainerProps) => {
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen">
-      <div className="text-center max-w-[400px]">
+    <div className="flex flex-col items-center justify-center min-h-screen px-4">
+      <div className="text-center max-w-[480px] w-full">
         <div className="mb-8">
           <div className="h-16 w-16 mx-auto rounded-full bg-green-100 flex items-center justify-center">
             <CheckCircleIcon className="h-8 w-8 text-green-500" />
           </div>
         </div>
         <h1 className="text-2xl font-bold mb-4">{title}</h1>
-        <p className="text-muted-foreground">{message}</p>
+
+        <div className="space-y-4">
+          <p className="text-muted-foreground">{message}</p>
+
+          {customerEmail && (
+            <div className="mt-6 pt-4 border-t border-border">
+              <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                <span>
+                  Confirmation sent to{' '}
+                  <span className="font-medium text-foreground">
+                    {customerEmail}
+                  </span>
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
<img width="567" height="333" alt="Screenshot 2025-11-20 at 12 12 09 PM" src="https://github.com/user-attachments/assets/dc6d9aaa-e412-4a38-a8bd-facbb482dd75" />


<img width="525" height="298" alt="Screenshot 2025-11-20 at 12 12 22 PM" src="https://github.com/user-attachments/assets/31edc104-21b4-4d25-be2a-45d72dc086bc" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the customer's email on checkout success pages so buyers know where the confirmation was sent. The email is fetched from the Customer record using customerId and shown when available.

- **New Features**
  - Retrieve email via selectCustomerById inside adminTransaction on Product, Purchase, and Subscription success pages.
  - Pass customerEmail to SuccessPageContainer and render a “Confirmation sent to {email}” line.
  - Minor UI tweaks: added horizontal padding, increased max width to 480px, and a divider above the confirmation line.

<sup>Written for commit 4b2a3a78c594df139fb467afa9ec90666ca3c7ba. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

