### PR TITLE
chore: add some clarifying comments

### DIFF
--- a/platform/flowglad-next/src/db/databaseAuthentication.ts
+++ b/platform/flowglad-next/src/db/databaseAuthentication.ts
@@ -117,6 +117,19 @@ interface DatabaseAuthenticationInfo {
   jwtClaim: JWTClaim
 }
 
+/**
+ * Creates authentication info for a Secret API key.
+ *
+ * Sets `auth_type: 'api_key'` in JWT claims, which allows API keys to bypass
+ * the membership `focused` check in RLS policies. This is necessary because
+ * API keys are scoped to a specific organization and should work regardless
+ * of which organization the user has focused in the webapp.
+ *
+ * @param verifyKeyResult - The verified API key result containing:
+ *   - `userId`: The user who created/owns the API key (extracted from metadata)
+ *   - `ownerId`: The organization ID this API key belongs to
+ * @returns Database authentication info with JWT claims set for API key auth
+ */
 export async function dbAuthInfoForSecretApiKeyResult(
   verifyKeyResult: KeyVerifyResult
 ): Promise<DatabaseAuthenticationInfo> {
@@ -270,6 +283,9 @@ export const dbInfoForCustomerBillingPortal = async ({
  * is present in the billing portal cookie state:
  * - If no customer organization ID: authenticates as merchant using focused membership
  * - If customer organization ID exists: authenticates as customer for billing portal
+ *
+ * Sets `auth_type: 'webapp'` in JWT claims, which means RLS policies will enforce
+ * the membership `focused` check (unlike API key auth which bypasses it).
  *
  * @param user - The Better Auth user making the request
  * @param __testOnlyOrganizationId - Optional test organization ID override

--- a/platform/flowglad-next/src/db/schema/memberships.ts
+++ b/platform/flowglad-next/src/db/schema/memberships.ts
@@ -51,6 +51,8 @@ export const memberships = pgTable(
           as: 'permissive',
           to: 'merchant',
           for: 'select',
+          // API keys bypass the focused check because they're scoped to a specific organization.
+          // Webapp auth requires focused=true to ensure users only see their active organization.
           using: sql`"user_id" = requesting_user_id() AND "organization_id" = current_organization_id() AND (current_auth_type() = 'api_key' OR "focused" = true)`,
         }
       ),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added clarifying comments in authentication and RLS code to explain how JWT `auth_type` differs for API keys vs webapp and how that impacts the `focused` membership check. This ties to FG-597 by documenting that API keys are org‑scoped and bypass focus, while webapp auth requires `focused=true`.

<sup>Written for commit 9c7d0439dbc6adcac5d24f40a3b902595c881214. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

