### PR TITLE
remove invalid cache input, setup bun should have caching enabled by …

### DIFF
--- a/.github/workflows/base-ci-cd.yml
+++ b/.github/workflows/base-ci-cd.yml
@@ -25,7 +25,6 @@ jobs:
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: '1.3.1'
-          cache: true
       - name: Install dependencies
         run: bun run install-packages --no-progress
       - name: Run linting and typechecking
@@ -47,7 +46,6 @@ jobs:
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: '1.3.1'
-          cache: true
       - name: Install dependencies
         run: bun run install-packages --no-progress
       - name: Generate OpenAPI documentation
@@ -94,7 +92,6 @@ jobs:
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: '1.3.1'
-          cache: true
       - name: Install dependencies
         run: bun install --no-progress
       - name: Run build (all packages)

--- a/.github/workflows/build-and-deploy-flowglad-next.yml
+++ b/.github/workflows/build-and-deploy-flowglad-next.yml
@@ -40,7 +40,6 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: '1.2.14'
-          cache: true
 
       - name: Install dependencies
         run: bun run install-packages --no-progress

--- a/.github/workflows/flowglad-next-sharded-unit-tests.yml
+++ b/.github/workflows/flowglad-next-sharded-unit-tests.yml
@@ -39,7 +39,6 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: '1.2.14'
-          cache: true
       - name: Install dependencies
         run: bun run install-packages --no-progress
       # Docker setup for test dependencies (databases, etc.)
@@ -102,7 +101,6 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: '1.2.14'
-          cache: true
       - name: Install dependencies
         run: bun run install-packages --no-progress
       # Download all shard reports from artifacts

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -46,7 +46,6 @@ jobs:
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: '1.3.1'
-          cache: true
 
       # Setup Node.js and configure npm registry authentication
       # NPM_TOKEN secret must be set in repository settings

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -41,7 +41,6 @@ jobs:
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: '1.3.1'
-          cache: true
 
       # Install all dependencies (needed to run changesets commands)
       - name: Install dependencies


### PR DESCRIPTION
## What Does this PR Do?
- remove invalid cache input, setup bun should have caching enabled by default

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the invalid cache input from Bun setup in GitHub Actions. Bun caches by default, so this avoids warnings and keeps CI consistent.

- **Bug Fixes**
  - Removed cache: true from oven-sh/setup-bun in base-ci-cd, build-and-deploy-flowglad-next, flowglad-next-sharded-unit-tests, publish-release, and version-pr workflows.

<sup>Written for commit a59404b9594cf72c4c065c9bb922a58bbef66749. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified CI/CD workflows to disable caching during dependency setup across multiple workflow jobs. This ensures fresh installation state but may impact workflow execution times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->