### PR TITLE
add deprecated message

### DIFF
--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,54 @@
+# ⚠️ DEPRECATED: @flowglad/types
+
+> **This package is deprecated and will no longer receive updates.**
+>
+> All type definitions have been migrated to **[@flowglad/shared](https://www.npmjs.com/package/@flowglad/shared)**.
+
+## Migration Guide
+
+Please update your imports from `@flowglad/types` to `@flowglad/shared`:
+
+### Before
+```typescript
+import { 
+  CreateProductCheckoutSessionParams,
+  Price,
+  Product,
+  Subscription,
+  Customer
+} from '@flowglad/types'
+```
+
+### After
+```typescript
+import { 
+  CreateProductCheckoutSessionParams,
+  Price,
+  Product,
+  Subscription,
+  Customer
+} from '@flowglad/shared'
+```
+
+## Why was this deprecated?
+
+To improve maintainability and reduce package fragmentation, we've consolidated all type definitions into the `@flowglad/shared` package. This provides:
+
+- **Single source of truth** for all Flowglad types
+- **Better organization** with types in a dedicated subfolder
+- **Simplified dependency management** across SDK packages
+- **Reduced bundle sizes** by eliminating duplicate type definitions
+
+## Timeline
+
+- **Last stable version**: 0.13.0
+- **Deprecation date**: December 2025
+- **Support status**: No further updates planned
+
+## Need Help?
+
+If you encounter any issues during migration:
+- Check the [@flowglad/shared documentation](https://github.com/flowglad/flowglad/tree/main/packages/shared)
+- Open an issue on [GitHub](https://github.com/flowglad/flowglad/issues)
+- Join our [Discord community](https://discord.com/servers/flowglad-1273695198639161364)
+

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@flowglad/types",
   "version": "0.13.0",
+  "deprecated": "This package is deprecated. Use @flowglad/shared instead. All type definitions have been moved to @flowglad/shared.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,15 @@
+// ⚠️ DEPRECATED: This package is deprecated. Use @flowglad/shared instead.
+// All type definitions have been moved to @flowglad/shared.
+// See: https://github.com/flowglad/flowglad/tree/main/packages/shared
+if (typeof console !== 'undefined' && console.warn) {
+  console.warn(
+    '\x1b[33m%s\x1b[0m',
+    '[@flowglad/types] DEPRECATED: This package is deprecated and will no longer receive updates. ' +
+      'Please migrate to @flowglad/shared. ' +
+      'See: https://github.com/flowglad/flowglad/tree/main/packages/shared'
+  )
+}
+
 export * from './paymentMethod'
 export * from './subscription'
 export * from './invoice'


### PR DESCRIPTION
## What Does this PR Do?
- add deprecation messages in the types sdk

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecated @flowglad/types and added clear guidance to migrate to @flowglad/shared. Includes a console warning, package deprecation flag, and a README with a short migration guide.

- **Migration**
  - Replace imports from @flowglad/types to @flowglad/shared.
  - See https://github.com/flowglad/flowglad/tree/main/packages/shared for details.

<sup>Written for commit 0d516cd4c32e5f9a4bcdeac26a4aa31b24ba9511. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecation Notice**
  * Package marked as deprecated; type definitions migrating to @flowglad/shared.
  * Migration guide added with import examples and rationale.
  * Last stable release: 0.13.0; full deprecation scheduled for Dec 2025.
  * Console warning issued on module load; support resources available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->