### PR TITLE
fix safari file drop error

### DIFF
--- a/platform/flowglad-next/src/components/FileInput.tsx
+++ b/platform/flowglad-next/src/components/FileInput.tsx
@@ -272,6 +272,8 @@ const FileInput: React.FC<FileInputProps> = ({
           setIsDragging(false)
         }}
         onDrop={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
           const files = e.dataTransfer.files
           if (files && files.length > 0) {
             handleFileChange({


### PR DESCRIPTION
## What Does this PR Do?
- fix file drop error on safari, so user can upload files via drag and drop on safari

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Safari drag-and-drop uploads so files are handled correctly instead of triggering the browser’s default behavior.

Added e.preventDefault() and e.stopPropagation() to the FileInput onDrop handler to ensure dropped files are processed.

<sup>Written for commit 3b5a81318f835e0ecad772f85e2b737e1a781918. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file drag-and-drop behavior to prevent unwanted browser default actions, ensuring smoother file input handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->