### PR TITLE
fix: only select livemode customer for magic links

### DIFF
--- a/platform/flowglad-next/src/utils/auth.ts
+++ b/platform/flowglad-next/src/utils/auth.ts
@@ -33,8 +33,9 @@ const handleCustomerBillingPortalEmailOTP = async (params: {
         organizationId,
         transaction
       )
+      // Only look for live mode customers - billing portals are not supported for test mode customers
       const customers = await selectCustomers(
-        { email, organizationId },
+        { email, organizationId, livemode: true },
         transaction
       )
       return {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Magic link billing portal now selects only live mode customers to prevent errors for test mode accounts.

<sup>Written for commit 259fdb82f24008691b971d0ab3b1e0e49862977a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed customer billing portal email authentication to correctly filter and process only live-mode customer accounts, ensuring test-mode accounts cannot access the billing portal through this authentication method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->