### PR TITLE
fix: customer select and actions in billing portal

### DIFF
--- a/platform/flowglad-next/src/db/databaseAuthentication.test.ts
+++ b/platform/flowglad-next/src/db/databaseAuthentication.test.ts
@@ -986,6 +986,7 @@ describe('Customer Role vs Merchant Role Authentication', () => {
       const result = await dbInfoForCustomerBillingPortal({
         betterAuthId: customerUser.betterAuthId!,
         organizationId: customerOrg.id,
+        customerId: customer1.id,
       })
 
       expect(result.jwtClaim.role).toBe('customer')
@@ -1010,6 +1011,7 @@ describe('Customer Role vs Merchant Role Authentication', () => {
       const customerResult = await dbInfoForCustomerBillingPortal({
         betterAuthId: customerUser.betterAuthId!,
         organizationId: customerOrg.id,
+        customerId: customer1.id,
       })
 
       expect(merchantResult.jwtClaim.role).toBe('merchant')
@@ -1029,6 +1031,7 @@ describe('Customer Role vs Merchant Role Authentication', () => {
         dbInfoForCustomerBillingPortal({
           betterAuthId: customerUser.betterAuthId!,
           organizationId: 'wrong_org_id',
+          customerId: customer1.id,
         })
       ).rejects.toThrow('Customer not found')
     })
@@ -1054,6 +1057,7 @@ describe('Customer Role vs Merchant Role Authentication', () => {
         dbInfoForCustomerBillingPortal({
           betterAuthId: userWithoutCustomer.betterAuthId!,
           organizationId: customerOrg.id,
+          customerId: 'non_existent_customer_id',
         })
       ).rejects.toThrow('Customer not found')
     })
@@ -1094,12 +1098,14 @@ describe('Customer Role vs Merchant Role Authentication', () => {
       const org1Result = await dbInfoForCustomerBillingPortal({
         betterAuthId: userWithMultipleCustomers.betterAuthId!,
         organizationId: customerOrg.id,
+        customerId: customerOrg1.id,
       })
 
       // Authenticate for org2
       const org2Result = await dbInfoForCustomerBillingPortal({
         betterAuthId: userWithMultipleCustomers.betterAuthId!,
         organizationId: differentOrg.id,
+        customerId: customerOrg2.id,
       })
 
       // Both should succeed but with different organization contexts
@@ -1115,6 +1121,7 @@ describe('Customer Role vs Merchant Role Authentication', () => {
       const liveModeResult = await dbInfoForCustomerBillingPortal({
         betterAuthId: customerUser.betterAuthId!,
         organizationId: customerOrg.id,
+        customerId: customer1.id,
       })
       expect(liveModeResult.livemode).toBe(true)
     })
@@ -1151,6 +1158,7 @@ describe('Customer Role vs Merchant Role Authentication', () => {
         dbInfoForCustomerBillingPortal({
           betterAuthId: testModeUser.betterAuthId!,
           organizationId: customerOrg.id,
+          customerId: testModeCustomer.id,
         })
       ).rejects.toThrow('Customer not found')
     })
@@ -1205,6 +1213,7 @@ describe('Customer Role vs Merchant Role Authentication', () => {
       const livemodeResult = await dbInfoForCustomerBillingPortal({
         betterAuthId: liveModeUser.betterAuthId!,
         organizationId: customerOrg.id,
+        customerId: liveModeCustomer.id,
       })
 
       expect(livemodeResult.userId).toBe(liveModeUser.id)
@@ -1227,6 +1236,7 @@ describe('Customer Role vs Merchant Role Authentication', () => {
       const customerAuth = await dbInfoForCustomerBillingPortal({
         betterAuthId: customerUser.betterAuthId!,
         organizationId: customerOrg.id,
+        customerId: customer1.id,
       })
 
       // Merchant should have session_id in some cases (for Secret API keys)
@@ -1257,6 +1267,7 @@ describe('Customer Role vs Merchant Role Authentication', () => {
       const customerAuth = await dbInfoForCustomerBillingPortal({
         betterAuthId: customerUser.betterAuthId!,
         organizationId: customerOrg.id,
+        customerId: customer1.id,
       })
 
       // Verify the role is strictly 'customer'
@@ -1282,6 +1293,7 @@ describe('Customer Role vs Merchant Role Authentication', () => {
       const customerAuth = await dbInfoForCustomerBillingPortal({
         betterAuthId: customerUser.betterAuthId!,
         organizationId: customerOrg.id,
+        customerId: customer1.id,
       })
 
       // Verify all required fields for RLS policies
@@ -1327,6 +1339,7 @@ describe('Customer Role vs Merchant Role Authentication', () => {
         dbInfoForCustomerBillingPortal({
           betterAuthId: unrelatedUser.betterAuthId!,
           organizationId: customerOrg.id,
+          customerId: nullUserCustomer.id,
         })
       ).rejects.toThrow('Customer not found')
     })

--- a/platform/flowglad-next/src/db/databaseAuthentication.ts
+++ b/platform/flowglad-next/src/db/databaseAuthentication.ts
@@ -14,10 +14,9 @@ import { JwtPayload } from 'jsonwebtoken'
 import { customers, customersSelectSchema } from './schema/customers'
 import { ApiKey } from './schema/apiKeys'
 import { parseUnkeyMeta } from '@/utils/unkey'
-import { auth, getSession } from '@/utils/auth'
+import { getSession } from '@/utils/auth'
 import { User } from 'better-auth'
 import { getCustomerBillingPortalOrganizationId } from '@/utils/customerBillingPortalState'
-import { headers } from 'next/headers'
 
 type SessionUser = Session['user']
 
@@ -265,10 +264,30 @@ export async function dbAuthInfoForBillingPortalApiKeyResult(
 export const requestingCustomerAndUser = async ({
   betterAuthId,
   organizationId,
+  customerId,
 }: {
   betterAuthId: string
   organizationId: string
+  customerId?: string
 }) => {
+  const whereConditions = [
+    eq(users.betterAuthId, betterAuthId),
+    eq(customers.organizationId, organizationId),
+    /**
+     * For now, only support granting access to livemode customers,
+     * so we can avoid unintentionally allowing customers to get access
+     * to test mode customers for the merchant who match their email.
+     *
+     * FIXME: support billing portal access for test mode customers specifically.
+     * This will require more sophisticated auth business logic.
+     */
+    eq(customers.livemode, true),
+  ]
+
+  if (customerId) {
+    whereConditions.push(eq(customers.id, customerId))
+  }
+
   const result = await db
     .select({
       customer: customers,
@@ -276,22 +295,9 @@ export const requestingCustomerAndUser = async ({
     })
     .from(customers)
     .innerJoin(users, eq(customers.userId, users.id))
-    .where(
-      and(
-        eq(users.betterAuthId, betterAuthId),
-        eq(customers.organizationId, organizationId),
-        /**
-         * For now, only support granting access to livemode customers,
-         * so we can avoid unintentionally allowing customers to get access
-         * to test mode customers for the merchant who match their email.
-         *
-         * FIXME: support billing portal access for test mode customers specifically.
-         * This will require more sophisticated auth business logic.
-         */
-        eq(customers.livemode, true)
-      )
-    )
+    .where(and(...whereConditions))
     .limit(1)
+
   return z
     .object({
       customer: customersSelectSchema,
@@ -304,13 +310,16 @@ export const requestingCustomerAndUser = async ({
 export const dbInfoForCustomerBillingPortal = async ({
   betterAuthId,
   organizationId,
+  customerId,
 }: {
   betterAuthId: string
   organizationId: string
+  customerId?: string
 }): Promise<DatabaseAuthenticationInfo> => {
   const [result] = await requestingCustomerAndUser({
     betterAuthId,
     organizationId,
+    customerId,
   })
   if (!result) {
     throw new Error('Customer not found')
@@ -344,9 +353,25 @@ export const dbInfoForCustomerBillingPortal = async ({
   }
 }
 
+/**
+ * Authenticates a webapp request for either merchant dashboard or customer billing portal.
+ *
+ * Determines the authentication context based on whether a customer organization ID
+ * is present in the billing portal cookie state:
+ * - If no customer organization ID: authenticates as merchant using focused membership
+ * - If customer organization ID exists: authenticates as customer for billing portal
+ *
+ * @param user - The Better Auth user making the request
+ * @param __testOnlyOrganizationId - Optional test organization ID override
+ * @param customerId - Optional customer ID for customer billing portal authentication.
+ *   When not provided, authenticates as the first customer found to enable RLS-based
+ *   customer listing (customer role can see all customers with the same userId).
+ * @returns Database authentication info with JWT claims and user context
+ */
 export async function databaseAuthenticationInfoForWebappRequest(
   user: User,
-  __testOnlyOrganizationId?: string | undefined
+  __testOnlyOrganizationId?: string | undefined,
+  customerId?: string
 ): Promise<DatabaseAuthenticationInfo> {
   const betterAuthId = user.id
   const customerOrganizationId =
@@ -354,47 +379,50 @@ export async function databaseAuthenticationInfoForWebappRequest(
       __testOrganizationId: __testOnlyOrganizationId,
     })
 
-  if (customerOrganizationId) {
-    return await dbInfoForCustomerBillingPortal({
-      betterAuthId: user.id,
-      organizationId: customerOrganizationId,
-    })
+  if (!customerOrganizationId) {
+    // Merchant dashboard authentication flow
+    const [focusedMembership] = await db
+      .select()
+      .from(memberships)
+      .innerJoin(users, eq(memberships.userId, users.id))
+      .where(and(eq(users.betterAuthId, betterAuthId)))
+      .orderBy(desc(memberships.focused))
+      .limit(1)
+    const userId = focusedMembership?.memberships.userId
+    const livemode = focusedMembership?.memberships.livemode ?? false
+    const jwtClaim = {
+      role: 'merchant',
+      sub: userId,
+      email: user.email,
+      user_metadata: {
+        id: userId,
+        user_metadata: {},
+        aud: 'stub',
+        email: user.email,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        role: 'merchant',
+        app_metadata: {
+          provider: '',
+        },
+      },
+      organization_id:
+        focusedMembership?.memberships.organizationId ?? '',
+      app_metadata: { provider: 'apiKey' },
+    }
+    return {
+      userId,
+      livemode,
+      jwtClaim,
+    }
   }
 
-  const [focusedMembership] = await db
-    .select()
-    .from(memberships)
-    .innerJoin(users, eq(memberships.userId, users.id))
-    .where(and(eq(users.betterAuthId, betterAuthId)))
-    .orderBy(desc(memberships.focused))
-    .limit(1)
-  const userId = focusedMembership?.memberships.userId
-  const livemode = focusedMembership?.memberships.livemode ?? false
-  const jwtClaim = {
-    role: 'merchant',
-    sub: userId,
-    email: user.email,
-    user_metadata: {
-      id: userId,
-      user_metadata: {},
-      aud: 'stub',
-      email: user.email,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-      role: 'merchant',
-      app_metadata: {
-        provider: '',
-      },
-    },
-    organization_id:
-      focusedMembership?.memberships.organizationId ?? '',
-    app_metadata: { provider: 'apiKey' },
-  }
-  return {
-    userId,
-    livemode,
-    jwtClaim,
-  }
+  // Customer billing portal authentication flow
+  return await dbInfoForCustomerBillingPortal({
+    betterAuthId: user.id,
+    organizationId: customerOrganizationId,
+    customerId,
+  })
 }
 
 export async function databaseAuthenticationInfoForApiKeyResult(
@@ -421,8 +449,9 @@ export async function databaseAuthenticationInfoForApiKeyResult(
 export async function getDatabaseAuthenticationInfo(params: {
   apiKey: string | undefined
   __testOnlyOrganizationId?: string
+  customerId?: string
 }): Promise<DatabaseAuthenticationInfo> {
-  const { apiKey, __testOnlyOrganizationId } = params
+  const { apiKey, __testOnlyOrganizationId, customerId } = params
   if (apiKey) {
     const verifyKeyResult = await keyVerify(apiKey)
     return await databaseAuthenticationInfoForApiKeyResult(
@@ -436,6 +465,7 @@ export async function getDatabaseAuthenticationInfo(params: {
   }
   return await databaseAuthenticationInfoForWebappRequest(
     sessionResult.user as User,
-    __testOnlyOrganizationId
+    __testOnlyOrganizationId,
+    customerId
   )
 }

--- a/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.integration.test.ts
+++ b/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.integration.test.ts
@@ -42,12 +42,8 @@ import {
   SubscriptionStatus,
   SubscriptionCancellationArrangement,
 } from '@/types'
-import type { ScheduleSubscriptionCancellationParams } from '@/subscriptions/schemas'
 import { adminTransaction } from '@/db/adminTransaction'
-import {
-  selectSubscriptionById,
-  updateSubscription,
-} from '@/db/tableMethods/subscriptionMethods'
+import { selectSubscriptionById } from '@/db/tableMethods/subscriptionMethods'
 import { selectPaymentMethodById } from '@/db/tableMethods/paymentMethodMethods'
 import { insertUser } from '@/db/tableMethods/userMethods'
 import core from '@/utils/core'
@@ -248,7 +244,9 @@ describe('Customer Billing Portal Router', () => {
       { timeout: 10000 },
       async () => {
         const ctx = createTestContext()
-        const input = {}
+        const input = {
+          customerId: customer.id,
+        }
 
         const result = await customerBillingPortalRouter
           .createCaller(ctx)
@@ -297,6 +295,7 @@ describe('Customer Billing Portal Router', () => {
       async () => {
         const ctx = createTestContext()
         const input = {
+          customerId: customer.id,
           invoicePagination: { page: 1, pageSize: 2 },
         }
 
@@ -353,6 +352,7 @@ describe('Customer Billing Portal Router', () => {
         newCustomerSetup.customer
       )
       const input = {
+        customerId: newCustomerSetup.customer.id,
         invoicePagination: { page: 1, pageSize: 10 },
       }
 
@@ -390,6 +390,7 @@ describe('Customer Billing Portal Router', () => {
 
         // Get page 2 with page size 5
         const input = {
+          customerId: customer.id,
           invoicePagination: { page: 2, pageSize: 5 },
         }
 
@@ -417,7 +418,7 @@ describe('Customer Billing Portal Router', () => {
       await expect(
         customerBillingPortalRouter
           .createCaller(ctxWithoutOrgId)
-          .getBilling({})
+          .getBilling({ customerId: customer.id })
       ).rejects.toThrow()
     })
   })
@@ -425,11 +426,12 @@ describe('Customer Billing Portal Router', () => {
   describe('cancelSubscription', () => {
     it('rejects immediate cancellation (not available to customers)', async () => {
       const ctx = createTestContext()
-      const input: ScheduleSubscriptionCancellationParams = {
+      const input = {
+        customerId: customer.id,
         id: subscription.id,
         cancellation: {
           timing: SubscriptionCancellationArrangement.Immediately,
-        },
+        } as const,
       }
 
       const error = await customerBillingPortalRouter
@@ -446,7 +448,8 @@ describe('Customer Billing Portal Router', () => {
 
     it('rejects future date cancellation (not available to customers)', async () => {
       const ctx = createTestContext()
-      const input: ScheduleSubscriptionCancellationParams = {
+      const input = {
+        customerId: customer.id,
         id: subscription.id,
         cancellation: {
           timing: SubscriptionCancellationArrangement.AtFutureDate,
@@ -471,12 +474,13 @@ describe('Customer Billing Portal Router', () => {
       { timeout: 30000 },
       async () => {
         const ctx = createTestContext()
-        const input: ScheduleSubscriptionCancellationParams = {
+        const input = {
+          customerId: customer.id,
           id: subscription.id,
           cancellation: {
             timing:
               SubscriptionCancellationArrangement.AtEndOfCurrentBillingPeriod,
-          },
+          } as const,
         }
 
         const result = await customerBillingPortalRouter
@@ -520,11 +524,12 @@ describe('Customer Billing Portal Router', () => {
       })
 
       const ctx = createTestContext()
-      const input: ScheduleSubscriptionCancellationParams = {
+      const input = {
+        customerId: customer.id,
         id: otherSubscription.id,
         cancellation: {
           timing: SubscriptionCancellationArrangement.Immediately,
-        },
+        } as const,
       }
 
       await expect(
@@ -536,12 +541,13 @@ describe('Customer Billing Portal Router', () => {
 
     it('handles non-existent subscription gracefully', async () => {
       const ctx = createTestContext()
-      const input: ScheduleSubscriptionCancellationParams = {
+      const input = {
+        customerId: customer.id,
         id: 'non_existent_subscription_id',
         cancellation: {
           timing:
             SubscriptionCancellationArrangement.AtEndOfCurrentBillingPeriod,
-        },
+        } as const,
       }
 
       await expect(
@@ -565,12 +571,13 @@ describe('Customer Billing Portal Router', () => {
       })
 
       const ctx = createTestContext()
-      const input: ScheduleSubscriptionCancellationParams = {
+      const input = {
+        customerId: customer.id,
         id: nonRenewingSubscription.id,
         cancellation: {
           timing:
             SubscriptionCancellationArrangement.AtEndOfCurrentBillingPeriod,
-        },
+        } as const,
       }
 
       const error = await customerBillingPortalRouter
@@ -599,12 +606,13 @@ describe('Customer Billing Portal Router', () => {
       })
 
       const ctx = createTestContext()
-      const input: ScheduleSubscriptionCancellationParams = {
+      const input = {
+        customerId: customer.id,
         id: canceledSubscription.id,
         cancellation: {
           timing:
             SubscriptionCancellationArrangement.AtEndOfCurrentBillingPeriod,
-        },
+        } as const,
       }
 
       const error = await customerBillingPortalRouter
@@ -633,12 +641,13 @@ describe('Customer Billing Portal Router', () => {
       })
 
       const ctx = createTestContext()
-      const input: ScheduleSubscriptionCancellationParams = {
+      const input = {
+        customerId: customer.id,
         id: expiredSubscription.id,
         cancellation: {
           timing:
             SubscriptionCancellationArrangement.AtEndOfCurrentBillingPeriod,
-        },
+        } as const,
       }
 
       const error = await customerBillingPortalRouter
@@ -718,7 +727,7 @@ describe('Customer Billing Portal Router', () => {
 
       const result = await customerBillingPortalRouter
         .createCaller(ctx)
-        .createAddPaymentMethodSession({})
+        .createAddPaymentMethodSession({ customerId: customer.id })
 
       expect(result).toMatchObject({
         sessionUrl: 'https://checkout.stripe.com/test-session-url',
@@ -764,7 +773,9 @@ describe('Customer Billing Portal Router', () => {
       await expect(
         customerBillingPortalRouter
           .createCaller(ctx)
-          .createAddPaymentMethodSession({})
+          .createAddPaymentMethodSession({
+            customerId: customerWithoutStripe.id,
+          })
       ).rejects.toThrow(TRPCError)
     })
 
@@ -792,7 +803,9 @@ describe('Customer Billing Portal Router', () => {
       await expect(
         customerBillingPortalRouter
           .createCaller(ctxWithoutCustomer)
-          .createAddPaymentMethodSession({})
+          .createAddPaymentMethodSession({
+            customerId: 'non_existent_customer_id',
+          })
       ).rejects.toThrow(TRPCError)
     })
   })
@@ -814,6 +827,7 @@ describe('Customer Billing Portal Router', () => {
 
         const ctx = createTestContext()
         const input = {
+          customerId: customer.id,
           paymentMethodId: additionalPaymentMethod.id,
         }
 
@@ -871,6 +885,7 @@ describe('Customer Billing Portal Router', () => {
 
       const ctx = createTestContext()
       const input = {
+        customerId: customer.id,
         paymentMethodId: otherPaymentMethod.id,
       }
 
@@ -884,6 +899,7 @@ describe('Customer Billing Portal Router', () => {
     it('handles non-existent payment method gracefully', async () => {
       const ctx = createTestContext()
       const input = {
+        customerId: customer.id,
         paymentMethodId: 'non_existent_payment_method_id',
       }
 
@@ -910,6 +926,7 @@ describe('Customer Billing Portal Router', () => {
 
         const ctx = createTestContext()
         const input = {
+          customerId: customer.id,
           paymentMethodId: newPaymentMethod.id,
         }
 
@@ -931,5 +948,153 @@ describe('Customer Billing Portal Router', () => {
         )
       }
     )
+  })
+
+  describe('customerId authorization edge cases', () => {
+    it('throws UNAUTHORIZED when customerId is valid but user does not have access', async () => {
+      // Create a different user and customer in the same organization
+      const otherUserAndCustomer = await setupUserAndCustomer({
+        organizationId: organization.id,
+        livemode: true,
+      })
+      const otherCustomer = otherUserAndCustomer.customer
+
+      // The middleware will query the database using the original user's ID
+      // and the other customer's ID. Since they don't match, the query will
+      // return no results and the middleware will throw UNAUTHORIZED.
+
+      const ctx = createTestContext()
+      const input = {
+        customerId: otherCustomer.id,
+      }
+
+      const error = await customerBillingPortalRouter
+        .createCaller(ctx)
+        .getBilling(input)
+        .catch((e) => e)
+
+      expect(error).toBeInstanceOf(TRPCError)
+      expect(error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('throws UNAUTHORIZED when customerId belongs to a different organization', async () => {
+      // Create a second organization with a customer
+      const otherOrgSetup = await setupOrg()
+      const otherOrganization = otherOrgSetup.organization
+
+      const otherOrgUserAndCustomer = await setupUserAndCustomer({
+        organizationId: otherOrganization.id,
+        livemode: true,
+      })
+      const otherOrgCustomer = otherOrgUserAndCustomer.customer
+
+      // The middleware will query the database using the original user's ID
+      // and the original organization ID (from beforeEach mock).
+      // Since the customer belongs to a different organization, the query will
+      // return no results and the middleware will throw UNAUTHORIZED.
+
+      const ctx = createTestContext()
+      const input = {
+        customerId: otherOrgCustomer.id,
+      }
+
+      const error = await customerBillingPortalRouter
+        .createCaller(ctx)
+        .getBilling(input)
+        .catch((e) => e)
+
+      expect(error).toBeInstanceOf(TRPCError)
+      expect(error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('throws UNAUTHORIZED when trying to cancel subscription for customer user does not have access to', async () => {
+      // Create a different user and customer with subscription in the same organization
+      const otherUserAndCustomer = await setupUserAndCustomer({
+        organizationId: organization.id,
+        livemode: true,
+      })
+      const otherCustomer = otherUserAndCustomer.customer
+
+      const otherPaymentMethod = await setupPaymentMethod({
+        organizationId: organization.id,
+        customerId: otherCustomer.id,
+        livemode: true,
+        default: true,
+        stripePaymentMethodId: `pm_${core.nanoid()}`,
+        type: PaymentMethodType.Card,
+      })
+
+      const otherSubscription = await setupSubscription({
+        organizationId: organization.id,
+        customerId: otherCustomer.id,
+        paymentMethodId: otherPaymentMethod.id,
+        defaultPaymentMethodId: otherPaymentMethod.id,
+        priceId: price.id,
+        status: SubscriptionStatus.Active,
+        livemode: true,
+        currentBillingPeriodStart:
+          Date.now() - 15 * 24 * 60 * 60 * 1000,
+        currentBillingPeriodEnd:
+          Date.now() + 15 * 24 * 60 * 60 * 1000,
+      })
+
+      // The middleware will query the database using the original user's ID
+      // and the other customer's ID. Since they don't match, the query will
+      // return no results and the middleware will throw UNAUTHORIZED.
+
+      const ctx = createTestContext()
+      const input = {
+        customerId: otherCustomer.id,
+        id: otherSubscription.id,
+        cancellation: {
+          timing:
+            SubscriptionCancellationArrangement.AtEndOfCurrentBillingPeriod,
+        } as const,
+      }
+
+      const error = await customerBillingPortalRouter
+        .createCaller(ctx)
+        .cancelSubscription(input)
+        .catch((e) => e)
+
+      expect(error).toBeInstanceOf(TRPCError)
+      expect(error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('throws UNAUTHORIZED when trying to set default payment method for customer user does not have access to', async () => {
+      // Create a different user and customer with payment method in the same organization
+      const otherUserAndCustomer = await setupUserAndCustomer({
+        organizationId: organization.id,
+        livemode: true,
+      })
+      const otherCustomer = otherUserAndCustomer.customer
+
+      const otherPaymentMethod = await setupPaymentMethod({
+        organizationId: organization.id,
+        customerId: otherCustomer.id,
+        livemode: true,
+        default: false,
+        stripePaymentMethodId: `pm_${core.nanoid()}`,
+        type: PaymentMethodType.Card,
+      })
+
+      // The middleware will query the database using the original user's ID
+      // and the other customer's ID. Since they don't match, the query will
+      // return no results and the middleware will throw UNAUTHORIZED.
+
+      const ctx = createTestContext()
+      const input = {
+        customerId: otherCustomer.id,
+        paymentMethodId: otherPaymentMethod.id,
+      }
+
+      const error = await customerBillingPortalRouter
+        .createCaller(ctx)
+        .setDefaultPaymentMethod(input)
+        .catch((e) => e)
+
+      expect(error).toBeInstanceOf(TRPCError)
+      expect(error.code).toBe('UNAUTHORIZED')
+    })
   })
 })

--- a/platform/flowglad-next/src/server/trpc.ts
+++ b/platform/flowglad-next/src/server/trpc.ts
@@ -8,12 +8,10 @@ import { createTracingMiddleware } from './tracingMiddleware'
 import { FeatureFlag } from '@/types'
 import { hasFeatureFlag } from '@/utils/organizationHelpers'
 import { adminTransaction } from '@/db/adminTransaction'
-import {
-  selectCustomerAndOrganizationByCustomerWhere,
-  selectCustomers,
-} from '@/db/tableMethods/customerMethods'
+import { selectCustomerAndOrganizationByCustomerWhere } from '@/db/tableMethods/customerMethods'
 import { getCustomerBillingPortalOrganizationId } from '@/utils/customerBillingPortalState'
 import { IS_DEV } from '@/utils/core'
+import { z } from 'zod'
 
 // Create tracing middleware factory
 const tracingMiddlewareFactory = createTracingMiddleware()
@@ -29,6 +27,18 @@ const baseProcedure = t.procedure.use(tracingMiddleware)
 // Public procedure with tracing
 export const publicProcedure = baseProcedure
 
+/**
+ * Authentication middleware for general webapp and API key access.
+ *
+ * Supports two authentication modes:
+ * 1. API key authentication: If `isApi` is true, allows API key access
+ * 2. User authentication: Requires a logged-in user
+ *
+ * Uses organization from context (set by middleware/auth from user's focused membership).
+ *
+ * @returns Context with user (or API auth), organization, and environment info
+ * @throws {TRPCError} UNAUTHORIZED if no user and not API key request
+ */
 const isAuthed = t.middleware(({ next, ctx }) => {
   const { isApi, environment, apiKey } = ctx as TRPCApiContext
   const livemode = environment === 'live'
@@ -61,78 +71,78 @@ const isAuthed = t.middleware(({ next, ctx }) => {
   })
 })
 
-const isCustomerAuthed = t.middleware(async ({ next, ctx }) => {
-  const { environment } = ctx as TRPCApiContext
-  const livemode = environment === 'live'
-  const user = (ctx as TRPCContext).user
-  if (!user) {
-    throw new TRPCError({ code: 'UNAUTHORIZED' })
-  }
-  const organizationId =
-    await getCustomerBillingPortalOrganizationId()
-
-  const [customerAndOrganization] = await adminTransaction(
-    async ({ transaction }) => {
-      return selectCustomerAndOrganizationByCustomerWhere(
-        {
-          userId: user.id,
-          organizationId,
-        },
-        transaction
-      )
-    }
-  )
-
-  if (!customerAndOrganization) {
-    throw new TRPCError({ code: 'UNAUTHORIZED' })
-  }
-
-  return next({
-    ctx: {
-      user,
-      customer: customerAndOrganization.customer,
-      organization: customerAndOrganization.organization,
-      path: (ctx as TRPCContext).path,
-      environment,
-      organizationId,
-      livemode,
-    },
-  })
-})
-
-const isCustomerBillingAuthed = t.middleware(
-  async ({ next, ctx }) => {
-    const { isApi, environment } = ctx as TRPCApiContext
+/**
+ * Authentication middleware for customer billing portal operations.
+ *
+ * Authenticates logged-in users and validates their access to customer profiles.
+ * Supports multi-customer scenarios where users can have multiple customer profiles
+ * within the same organization.
+ *
+ * The middleware:
+ * - Requires a logged-in user (no API key support)
+ * - Gets the organization ID from the billing portal cookie state
+ * - Requires `customerId` in the request input
+ * - Queries the database to find a matching customer for the user and organization
+ * - Validates the user has access to that specific customer
+ * - Adds the customer and organization to the context for use in procedures
+ *
+ * @param getRawInput - Used to extract required `customerId` from request input
+ * @returns Context with user, customer, organization, and environment info
+ * @throws {TRPCError} UNAUTHORIZED if no user or user doesn't have access to customer
+ */
+const isCustomerAuthed = t.middleware(
+  async ({ next, ctx, getRawInput }) => {
+    const { environment } = ctx as TRPCApiContext
     const livemode = environment === 'live'
     const user = (ctx as TRPCContext).user
     if (!user) {
       throw new TRPCError({ code: 'UNAUTHORIZED' })
     }
+    const organizationId =
+      await getCustomerBillingPortalOrganizationId()
 
-    const [customer] = await adminTransaction(
+    // Extract customerId from raw input to populate ctx.customer and ctx.organization.
+    // Middleware runs before input validation, so we must use getRawInput() instead of validated input.
+    const rawInput = await getRawInput()
+    const customerIdSchema = z.object({
+      customerId: z.string(),
+    })
+
+    const parsed = customerIdSchema.safeParse(rawInput)
+    if (!parsed.success) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'customerId is required',
+      })
+    }
+
+    const customerId = parsed.data.customerId
+
+    const [customerAndOrganization] = await adminTransaction(
       async ({ transaction }) => {
-        return selectCustomers(
+        return selectCustomerAndOrganizationByCustomerWhere(
           {
             userId: user.id,
-            organizationId: (ctx as TRPCContext).organizationId,
+            organizationId,
+            id: customerId,
           },
           transaction
         )
       }
     )
 
-    if (!customer) {
+    if (!customerAndOrganization) {
       throw new TRPCError({ code: 'UNAUTHORIZED' })
     }
 
     return next({
       ctx: {
         user,
-        customer,
+        customer: customerAndOrganization.customer,
+        organization: customerAndOrganization.organization,
         path: (ctx as TRPCContext).path,
         environment,
-        organizationId: (ctx as TRPCContext).organizationId,
-        organization: (ctx as TRPCContext).organization,
+        organizationId,
         livemode,
       },
     })
@@ -154,9 +164,6 @@ export const devOnlyProcedure = baseProcedure.use(({ next, ctx }) => {
 
 export const customerProtectedProcedure =
   baseProcedure.use(isCustomerAuthed)
-export const customerBillingProtectedProcedure = baseProcedure.use(
-  isCustomerBillingAuthed
-)
 
 export const featureFlaggedProcedure = (featureFlag: FeatureFlag) => {
   return protectedProcedure.use(({ next, ctx }) => {


### PR DESCRIPTION
Fixes an issue in the billing portal where you couldn't select customers or take actions in the billing portal by scoping them to a specific customer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes all billing portal queries and actions to the selected customer to fix selection and unauthorized access. Adds strict customer authorization and passes customerId through the UI and router.

- **Bug Fixes**
  - Require customerId in getBilling, cancelSubscription, add payment method, setDefaultPaymentMethod, and checkout sessions.
  - New TRPC customer auth middleware validates customerId against the logged-in user and org; removes old middleware.
  - Database auth and transaction helpers now carry customerId so RLS runs in the correct customer context (livemode only).
  - Cancel subscription blocks immediate/future-date timing for customers and prevents re-scheduling if already scheduled.
  - Frontend passes customerId to queries/mutations and refreshes via trpc utils.invalidate.

- **Migration**
  - Client calls to customer billing procedures must include customerId.
  - Use trpc.useUtils().customerBillingPortal.getBilling.invalidate({ customerId }) after mutations to refresh data.
  - Customer list fetch uses protectedProcedure; ensure the billing portal cookie has organizationId set.

<sup>Written for commit 93a9c1d8c5a909de999ba675a1d03b1ed4bcc989. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customer-specific scoping for billing inquiries, payment methods, and subscription management.

* **Bug Fixes**
  * Enhanced authorization validation to prevent unauthorized cross-customer access to billing operations.

* **Tests**
  * Added authorization edge case tests for customer isolation in billing portal operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->