### PR TITLE
update imports to get types from flowglad/shared

### DIFF
--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -13,8 +13,7 @@
       "paths": {
         "@flowglad/react": ["../react/src/index.ts"],
         "@flowglad/shared": ["../shared/src/index.ts"],
-        "@flowglad/server": ["../server/src/index.ts"],
-        "@flowglad/types": ["../types/src/index.ts"]
+        "@flowglad/server": ["../server/src/index.ts"]
       }
     },
     "include": ["src"]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,7 +24,6 @@
     "zod": "4.1.5"
   },
   "devDependencies": {
-    "@flowglad/types": "workspace:*",
     "@types/autoprefixer": "^10.2.0",
     "@types/react": "18.3.12",
     "autoprefixer": "^10.4.18",

--- a/packages/react/src/FlowgladContext.tsx
+++ b/packages/react/src/FlowgladContext.tsx
@@ -12,13 +12,11 @@ import {
   type BillingWithChecks,
   constructGetProduct,
   constructGetPrice,
+  type CustomerBillingDetails,
+  type CreateProductCheckoutSessionParams,
 } from '@flowglad/shared'
 import type { Flowglad } from '@flowglad/node'
 import { validateUrl } from './utils'
-import type {
-  CreateProductCheckoutSessionParams,
-  CustomerBillingDetails,
-} from '@flowglad/types'
 import { devError } from './lib/utils'
 
 export type FrontendProductCreateCheckoutSessionParams =

--- a/packages/react/src/FlowgladProvider.tsx
+++ b/packages/react/src/FlowgladProvider.tsx
@@ -9,7 +9,7 @@ import {
   RequestConfig,
 } from './FlowgladContext'
 import { validateUrl } from './utils'
-import { CustomerBillingDetails } from '@flowglad/types'
+import { CustomerBillingDetails } from '@flowglad/shared'
 
 const queryClient = new QueryClient()
 

--- a/packages/react/src/lib/utils.ts
+++ b/packages/react/src/lib/utils.ts
@@ -1,5 +1,5 @@
 import { format } from 'date-fns'
-import { CurrencyCode } from '@flowglad/types'
+import { CurrencyCode } from '@flowglad/shared'
 import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,6 +1,6 @@
 import Flowglad from '@flowglad/node'
 
-import { Subscription } from '@flowglad/types'
+import { Subscription } from '@flowglad/shared'
 
 export type SubscriptionCardSubscription = Pick<
   Subscription,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@flowglad/shared": "workspace:*",
-    "@flowglad/types": "workspace:*",
     "@flowglad/node": "0.23.0",
     "zod": "4.1.5"
   },

--- a/packages/server/src/FlowgladServer.ts
+++ b/packages/server/src/FlowgladServer.ts
@@ -14,12 +14,12 @@ import {
   createActivateSubscriptionCheckoutSessionSchema,
   createAddPaymentMethodCheckoutSessionSchema,
   createProductCheckoutSessionSchema,
+  type CreateProductCheckoutSessionParams,
 } from '@flowglad/shared'
 import {
   type CoreCustomerUser,
   type FlowgladServerSessionParams,
 } from './types'
-import type { CreateProductCheckoutSessionParams } from '@flowglad/types'
 import { Flowglad as FlowgladNode } from '@flowglad/node'
 import { getSessionFromParams } from './serverUtils'
 


### PR DESCRIPTION
## What Does this PR Do?
- change imports from flowglad/types to use flowglad/shared

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch all type imports from @flowglad/types to @flowglad/shared to consolidate SDK types. Removes the @flowglad/types dependency and updates path aliases.

- **Refactors**
  - Replaced type imports in React and Server (CustomerBillingDetails, CurrencyCode, Subscription, CreateProductCheckoutSessionParams) to use @flowglad/shared.
  - No API changes; compile-time only.

- **Dependencies**
  - Removed @flowglad/types from react and server package.json.
  - Dropped the @flowglad/types path alias from nextjs tsconfig.

<sup>Written for commit 1c9cf5a92011470a321f2c0aa23cdf6e074b6652. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated internal type definitions and reorganized module dependencies across packages to streamline codebase structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->