### PR TITLE
fix: quick modification to billing run retires using attempt number

### DIFF
--- a/platform/flowglad-next/src/subscriptions/billingRunHelpers.test.ts
+++ b/platform/flowglad-next/src/subscriptions/billingRunHelpers.test.ts
@@ -858,14 +858,12 @@ describe('billingRunHelpers', async () => {
   describe('Billing Run Retry Logic', () => {
     it('should schedule billing run retries according to the defined schedule', async () => {
       const retryTimesInDays = [3, 5, 5]
-      let allBillingRunsForPeriod: BillingRun.Record[] = [billingRun]
+      let currentBillingRun: BillingRun.Record = billingRun
 
       for (let i = 0; i < retryTimesInDays.length; i++) {
         const daysToRetry = retryTimesInDays[i]
-        const retryInsert = constructBillingRunRetryInsert(
-          billingRun,
-          allBillingRunsForPeriod
-        )
+        const retryInsert =
+          constructBillingRunRetryInsert(currentBillingRun)
 
         expect(retryInsert).toBeDefined()
         const expectedRetryDate =
@@ -875,15 +873,16 @@ describe('billingRunHelpers', async () => {
           -3 // tolerance of 1 second
         )
 
-        // Add the new retry run to the list for the next iteration
-        allBillingRunsForPeriod.push({
-          ...billingRun,
+        // Use the retry run for the next iteration
+        currentBillingRun = {
+          ...currentBillingRun,
           ...(retryInsert as BillingRun.Insert),
           id: `retry-run-${i}`,
           createdAt: Date.now(),
           updatedAt: Date.now(),
           status: retryInsert!.status,
-        } as BillingRun.Record)
+          attemptNumber: retryInsert!.attemptNumber,
+        } as BillingRun.Record
       }
     })
 


### PR DESCRIPTION
There was an issue where we were gathering all billing runs for a given billing period when attempting a billing run retry. Now we can just use the attempt number that exists inside of the billing runs schema avoiding any issues that may arise from the new billing run creation in adjust subscription.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplify billing run retry scheduling by using attemptNumber on the current run to compute the next retry and enforce max attempts. Removes period-wide filtering, preventing miscounted attempts and premature stops.

<sup>Written for commit efc1e37af70eedec96a4ebefb4d25c52f108f1de. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected counting of prior billing attempts so next retries are scheduled accurately.
  * Scheduled retry runs are now persisted reliably when applicable.
  * Retry entries consistently include the computed attempt number to prevent mis-scheduling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->