### PR TITLE
fix: split link - streaming vs regular batching

### DIFF
--- a/platform/flowglad-next/src/app/_trpc/Provider.tsx
+++ b/platform/flowglad-next/src/app/_trpc/Provider.tsx
@@ -3,7 +3,11 @@ import {
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query'
-import { httpBatchStreamLink } from '@trpc/client'
+import {
+  httpBatchStreamLink,
+  httpBatchLink,
+  splitLink,
+} from '@trpc/client'
 import React, { useState } from 'react'
 
 import { trpc } from './client'
@@ -33,9 +37,29 @@ export default function Provider({
   const [trpcClient] = useState(() =>
     trpc.createClient({
       links: [
-        httpBatchStreamLink({
-          url: `${core.envVariable('APP_URL')}/api/trpc`,
-          transformer: SuperJSON,
+        /**
+         * Conditional link to use streaming or batching based on the path
+         * .streaming suffix on procedure name indicates a streaming response.
+         */
+        splitLink({
+          // decide which link to use
+          condition(op) {
+            return op.path.endsWith('.streaming')
+          },
+          // true branch -> stream responses
+          true: [
+            httpBatchStreamLink({
+              url: `${core.envVariable('APP_URL')}/api/trpc`,
+              transformer: SuperJSON,
+            }),
+          ],
+          // false branch -> normal batching
+          false: [
+            httpBatchLink({
+              url: `${core.envVariable('APP_URL')}/api/trpc`,
+              transformer: SuperJSON,
+            }),
+          ],
         }),
       ],
     })

--- a/platform/flowglad-next/src/components/forms/PricingModelIntegrationGuideModal.tsx
+++ b/platform/flowglad-next/src/components/forms/PricingModelIntegrationGuideModal.tsx
@@ -37,7 +37,7 @@ export function PricingModelIntegrationGuideModal({
     codebaseMarkdown.trim() !== ''
 
   const { data, isLoading } =
-    trpc.pricingModels.getIntegrationGuide.useQuery(
+    trpc.pricingModels.getIntegrationGuide.streaming.useQuery(
       { id: pricingModelId },
       { enabled: isOpen && hasCodebaseOverview }
     )

--- a/platform/flowglad-next/src/server/routers/pricingModelsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/pricingModelsRouter.ts
@@ -370,5 +370,7 @@ export const pricingModelsRouter = router({
   clone: clonePricingModelProcedure,
   getTableRows: getTableRowsProcedure,
   export: exportPricingModelProcedure,
-  getIntegrationGuide: getIntegrationGuideProcedure,
+  getIntegrationGuide: {
+    streaming: getIntegrationGuideProcedure,
+  },
 })


### PR DESCRIPTION
## What Does this PR Do?
- fixes the issue where TRPC mutations went all-stream (therefore creating issues with termination and router refresh in certain edge cases)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split tRPC links to route streaming calls separately from regular batching. Fixes the “all-stream” behavior that caused termination and router refresh issues.

- **Bug Fixes**
  - Use splitLink to send .streaming procedures via httpBatchStreamLink and all others via httpBatchLink.
  - Moved pricingModels.getIntegrationGuide to pricingModels.getIntegrationGuide.streaming and updated the client call.

- **Migration**
  - For streaming endpoints, add a .streaming segment in the router and client.
  - Example: trpc.pricingModels.getIntegrationGuide.streaming.useQuery.

<sup>Written for commit 59b7e98264837019d8d236709884fbd17c3a5df1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

