### PR TITLE
fix: checkout form

### DIFF
--- a/platform/flowglad-next/src/components/CheckoutForm.tsx
+++ b/platform/flowglad-next/src/components/CheckoutForm.tsx
@@ -83,6 +83,10 @@ function CheckoutForm() {
         'pt-0 pb-0', // Remove default padding
         'items-stretch lg:items-start' // Full width on mobile
       )}
+      style={{
+        fontFamily:
+          'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+      }}
     >
       <Elements
         stripe={stripePromise}
@@ -142,7 +146,7 @@ function CheckoutForm() {
               // === TYPOGRAPHY VARIABLES ===
               // Currently using:
               fontFamily:
-                'SF Pro, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+                'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
               fontSizeBase: '14px', // Base font size for all text
               fontLineHeight: '1.3', // Line height multiplier
 

--- a/platform/flowglad-next/src/components/CheckoutPage.tsx
+++ b/platform/flowglad-next/src/components/CheckoutPage.tsx
@@ -88,7 +88,13 @@ const CheckoutPage = ({
       <div className={outerWrapper}>
         <div className={checkoutContainer}>
           {/* Product Details Section */}
-          <div className={productSectionContainer}>
+          <div
+            className={productSectionContainer}
+            style={{
+              fontFamily:
+                'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+            }}
+          >
             <div className="w-full">
               <CheckoutDetails />
             </div>

--- a/platform/flowglad-next/src/components/checkout/billing-header.tsx
+++ b/platform/flowglad-next/src/components/checkout/billing-header.tsx
@@ -122,6 +122,10 @@ export const BillingHeader = React.forwardRef<
             'text-[24px] font-medium leading-[32px]', // LS typography
             'text-foreground dark:text-white' // Adaptive color
           )}
+          style={{
+            fontFamily:
+              'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+          }}
           data-testid="checkout-product-name"
         >
           <span>{product.name}</span>


### PR DESCRIPTION
Fixes the checkout form typography to be sans serif
<img width="2186" height="1676" alt="CleanShot 2025-12-05 at 13 14 39@2x" src="https://github.com/user-attachments/assets/5dc25217-8f3b-4a5c-bba2-8a57c6c9c512" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched checkout typography to a system sans‑serif stack for a consistent look across the form and product details. Removed SF Pro references and aligned Stripe Element typography variables.

- **Bug Fixes**
  - Set fontFamily to 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif' in CheckoutForm container and Stripe Elements appearance.
  - Applied the same font stack to the CheckoutPage product section container.
  - Applied the font stack to the BillingHeader title.

<sup>Written for commit b30ee2309788206a05f49697e8f71778f6e354a5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Style**
- Updated typography and font rendering across checkout interface components including the payment form, product details section, and billing header to enhance visual consistency and professional appearance
- Applied consistent styling to ensure uniform text presentation across all checkout elements
- Results in a more polished and cohesive checkout experience

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->