### PR TITLE
add changeset for new release

### DIFF
--- a/.changeset/wacky-heads-swim.md
+++ b/.changeset/wacky-heads-swim.md
@@ -7,4 +7,9 @@
 "@flowglad/types": minor
 ---
 
-bump @flowglad/node dependency to v0.23, price slug support for create usage events & create subscription, activate subscription checkout cleanup, add test coverage to @flowglad/shared, migrate types from @flowglad/types to @flowglad/shared, deprecate @flowglad/types
+- bump @flowglad/node dependency to v0.23
+- price slug support for create usage events & create subscription
+- activate subscription checkout cleanup
+- add test coverage to @flowglad/shared
+- migrate types from @flowglad/types to @flowglad/shared
+- deprecate @flowglad/types


### PR DESCRIPTION
## What Does this PR Do?
add changeset for new release



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a changeset for minor releases across @flowglad/express, @flowglad/nextjs, @flowglad/react, @flowglad/server, @flowglad/shared, and @flowglad/types. Includes @flowglad/node v0.23, price slug support, checkout cleanup, adds test coverage to @flowglad/shared, and deprecates @flowglad/types (types moved to @flowglad/shared).

- **New Features**
  - Price slug support for create usage events and create subscription.
  - Cleanup in the activate subscription checkout flow.

- **Migration**
  - Move type imports from @flowglad/types to @flowglad/shared.
  - Replace any remaining usage of @flowglad/types; the package is deprecated.

<sup>Written for commit 2e63673fb83c5d2364e79770c47e49990d2aa7bd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added price slug support for creating usage events and subscriptions.

* **Improvements**
  * Streamlined subscription checkout flow with cleanup.
  * Expanded test coverage for shared components.

* **Chores**
  * Updated multiple package versions and migrated type definitions into a shared package.

* **Deprecations**
  * Marked the separate types package as deprecated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->