### PR TITLE
fix: invoice spacing

### DIFF
--- a/platform/flowglad-next/src/app/invoice/view/[organizationId]/[invoiceId]/CustomerInvoiceButtonBanner.tsx
+++ b/platform/flowglad-next/src/app/invoice/view/[organizationId]/[invoiceId]/CustomerInvoiceButtonBanner.tsx
@@ -62,15 +62,15 @@ export const CustomerInvoiceDownloadReceiptButtonBanner = ({
         </Button>
       )}
 
-      {/* {invoice.receiptPdfURL && ( */}
-      <Button
-        onClick={() => {
-          window.open(invoice.receiptPdfURL!, '_blank')
-        }}
-      >
-        Download receipt
-      </Button>
-      {/* )} */}
+      {invoice.receiptPdfURL && (
+        <Button
+          onClick={() => {
+            window.open(invoice.receiptPdfURL!, '_blank')
+          }}
+        >
+          Download receipt
+        </Button>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## What Does this PR Do?
Now:
<img width="1196" height="628" alt="CleanShot 2025-11-20 at 16 52 49@2x" src="https://github.com/user-attachments/assets/75eaef31-8b28-4815-8d2e-c6813e18fb31" />

Before:
<img width="1594" height="1226" alt="CleanShot 2025-11-20 at 16 38 41@2x" src="https://github.com/user-attachments/assets/97c88902-1b35-49da-9443-dcde066a1712" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix spacing in the customer invoice banner by switching the container to a full-width flex row. Buttons now align side-by-side with space between, removing the extra vertical gaps.

<sup>Written for commit 87e9b8c6a970805bba547204f731aee9a2d4da21. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

