### PR TITLE
fix get billing portal procedure currentSubscription schema

### DIFF
--- a/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.ts
+++ b/platform/flowglad-next/src/server/routers/customerBillingPortalRouter.ts
@@ -88,8 +88,9 @@ const getBillingProcedure = customerProtectedProcedure
         .describe(
           'The current subscriptions for the customer. By default, customers can only have one active subscription at a time. This will only return multiple subscriptions if you have enabled multiple subscriptions per customer.'
         ),
-      currentSubscription:
-        richSubscriptionClientSelectSchema.describe(
+      currentSubscription: richSubscriptionClientSelectSchema
+        .optional()
+        .describe(
           'The most recently created current subscription for the customer. If createdAt timestamps tie, the most recently updated subscription will be returned. If updatedAt also ties, subscription id is used as the final tiebreaker.'
         ),
       catalog: pricingModelWithProductsAndUsageMetersSchema,
@@ -165,9 +166,11 @@ const getBillingProcedure = customerProtectedProcedure
       currentSubscriptions: currentSubscriptions.map((item) =>
         richSubscriptionClientSelectSchema.parse(item)
       ),
-      currentSubscription: richSubscriptionClientSelectSchema.parse(
-        currentSubscription
-      ),
+      currentSubscription: currentSubscription
+        ? richSubscriptionClientSelectSchema.parse(
+            currentSubscription
+          )
+        : undefined,
       purchases,
       subscriptions,
       catalog: pricingModel,


### PR DESCRIPTION
## What Does this PR Do?
- loosen currentSubscription schema in get billing portal procedure to prevent zod validation error and unblock customers from accessing their portal when they don't have a subscription with status current
(for context tembo added this `currentSubscription` to the `getBillingProcedure` of `customerBillingPortalRouter.ts` as part of the add currentSubscription [PR](https://github.com/flowglad/flowglad/pull/824) and made `currentSubscription` required for billing portal. this current PR makes it optional which would match the behavior of `getCustomerBilling` in `customersRouter.ts`)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make currentSubscription optional in the billing portal response to stop Zod validation errors when a customer has no current subscription. This unblocks access to the billing portal and matches getCustomerBilling behavior.

- **Bug Fixes**
  - Marked currentSubscription as optional in getBillingProcedure.
  - Parse currentSubscription only when present; return undefined otherwise.

<sup>Written for commit 72e6a824101d58f26b15235fc74698d8081f7824. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing portal to properly handle customers without active subscriptions by making subscription data optional and conditionally processing it only when available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->