### PR TITLE
fix stripe connect redirect issue on safari

### DIFF
--- a/platform/flowglad-next/src/components/forms/RequestStripeConnectOnboardingLinkModal.tsx
+++ b/platform/flowglad-next/src/components/forms/RequestStripeConnectOnboardingLinkModal.tsx
@@ -1,10 +1,22 @@
-import FormModal from './FormModal'
+'use client'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { trpc } from '@/app/_trpc/client'
 import {
   Country,
   requestStripeConnectOnboardingLinkInputSchema,
 } from '@/db/schema/countries'
 import RequestStripeConnectOnboardingLinkFormFields from '@/components/forms/RequestStripeConnectOnboardingLinkFormFields'
+import { FormProvider, useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import ErrorLabel from '@/components/ErrorLabel'
 
 const RequestStripeConnectOnboardingLinkModal = ({
   isOpen,
@@ -17,28 +29,78 @@ const RequestStripeConnectOnboardingLinkModal = ({
 }) => {
   const requestStripeConnectOnboardingLink =
     trpc.organizations.requestStripeConnect.useMutation()
-  return (
-    <FormModal
-      title="Set up Stripe"
-      onSubmit={async (data) => {
-        const { onboardingLink } =
-          await requestStripeConnectOnboardingLink.mutateAsync(data)
-        window.location.href = onboardingLink
-      }}
-      formSchema={requestStripeConnectOnboardingLinkInputSchema}
-      defaultValues={{
-        CountryId: countries.find(
-          (country) => country.name === 'United States'
-        )?.id!,
-      }}
-      isOpen={isOpen}
-      setIsOpen={setIsOpen}
-      submitButtonText="Continue to Stripe"
+
+  const form = useForm<
+    z.infer<typeof requestStripeConnectOnboardingLinkInputSchema>
+  >({
+    resolver: zodResolver(
+      requestStripeConnectOnboardingLinkInputSchema
+    ),
+    defaultValues: {
+      CountryId: countries.find(
+        (country) => country.name === 'United States'
+      )?.id!,
+    },
+  })
+
+  const onSubmit = async (
+    data: z.infer<
+      typeof requestStripeConnectOnboardingLinkInputSchema
     >
-      <RequestStripeConnectOnboardingLinkFormFields
-        countries={countries}
-      />
-    </FormModal>
+  ) => {
+    try {
+      const { onboardingLink } =
+        await requestStripeConnectOnboardingLink.mutateAsync(data)
+      // Redirect to Stripe
+      window.location.href = onboardingLink
+    } catch (error) {
+      form.setError('root', {
+        message: (error as Error).message,
+      })
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Set up Stripe</DialogTitle>
+        </DialogHeader>
+        <FormProvider {...form}>
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="space-y-4"
+          >
+            <div className="flex flex-col gap-6">
+              <RequestStripeConnectOnboardingLinkFormFields
+                countries={countries}
+              />
+            </div>
+            <div className="text-left">
+              <ErrorLabel error={form.formState.errors.root} />
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => {
+                  form.reset()
+                  setIsOpen(false)
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={form.formState.isSubmitting}
+              >
+                Continue to Stripe
+              </Button>
+            </DialogFooter>
+          </form>
+        </FormProvider>
+      </DialogContent>
+    </Dialog>
   )
 }
 


### PR DESCRIPTION
## What Does this PR Do?
- fix stripe connect redirect issue on safari by using dialog directly instead of form modal (which has router.refresh call that cancels the redirect)

https://github.com/user-attachments/assets/e677000a-301a-417d-a6e4-b5af065db1b7



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Stripe Connect onboarding redirect failing on Safari by replacing the FormModal with a client-side dialog so no router.refresh cancels the redirect.

- **Bug Fixes**
  - Redirect to Stripe now completes reliably on Safari using window.location.href after the mutation.

- **Refactors**
  - Replaced FormModal with Dialog, react-hook-form, and zod resolver.
  - Added error display and a Cancel button that resets the form and closes the dialog.

<sup>Written for commit 07c3f8ee9944f63df0e1436305bb106aa798cf29. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and display in the Stripe Connect onboarding modal
  * Fixed cancel button functionality

* **Refactor**
  * Enhanced form validation with better user feedback
  * Submit button now disabled during processing to prevent duplicate requests

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->