### PR TITLE
feat: add trace ID support for Better Stack logs

### DIFF
--- a/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
+++ b/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
@@ -228,6 +228,7 @@ const innerHandler = async (
           api_key_type: apiKeyType,
           body_size_bytes: requestBodySize,
           rest_sdk_version: sdkVersion,
+          span: parentSpan, // Pass span explicitly for trace correlation
         })
 
         // Create a new context with our parent span
@@ -289,6 +290,7 @@ const innerHandler = async (
           route_pattern: routeKey,
           procedure: route.procedure,
           matching_duration_ms: routeMatchingDuration,
+          span: parentSpan, // Pass span explicitly for trace correlation
         })
 
         // Extract parameters from URL with telemetry
@@ -615,6 +617,7 @@ const innerHandler = async (
           endpoint_category: endpointCategory,
           operation_type: operationType,
           rest_sdk_version: sdkVersion,
+          span: parentSpan, // Pass span explicitly for trace correlation
         })
 
         return NextResponse.json(responseData)
@@ -644,6 +647,7 @@ const innerHandler = async (
           url: req.url,
           total_duration_ms: totalDuration,
           rest_sdk_version: sdkVersion,
+          span: parentSpan, // Pass span explicitly for trace correlation
         })
 
         return NextResponse.json(

--- a/platform/flowglad-next/src/server/tracingMiddleware.ts
+++ b/platform/flowglad-next/src/server/tracingMiddleware.ts
@@ -64,7 +64,7 @@ export function createTracingMiddleware() {
               })
             }
             const service = apiKey ? 'api' : 'webapp'
-            // Log request start
+            // Log request start - pass span explicitly for trace context
             logger.info(
               `[${requestId}] 🟡 TRPC Request: ${type} ${path}`,
               {
@@ -81,6 +81,7 @@ export function createTracingMiddleware() {
                   : user
                     ? 'user'
                     : 'none',
+                span, // Pass span explicitly for trace correlation
               }
             )
 
@@ -102,6 +103,7 @@ export function createTracingMiddleware() {
                   type,
                   path,
                   duration_ms: duration,
+                  span, // Pass span explicitly for trace correlation
                 }
               )
 
@@ -171,6 +173,7 @@ export function createTracingMiddleware() {
                   error_code: errorCode,
                   duration_ms: duration,
                   organization_id: organizationId,
+                  span, // Pass span explicitly for trace correlation
                 }
               )
 


### PR DESCRIPTION
## Summary

- Adds explicit span parameter to logger functions for reliable trace context propagation
- Uses Better Stack's expected field names (`span.trace_id`, `span.span_id`)
- Passes span explicitly in TRPC middleware and REST API handlers

## VRL Transformation Required

After merging this PR, add the following VRL transformation in Better Stack to move the trace fields from the nested `fields` object to root level:

```vrl
if exists(.fields."span.trace_id") {
    .span.trace_id = .fields."span.trace_id"
}
if exists(.fields."span.span_id") {
    .span.span_id = .fields."span.span_id"
}
```

## Test plan

- [ ] Deploy to staging environment
- [ ] Verify logs in Better Stack show trace IDs in the Trace ID column
- [ ] Verify trace correlation works for both TRPC and REST API requests

Fixes: FG-291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable trace correlation in Better Stack by emitting span.trace_id/span.span_id and passing spans to the logger. Addresses FG-291 so the Trace ID column populates for TRPC and REST requests.

- New Features
  - Logger accepts an explicit Span and falls back to the active span.
  - Emits Better Stack field names: span.trace_id and span.span_id.
  - TRPC middleware and REST v1 route pass the span when logging.

- Migration
  - In Better Stack, add VRL to move fields from fields to root:
    - .span.trace_id = .fields."span.trace_id"
    - .span.span_id = .fields."span.span_id"

<sup>Written for commit 18e69f0d1a8e9276d5cd87038c1208d4ca1e707f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging infrastructure to improve trace correlation across API routes and middleware with explicit span propagation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->