### PR TITLE
fix: experimental fallback for customer email

### DIFF
--- a/platform/flowglad-next/src/components/PaymentForm.tsx
+++ b/platform/flowglad-next/src/components/PaymentForm.tsx
@@ -427,7 +427,18 @@ const PaymentForm = () => {
           // This point will only be reached if there is an immediate error when
           // confirming the payment. Show error to your customer (for example, payment
           // details incomplete)
-          setErrorMessage(error?.message)
+          const errorMessage = error?.message || ''
+
+          if (
+            errorMessage.includes('fields.billing_details.email') &&
+            errorMessage.includes(
+              'confirmParams.payment_method_data.billing_details.email'
+            )
+          ) {
+            core.error(error)
+          }
+
+          setErrorMessage(errorMessage)
         } else {
           // Your customer will be redirected to your `return_url`. For some payment
           // methods like iDEAL, your customer will be redirected to an intermediate


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an experimental fallback in PaymentForm to populate billing_details.email from checkoutSession.customerEmail when LinkAuthenticationElement email isn’t available at confirm time. Ensures email is sent to Stripe for SetupIntent and consented PaymentIntent flows, and logs the billing_details.email edge case.

<sup>Written for commit 56b3e144777dd7ac065f159d5bead4a7ce154c91. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment form email handling with enhanced fallback logic to ensure more reliable customer email capture during checkout.
  * Enhanced error reporting for email-related payment failures to surface and log issues more clearly for faster resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->