### PR TITLE
fix: frontend changes to customer search

### DIFF
--- a/platform/flowglad-next/src/app/customers/Internal.tsx
+++ b/platform/flowglad-next/src/app/customers/Internal.tsx
@@ -4,12 +4,7 @@ import CreateCustomerFormModal from '@/components/forms/CreateCustomerFormModal'
 import InternalPageContainer from '@/components/InternalPageContainer'
 import Breadcrumb from '@/components/navigation/Breadcrumb'
 import { PageHeader } from '@/components/ui/page-header'
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@/components/ui/tabs'
+import { TabsTrigger } from '@/components/ui/tabs'
 import { useAuthenticatedContext } from '@/contexts/authContext'
 import { CustomersDataTable } from './data-table'
 

--- a/platform/flowglad-next/src/app/customers/data-table.tsx
+++ b/platform/flowglad-next/src/app/customers/data-table.tsx
@@ -1,13 +1,9 @@
 'use client'
 
 import {
-  type ColumnFiltersState,
   type ColumnSizingState,
   flexRender,
   getCoreRowModel,
-  getFilteredRowModel,
-  getSortedRowModel,
-  type SortingState,
   useReactTable,
   type VisibilityState,
 } from '@tanstack/react-table'
@@ -62,7 +58,7 @@ export function CustomersDataTable({
 
   // Server-side filtering (preserve enterprise architecture) - FIXED: Using stable debounced hook
   const { inputValue, setInputValue, searchQuery } =
-    useSearchDebounce(1000)
+    useSearchDebounce(300)
 
   // Page size state for server-side pagination
   const [currentPageSize, setCurrentPageSize] = React.useState(10)
@@ -93,10 +89,13 @@ export function CustomersDataTable({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filtersKey])
 
-  // Client-side features (Shadcn patterns)
-  const [sorting, setSorting] = React.useState<SortingState>([])
-  const [columnFilters, setColumnFilters] =
-    React.useState<ColumnFiltersState>([])
+  // Reset to first page when debounced search changes
+  React.useEffect(() => {
+    goToFirstPage()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery])
+
+  // Client-side sorting/filtering removed; handled server-side
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>({})
   const [columnSizing, setColumnSizing] =
@@ -113,12 +112,11 @@ export function CustomersDataTable({
       minSize: 50,
       maxSize: 500,
     },
+    enableSorting: false, // Disable header sorting UI/interactions
     manualPagination: true, // Server-side pagination
-    manualSorting: false, // Client-side sorting on current page
-    manualFiltering: false, // Client-side filtering on current page
+    manualSorting: true, // Disable client-side sorting
+    manualFiltering: true, // Disable client-side filtering
     pageCount: Math.ceil((data?.total || 0) / currentPageSize),
-    onSortingChange: setSorting,
-    onColumnFiltersChange: setColumnFilters,
     onColumnSizingChange: setColumnSizing,
     onColumnVisibilityChange: setColumnVisibility,
     onPaginationChange: (updater) => {
@@ -138,11 +136,7 @@ export function CustomersDataTable({
       }
     },
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
     state: {
-      sorting,
-      columnFilters,
       columnVisibility,
       columnSizing,
       pagination: { pageIndex, pageSize: currentPageSize },
@@ -206,7 +200,7 @@ export function CustomersDataTable({
           <CollapsibleSearch
             value={inputValue}
             onChange={setInputValue}
-            placeholder="Search customers..."
+            placeholder="Name, email, cust_id..."
             disabled={isLoading}
             isLoading={isFetching}
           />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved customer search responsiveness and aligned the table to server-side filtering/sorting. Pagination now resets on new searches, and client-side sorting/filtering UI is disabled.

- **Bug Fixes**
  - Reduced search debounce from 1000ms to 300ms.
  - Reset to first page when the debounced search query changes.
  - Disabled client-side sorting/filtering and removed related row models; header sorting interactions are off.
  - Updated search placeholder to "Name, email, cust_id..." and removed unused tabs imports.

<sup>Written for commit f6cf2f1daff34290ca4da2232ee5bcf811ea3125. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Disabled sorting controls in table headers
  * Updated search placeholder text to clarify searchable fields (Name, email, cust_id)
  * Reduced search debounce to 300ms for faster responsiveness
  * Transitioned filtering and sorting to server-side handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->