### PR TITLE
mcp: enable mcp in flowglad-next

### DIFF
--- a/platform/flowglad-next/src/app/api/mcp/route.ts
+++ b/platform/flowglad-next/src/app/api/mcp/route.ts
@@ -1,6 +1,5 @@
 import { createMcpHandler, withMcpAuth } from 'mcp-handler'
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js'
-import core from '@/utils/core'
 import { verifyApiKey } from '@/utils/unkey'
 import { z } from 'zod/v3'
 import {
@@ -79,10 +78,8 @@ const handler = createMcpHandler(
               const markdown = await fetchMarkdownFromDocs(
                 result.path
               )
-              const similarity = (1 - result.$dist).toFixed(4)
 
               return {
-                similarity,
                 path: result.path,
                 title: result.title,
                 description: result.description,
@@ -190,13 +187,13 @@ const verifyToken = async (
  * Example MCP client configuration:
  *   "Authorization": "Bearer sk_test_..."
  */
+// Let withMcpAuth handle authentication using verifyToken
+const authHandler = withMcpAuth(handler, verifyToken, {
+  required: true, // Auth is required and we verify it via verifyToken
+})
+
 export async function POST(req: Request) {
   try {
-    // Let withMcpAuth handle authentication using verifyToken
-    const authHandler = withMcpAuth(handler, verifyToken, {
-      required: true, // Auth is required and we verify it via verifyToken
-    })
-
     // Ensure Accept header is set (required by mcp-handler)
     const acceptHeader = req.headers.get('Accept')
     if (!acceptHeader || !acceptHeader.includes('application/json')) {


### PR DESCRIPTION
## What Does this PR Do?
- enable mcp in flowglad-next



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables MCP in flowglad-next. The MCP API route is now active in production and returns cleaner search results.

- **New Features**
  - Activates POST /api/mcp by removing the prod block; access remains protected via withMcpAuth and verifyToken.
  - Simplifies result formatting by removing similarity and path lines; keeps title, description, and markdown content.

<sup>Written for commit 50d0c05bdbb2447d11e418b60fe70519bd8b08c7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search/document results now show cleaner, simplified formatting by removing redundant metadata for improved readability.
  * Authentication flow streamlined into a single, consistent handler with enforced token verification to improve access control and reliability across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->