### PR TITLE
changeset: 0.14.1

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@flowglad/playground-express"]
+  "ignore": [
+    "@flowglad/playground-express",
+    "@flowglad/playground-generation-based-subscription"
+  ]
 }

--- a/.changeset/hungry-coats-dress.md
+++ b/.changeset/hungry-coats-dress.md
@@ -1,0 +1,10 @@
+---
+"@flowglad/express": patch
+"@flowglad/nextjs": patch
+"@flowglad/react": patch
+"@flowglad/server": patch
+"@flowglad/shared": patch
+"@flowglad/types": patch
+---
+
+@flowglad/nextjs: bump peer dependency for next to support ^16.0.0


### PR DESCRIPTION
## What Does this PR Do?
changeset for 0.14.1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 0.14.1 release with patch bumps across packages. Adds Next.js 16 support in @flowglad/nextjs and updates changeset config to ignore the new generation-based subscription playground.

- **Dependencies**
  - @flowglad/nextjs: widen peer dependency to next ^16.0.0.

<sup>Written for commit 5a1a20deebddefce432693704c8ae50faa78e679. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch updates released across multiple packages (Express, Next.js, React, Server, Shared, Types) for maintenance and improvements.
  * Next.js peer dependency updated to support version 16.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->