### PR TITLE
fix: broken link on /onboarding

### DIFF
--- a/platform/flowglad-next/src/app/onboarding/OnboardingStatusTable.tsx
+++ b/platform/flowglad-next/src/app/onboarding/OnboardingStatusTable.tsx
@@ -238,7 +238,7 @@ const OnboardingStatusTable = ({
               className="w-full"
               onClick={() => {
                 window.open(
-                  'https://docs.flowglad.com/setup-by-prompt#2-one-shot-integration',
+                  'https://docs.flowglad.com/integrate-by-prompt',
                   '_blank'
                 )
               }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the broken docs link on the onboarding page to point to https://docs.flowglad.com/integrate-by-prompt, so users reach the correct integration guide.

<sup>Written for commit 344c02860c401933b583bc3596cb28715b3accb1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

