### PR TITLE
Cancel subscription immediately when first payment fails

### DIFF
--- a/platform/flowglad-next/src/subscriptions/processBillingRunPaymentIntents.ts
+++ b/platform/flowglad-next/src/subscriptions/processBillingRunPaymentIntents.ts
@@ -405,11 +405,11 @@ export const processPaymentIntentEventForBillingRun = async (
   } else if (billingRunStatus === BillingRunStatus.Failed) {
     const firstPayment = await isFirstPayment(
       subscription,
-      billingPeriod,
       transaction
     )
 
-    if (firstPayment) {
+    // Do not cancel if first payment fails for free or default plans
+    if (firstPayment && !subscription.isFreePlan) {
       // First payment failure - cancel subscription immediately
       const {
         result: canceledSubscription,


### PR DESCRIPTION
Create a helper function in billingRunHelpers to help us determine if a payment has been made for a subscription or not. Use this function to cancel subscription if a first payment fails



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel subscription immediately when the first payment fails, except for free plans. Detect first payments and only schedule retries for later failures or free-plan failures.

- **New Features**
  - Added isFirstPayment helper that checks for any prior successful non-zero payments.
  - Updated payment intent handling: on failure, cancel immediately if first payment on paid plans; otherwise schedule retry, send failed notifications, and mark PastDue.
  - Added integration tests for first-payment failure cancellation, free plan behavior, and usage credit scenarios.

<sup>Written for commit 9a9e6c7364cb1367fd1b2dbecfd6a5057747838b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Billing now treats a customer's very first failed payment differently: paid-plan subscriptions are immediately canceled on first failure; free-plan subscriptions enter a past-due state with a retry scheduled.

* **Tests**
  * Added end-to-end tests covering first-payment failure flows, cancellation behavior, and retry/past-due handling for free plans.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->