### PR TITLE
feat: integrate customer subscription cancellation notification

### DIFF
--- a/platform/flowglad-next/src/subscriptions/cancelSubscription.ts
+++ b/platform/flowglad-next/src/subscriptions/cancelSubscription.ts
@@ -366,9 +366,19 @@ export const cancelSubscriptionImmediately = async (
     updatedSubscription = result
   }
   await reassignDefaultSubscription(updatedSubscription, transaction)
-  await idempotentSendCustomerSubscriptionCanceledNotification(
-    updatedSubscription.id
-  )
+  try {
+    await idempotentSendCustomerSubscriptionCanceledNotification(
+      updatedSubscription.id
+    )
+  } catch (error) {
+    console.error(
+      'Failed to send customer subscription canceled notification',
+      {
+        subscriptionId: updatedSubscription.id,
+        error,
+      }
+    )
+  }
   return {
     result: updatedSubscription,
     eventsToInsert: [


### PR DESCRIPTION
## What Does this PR Do?

Integrates the customer subscription cancellation notification into the subscription cancellation flow. When a subscription is canceled immediately, the system now sends a notification email to the customer informing them that their subscription has been canceled and there will be no further charges. This completes the customer feedback loop by confirming the cancellation action.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send a customer email when a subscription is canceled immediately, confirming the cancellation and that billing stops. This closes the feedback loop in the cancellation flow.

- **New Features**
  - Calls idempotentSendCustomerSubscriptionCanceledNotification with the subscription ID after cancellation and default subscription reassignment.

- **Bug Fixes**
  - Wraps the notification call in try/catch so failures don't block cancellation; logs errors for debugging.

<sup>Written for commit b4389fd3f31ff8eefbc3d72d344d396d247b755d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customers now receive direct notification when their subscription is canceled, alongside organization-level notices.
  * Cancellation notifications are sent at additional points during the immediate cancellation flow to improve delivery reliability.
  * Notification delivery failures are logged for monitoring and troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->