### PR TITLE
fix: add unit tests for subscription-card

### DIFF
--- a/platform/flowglad-next/src/registry/base/subscription-card/cancel-subscription-dialog.tsx
+++ b/platform/flowglad-next/src/registry/base/subscription-card/cancel-subscription-dialog.tsx
@@ -17,7 +17,6 @@ export function CancelSubscriptionDialog({
   isOpen,
   onOpenChange,
   subscriptionId,
-  subscriptionName,
   currentPeriodEnd,
   onConfirm,
   loading = false,

--- a/platform/flowglad-next/src/registry/base/subscription-card/subscription-card.test.tsx
+++ b/platform/flowglad-next/src/registry/base/subscription-card/subscription-card.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SubscriptionCard } from './subscription-card'
+import type { Subscription } from './types'
+
+describe('SubscriptionCard - Cancellation Button Conditional Logic', () => {
+  const baseSubscription: Subscription = {
+    id: 'sub_123',
+    name: 'Test Subscription',
+    status: 'active',
+    cancelAtPeriodEnd: false,
+    currency: 'usd',
+    items: [],
+  }
+
+  describe('Default plan subscription - button should be hidden', () => {
+    it('should not render cancellation button when onCancel is undefined', () => {
+      render(
+        <SubscriptionCard
+          subscription={baseSubscription}
+          onCancel={undefined}
+        />
+      )
+
+      // SubscriptionActions should not be rendered when onCancel is undefined
+      expect(
+        screen.queryByText('Cancel Subscription')
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Non-default plan subscription - button should be shown', () => {
+    it('should render cancellation button when onCancel is provided', () => {
+
+      render(
+        <SubscriptionCard
+          subscription={baseSubscription}
+          onCancel={async () => {}}
+        />
+      )
+
+      // SubscriptionActions should be rendered when onCancel is provided
+      expect(
+        screen.getByText('Cancel Subscription')
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('Canceled subscription - button should be hidden', () => {
+    it('should not render cancellation button when subscription is canceled, even if onCancel is provided', () => {
+      const canceledSubscription = {
+        ...baseSubscription,
+        status: 'canceled' as const,
+      }
+
+      render(
+        <SubscriptionCard
+          subscription={canceledSubscription}
+          onCancel={async () => {}}
+        />
+      )
+
+      // SubscriptionActions should not be rendered for canceled subscriptions
+      // even when onCancel is provided, because canCancel checks status
+      expect(
+        screen.queryByText('Cancel Subscription')
+      ).not.toBeInTheDocument()
+    })
+  })
+})

--- a/platform/flowglad-next/src/scripts/validate-registry.ts
+++ b/platform/flowglad-next/src/scripts/validate-registry.ts
@@ -432,6 +432,11 @@ class RegistryValidator {
           continue
         }
 
+        // Skip test files as they don't need to be in the registry
+        if (entry.name.endsWith('.test.tsx')) {
+          continue
+        }
+
         if (!referencedFiles.has(relPath)) {
           this.errors.push({
             type: 'warning',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added unit tests for SubscriptionCard to verify the cancel button shows only when onCancel is provided and hides for canceled subscriptions. Updated the registry validator to ignore .test.tsx files and removed an unused prop from CancelSubscriptionDialog.

<sup>Written for commit 45a263a45443bf7e28b71de613a07abfe962e626. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for subscription card cancellation button visibility logic across various subscription states.

* **Chores**
  * Removed unused parameter from subscription dialog component.
  * Improved registry validation to properly exclude test files from orphan checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->