### PR TITLE
modifying excuteBillingRun sig to include adjustmentParams

### DIFF
--- a/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
+++ b/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
@@ -929,11 +929,16 @@ export const executeBillingRun = async (
       error,
     })
     return adminTransaction(async ({ transaction }) => {
+      const isError = error instanceof Error
       return updateBillingRun(
         {
           id: billingRun.id,
           status: BillingRunStatus.Failed,
-          errorDetails: JSON.parse(JSON.stringify(error)),
+          errorDetails: {
+            message: isError ? error.message : String(error),
+            name: isError ? error.name : 'Error',
+            stack: isError ? error.stack : undefined,
+          },
         },
         transaction
       )


### PR DESCRIPTION
Making a small change to the signature of executeBillingRun. We are adding an optional object that is going to contain all of the necessary items that we will need for an adjustment billing run!





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated executeBillingRun to support adjustment billing runs by adding an optional adjustmentParams. Adjustment runs now require these params and fail with a clear error if missing.

- **New Features**
  - Optional adjustmentParams: { newSubscriptionItems: SubscriptionItem.Record[], adjustmentDate: Date | number }.

- **Bug Fixes**
  - Failed runs persist structured errorDetails (message, name, stack) for clearer diagnostics.

<sup>Written for commit bf26ec2c8e9789ef23815cd38f5a60bbb08dad7c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Billing adjustments now supported with customizable adjustment dates and subscription item configurations.

* **Bug Fixes / Validation**
  * Validation enforces required adjustment parameters for billing runs marked as adjustments, preventing incomplete runs.
  * Improved error reporting for failed billing runs with clearer error details.

* **Tests**
  * Added end-to-end tests covering adjustment billing runs, including success and failure scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->