### PR TITLE
Export formatEmailSubject and apply to notification subjects

### DIFF
--- a/platform/flowglad-next/src/trigger/notifications/send-customer-subscription-canceled-notification.ts
+++ b/platform/flowglad-next/src/trigger/notifications/send-customer-subscription-canceled-notification.ts
@@ -8,7 +8,7 @@ import {
   createTriggerIdempotencyKey,
   testSafeTriggerInvoker,
 } from '@/utils/backendCore'
-import { safeSend } from '@/utils/email'
+import { formatEmailSubject, safeSend } from '@/utils/email'
 
 const sendCustomerSubscriptionCanceledNotificationTask = task({
   id: 'send-customer-subscription-canceled-notification',
@@ -112,7 +112,10 @@ const sendCustomerSubscriptionCanceledNotificationTask = task({
     await safeSend({
       from: 'Flowglad <notifications@flowglad.com>',
       to: customer.email,
-      subject: `Subscription Canceled: Your ${subscriptionName} subscription has been canceled`,
+      subject: formatEmailSubject(
+        `Subscription Canceled: Your ${subscriptionName} subscription has been canceled`,
+        subscription.livemode
+      ),
       react: CustomerSubscriptionCanceledEmail({
         customerName: customer.name,
         organizationName: organization.name,

--- a/platform/flowglad-next/src/trigger/notifications/send-customer-subscription-cancellation-scheduled-notification.ts
+++ b/platform/flowglad-next/src/trigger/notifications/send-customer-subscription-cancellation-scheduled-notification.ts
@@ -9,7 +9,7 @@ import {
   testSafeTriggerInvoker,
 } from '@/utils/backendCore'
 import { formatDate } from '@/utils/core'
-import { safeSend } from '@/utils/email'
+import { formatEmailSubject, safeSend } from '@/utils/email'
 
 const sendCustomerSubscriptionCancellationScheduledNotificationTask =
   task({
@@ -94,7 +94,10 @@ const sendCustomerSubscriptionCancellationScheduledNotificationTask =
       await safeSend({
         from: 'Flowglad <notifications@flowglad.com>',
         to: customer.email,
-        subject: `Cancellation Scheduled: Your ${subscriptionName} subscription will be canceled on ${formatDate(cancellationDate)}`,
+        subject: formatEmailSubject(
+          `Cancellation Scheduled: Your ${subscriptionName} subscription will be canceled on ${formatDate(cancellationDate)}`,
+          subscription.livemode
+        ),
         react: CustomerSubscriptionCancellationScheduledEmail({
           customerName: customer.name,
           organizationName: organization.name,

--- a/platform/flowglad-next/src/trigger/notifications/send-customer-subscription-created-notification.ts
+++ b/platform/flowglad-next/src/trigger/notifications/send-customer-subscription-created-notification.ts
@@ -13,7 +13,7 @@ import {
   testSafeTriggerInvoker,
 } from '@/utils/backendCore'
 import core from '@/utils/core'
-import { safeSend } from '@/utils/email'
+import { formatEmailSubject, safeSend } from '@/utils/email'
 
 const sendCustomerSubscriptionCreatedNotificationTask = task({
   id: 'send-customer-subscription-created-notification',
@@ -121,7 +121,10 @@ const sendCustomerSubscriptionCreatedNotificationTask = task({
       from: `${organization.name} Billing <${kebabCase(organization.name)}-notifications@flowglad.com>`,
       bcc: notifUatEmail ? [notifUatEmail] : undefined,
       to: [customer.email],
-      subject: 'Payment method confirmed - Subscription active',
+      subject: formatEmailSubject(
+        'Payment method confirmed - Subscription active',
+        subscription.livemode
+      ),
       react: await CustomerSubscriptionCreatedEmail({
         customerName: customer.name,
         organizationName: organization.name,

--- a/platform/flowglad-next/src/trigger/notifications/send-customer-subscription-upgraded-notification.ts
+++ b/platform/flowglad-next/src/trigger/notifications/send-customer-subscription-upgraded-notification.ts
@@ -13,7 +13,7 @@ import {
   testSafeTriggerInvoker,
 } from '@/utils/backendCore'
 import core from '@/utils/core'
-import { safeSend } from '@/utils/email'
+import { formatEmailSubject, safeSend } from '@/utils/email'
 
 const sendCustomerSubscriptionUpgradedNotificationTask = task({
   id: 'send-customer-subscription-upgraded-notification',
@@ -148,7 +148,10 @@ const sendCustomerSubscriptionUpgradedNotificationTask = task({
       from: `${organization.name} Billing <${kebabCase(organization.name)}-notifications@flowglad.com>`,
       bcc: notifUatEmail ? [notifUatEmail] : undefined,
       to: [customer.email],
-      subject: 'Payment method confirmed - Subscription upgraded',
+      subject: formatEmailSubject(
+        'Payment method confirmed - Subscription upgraded',
+        newSubscription.livemode
+      ),
       react: await CustomerSubscriptionUpgradedEmail({
         customerName: customer.name,
         organizationName: organization.name,

--- a/platform/flowglad-next/src/trigger/notifications/send-organization-payment-failed-notification.ts
+++ b/platform/flowglad-next/src/trigger/notifications/send-organization-payment-failed-notification.ts
@@ -10,7 +10,7 @@ import {
   testSafeTriggerInvoker,
 } from '@/utils/backendCore'
 import { isNil } from '@/utils/core'
-import { safeSend } from '@/utils/email'
+import { formatEmailSubject, safeSend } from '@/utils/email'
 
 interface PaymentFailedNotificationData {
   organizationId: string
@@ -70,7 +70,10 @@ const sendOrganizationPaymentFailedNotificationTask = task({
       to: usersAndMemberships
         .map(({ user }) => user.email)
         .filter((email) => !isNil(email)),
-      subject: `Payment Failed: ${customer.name} payment of ${paymentData.amount} ${paymentData.currency} failed`,
+      subject: formatEmailSubject(
+        `Payment Failed: ${customer.name} payment of ${paymentData.amount} ${paymentData.currency} failed`,
+        paymentData.livemode
+      ),
       react: OrganizationPaymentFailedNotificationEmail({
         organizationName: organization.name,
         amount: paymentData.amount,

--- a/platform/flowglad-next/src/trigger/notifications/send-organization-subscription-canceled-notification.ts
+++ b/platform/flowglad-next/src/trigger/notifications/send-organization-subscription-canceled-notification.ts
@@ -10,7 +10,7 @@ import {
   testSafeTriggerInvoker,
 } from '@/utils/backendCore'
 import { isNil } from '@/utils/core'
-import { safeSend } from '@/utils/email'
+import { formatEmailSubject, safeSend } from '@/utils/email'
 
 const sendOrganizationSubscriptionCanceledNotificationTask = task({
   id: 'send-organization-subscription-canceled-notification',
@@ -62,7 +62,10 @@ const sendOrganizationSubscriptionCanceledNotificationTask = task({
       to: usersAndMemberships
         .map(({ user }) => user.email)
         .filter((email) => !isNil(email)),
-      subject: `Subscription Cancelled: ${customer.name} canceled ${subscription.name}`,
+      subject: formatEmailSubject(
+        `Subscription Cancelled: ${customer.name} canceled ${subscription.name}`,
+        subscription.livemode
+      ),
       react: OrganizationSubscriptionCanceledNotificationEmail({
         organizationName: organization.name,
         subscriptionName: subscription.name!,

--- a/platform/flowglad-next/src/trigger/notifications/send-organization-subscription-cancellation-scheduled-notification.ts
+++ b/platform/flowglad-next/src/trigger/notifications/send-organization-subscription-cancellation-scheduled-notification.ts
@@ -10,7 +10,7 @@ import {
   testSafeTriggerInvoker,
 } from '@/utils/backendCore'
 import { formatDate, isNil } from '@/utils/core'
-import { safeSend } from '@/utils/email'
+import { formatEmailSubject, safeSend } from '@/utils/email'
 
 const sendOrganizationSubscriptionCancellationScheduledNotificationTask =
   task({
@@ -70,7 +70,10 @@ const sendOrganizationSubscriptionCancellationScheduledNotificationTask =
         to: usersAndMemberships
           .map(({ user }) => user.email)
           .filter((email) => !isNil(email)),
-        subject: `Cancellation Scheduled: ${customer.name} scheduled cancellation for ${subscriptionName} on ${formatDate(cancellationDate)}`,
+        subject: formatEmailSubject(
+          `Cancellation Scheduled: ${customer.name} scheduled cancellation for ${subscriptionName} on ${formatDate(cancellationDate)}`,
+          subscription.livemode
+        ),
         react:
           OrganizationSubscriptionCancellationScheduledNotificationEmail(
             {

--- a/platform/flowglad-next/src/trigger/notifications/send-organization-subscription-created-notification.ts
+++ b/platform/flowglad-next/src/trigger/notifications/send-organization-subscription-created-notification.ts
@@ -10,7 +10,7 @@ import {
   testSafeTriggerInvoker,
 } from '@/utils/backendCore'
 import core, { isNil } from '@/utils/core'
-import { safeSend } from '@/utils/email'
+import { formatEmailSubject, safeSend } from '@/utils/email'
 
 const sendOrganizationSubscriptionCreatedNotificationTask = task({
   id: 'send-organization-subscription-created-notification',
@@ -63,7 +63,10 @@ const sendOrganizationSubscriptionCreatedNotificationTask = task({
       to: usersAndMemberships
         .map(({ user }) => user.email)
         .filter((email) => !isNil(email)),
-      subject: `New Subscription: ${customer.name} subscribed to ${subscription.name}`,
+      subject: formatEmailSubject(
+        `New Subscription: ${customer.name} subscribed to ${subscription.name}`,
+        subscription.livemode
+      ),
       react: OrganizationSubscriptionCreatedNotificationEmail({
         organizationName: organization.name,
         subscriptionName: subscription.name!,

--- a/platform/flowglad-next/src/utils/email.ts
+++ b/platform/flowglad-next/src/utils/email.ts
@@ -63,7 +63,7 @@ const safeTo = (email: string) =>
  * @param livemode - Whether this is a livemode (production) email
  * @returns The formatted subject line with [TEST] prefix when livemode is false
  */
-const formatEmailSubject = (
+export const formatEmailSubject = (
   subject: string,
   livemode: boolean
 ): string => {


### PR DESCRIPTION
## What Does this PR Do?

Exports `formatEmailSubject` from `email.ts` to make it reusable across the codebase. Applied it to 8 notification trigger files to ensure test mode emails are clearly identified with a `[TEST]` prefix when `livemode` is false. This provides consistent visibility into whether emails are being sent in test or production mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported formatEmailSubject and applied it across notification handlers so test emails are clearly marked with a [TEST] prefix when livemode is false. This makes subjects consistent and reduces the risk of confusing test and production emails.

- **Refactors**
  - Exported formatEmailSubject from utils/email for reuse.
  - Used it in customer/org subscription and payment notifications; production subjects unchanged, test emails get a [TEST] prefix.

<sup>Written for commit b6f8011297ab3bc5021b3ef32e306c2400fbc3e1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized email subject formatting across subscription and payment notifications to dynamically adjust subjects based on deployment environment, ensuring consistent presentation for customer and organization notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->