### PR TITLE
handle zod resolver error before form submit

### DIFF
--- a/platform/flowglad-next/src/components/forms/CreateWebhookModal.tsx
+++ b/platform/flowglad-next/src/components/forms/CreateWebhookModal.tsx
@@ -9,6 +9,7 @@ import {
 import WebhookFormFields from '@/components/forms/WebhookFormFields'
 import { trpc } from '@/app/_trpc/client'
 import CopyableTextTableCell from '@/components/CopyableTextTableCell'
+import { toast } from 'sonner'
 
 interface CreateWebhookModalProps {
   isOpen: boolean
@@ -19,10 +20,21 @@ const CreateWebhookModal: React.FC<CreateWebhookModalProps> = ({
   isOpen,
   setIsOpen,
 }) => {
-  const createWebhook = trpc.webhooks.create.useMutation()
   const [webhookSecret, setWebhookSecret] = useState<string | null>(
     null
   )
+  const createWebhook = trpc.webhooks.create.useMutation({
+    onSuccess: (result) => {
+      setWebhookSecret(result.secret)
+      toast.success('Webhook created successfully')
+    },
+    onError: (error) => {
+      toast.error(
+        'Failed to create webhook. Please check your settings and try again.'
+      )
+      console.error('Webhook creation error:', error)
+    },
+  })
   const webhookDefaultValues: Webhook.ClientInsert = {
     name: '',
     url: '',
@@ -43,8 +55,7 @@ const CreateWebhookModal: React.FC<CreateWebhookModalProps> = ({
         webhook: webhookDefaultValues,
       }}
       onSubmit={async (data) => {
-        const result = await createWebhook.mutateAsync(data)
-        setWebhookSecret(result.secret)
+        await createWebhook.mutateAsync(data)
       }}
       hideFooter={webhookSecret ? true : false}
       autoClose={false}


### PR DESCRIPTION
## What Does this PR Do?
handle zod resolver error before form submit & mutation, display error next to invalid fields

before: (hangs on grey submit button)
<img width="497" height="467" alt="Screenshot 2025-11-20 at 3 18 21 PM" src="https://github.com/user-attachments/assets/763efb68-4831-4ca3-9e4d-fc83bd22b028" />
<img width="546" height="539" alt="Screenshot 2025-11-20 at 3 13 51 PM" src="https://github.com/user-attachments/assets/40671a21-1c9d-4959-a771-1d056da82626" />

after:
<img width="514" height="485" alt="Screenshot 2025-11-20 at 3 19 17 PM" src="https://github.com/user-attachments/assets/74613b2a-3946-4e83-be9d-03a535800c36" />
<img width="546" height="548" alt="Screenshot 2025-11-20 at 3 13 30 PM" src="https://github.com/user-attachments/assets/3274243b-815d-44c9-aa4e-5a6d2b470517" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes form submission hangs by catching Zod resolver errors and showing inline field messages before running mutations. Adds success/error toasts to the Create Webhook modal.

- **Bug Fixes**
  - Wrap zodResolver in try/catch to return field-level errors (and a root error when needed) instead of throwing.
  - Submit button no longer gets stuck; invalid fields now show messages next to inputs.

- **New Features**
  - CreateWebhookModal uses mutation callbacks to set the secret and show success/error toasts.

<sup>Written for commit 25e713d6821660c929f5f967c17abf5e00309dca. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

