### PR TITLE
chore: bump @flowglad/nextjs to next 16 peer dependency

### DIFF
--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -15,7 +15,7 @@ bun add @flowglad/nextjs
 ## Requirements
 
 - React 18 or 19
-- Next.js 14 or 15
+- Next.js 14, 15, or 16
 
 ## Usage
 

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "react": "^19.0.0 || ^18.0.0",
-    "next": "^14.0.3 || ^15.0.0"
+    "next": "^14.0.3 || ^15.0.0 || ^16.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## What Does this PR Do?
- Bumps peer dependency for @flowglad/nextjs to support 16

Addresses #927

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Next.js 16 support to @flowglad/nextjs by expanding the peer dependency and updating the README. Addresses issue #927.

<sup>Written for commit 0c61e15058e3e8a066a76a8937e54ae2829e1486. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect support for Next.js version 16, extending compatibility beyond previously supported versions 14 and 15.

* **Chores**
  * Extended peer dependency specifications to support Next.js 16, enabling the package to work seamlessly with versions 14, 15, and 16.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->