### PR TITLE
refactor: processOutcomeForBillingRun signature to contain adjustment params

### DIFF
--- a/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
+++ b/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
@@ -931,7 +931,10 @@ export const executeBillingRun = async (
     ) {
       await comprehensiveAdminTransaction(async ({ transaction }) => {
         return await processOutcomeForBillingRun(
-          confirmationResult,
+          {
+            input: confirmationResult,
+            adjustmentParams: adjustmentParams,
+          },
           transaction
         )
       })

--- a/platform/flowglad-next/src/subscriptions/processBillingRunPaymentIntents.test.ts
+++ b/platform/flowglad-next/src/subscriptions/processBillingRunPaymentIntents.test.ts
@@ -184,7 +184,7 @@ describe('processOutcomeForBillingRun integration tests', async () => {
 
       // The function should simply skip processing and return undefined.
       const { result } = await processOutcomeForBillingRun(
-        event,
+        { input: event },
         transaction
       )
       expect(result?.processingSkipped).toBe(true)
@@ -242,7 +242,10 @@ describe('processOutcomeForBillingRun integration tests', async () => {
       )
 
       const { result, ledgerCommands } =
-        await processOutcomeForBillingRun(event, transaction)
+        await processOutcomeForBillingRun(
+          { input: event },
+          transaction
+        )
 
       const updatedBillingRun = await selectBillingRunById(
         billingRun.id,
@@ -336,13 +339,19 @@ describe('processOutcomeForBillingRun integration tests', async () => {
 
     await adminTransaction(async ({ transaction }) => {
       const { ledgerCommands: firstLedgerCommands } =
-        await processOutcomeForBillingRun(event, transaction)
+        await processOutcomeForBillingRun(
+          { input: event },
+          transaction
+        )
 
       expect(firstLedgerCommands).toBeDefined()
       expect(firstLedgerCommands?.length).toBeGreaterThan(0)
 
       const { ledgerCommands: secondLedgerCommands } =
-        await processOutcomeForBillingRun(event, transaction)
+        await processOutcomeForBillingRun(
+          { input: event },
+          transaction
+        )
 
       expect(secondLedgerCommands).toBeUndefined()
     })
@@ -396,7 +405,7 @@ describe('processOutcomeForBillingRun integration tests', async () => {
         }
       )
       const { ledgerCommands } = await processOutcomeForBillingRun(
-        event,
+        { input: event },
         transaction
       )
 
@@ -478,7 +487,7 @@ describe('processOutcomeForBillingRun integration tests', async () => {
       )
 
       const { ledgerCommands } = await processOutcomeForBillingRun(
-        event,
+        { input: event },
         transaction
       )
 
@@ -557,7 +566,7 @@ describe('processOutcomeForBillingRun integration tests', async () => {
       )
 
       const { ledgerCommands } = await processOutcomeForBillingRun(
-        event,
+        { input: event },
         transaction
       )
 
@@ -646,7 +655,7 @@ describe('processOutcomeForBillingRun integration tests', async () => {
       )
 
       const { ledgerCommands } = await processOutcomeForBillingRun(
-        event,
+        { input: event },
         transaction
       )
 
@@ -705,7 +714,7 @@ describe('processOutcomeForBillingRun integration tests', async () => {
       )
 
       await expect(
-        processOutcomeForBillingRun(event, transaction)
+        processOutcomeForBillingRun({ input: event }, transaction)
       ).rejects.toThrow(
         `Invoice for billing period ${billingRun.billingPeriodId} not found.`
       )
@@ -751,7 +760,7 @@ describe('processOutcomeForBillingRun integration tests', async () => {
       )
 
       await expect(
-        processOutcomeForBillingRun(event, transaction)
+        processOutcomeForBillingRun({ input: event }, transaction)
       ).rejects.toThrow(
         /No latest charge found for payment intent pi_no_charge/
       )
@@ -798,7 +807,7 @@ describe('processOutcomeForBillingRun integration tests', async () => {
   //     } as any
 
   //     await expect(
-  //       processOutcomeForBillingRun(event, transaction)
+  //       processOutcomeForBillingRun(event, adjustmentParams, transaction)
   //     ).rejects.toThrow(
   //       `Payment record not found for stripe charge ${event.data.object.latest_charge}`
   //     )
@@ -894,7 +903,10 @@ describe('processOutcomeForBillingRun integration tests', async () => {
           livemode: true,
         }
       )
-      return await processOutcomeForBillingRun(event, transaction)
+      return await processOutcomeForBillingRun(
+        { input: event },
+        transaction
+      )
     })
 
     // Verify subscription was canceled
@@ -1039,7 +1051,10 @@ describe('processOutcomeForBillingRun integration tests', async () => {
           livemode: true,
         }
       )
-      return await processOutcomeForBillingRun(event, transaction)
+      return await processOutcomeForBillingRun(
+        { input: event },
+        transaction
+      )
     })
 
     // Verify subscription was NOT canceled (unlike paid plans)
@@ -1173,7 +1188,10 @@ describe('processOutcomeForBillingRun integration tests', async () => {
           }
         )
 
-        return await processOutcomeForBillingRun(event, transaction)
+        return await processOutcomeForBillingRun(
+          { input: event },
+          transaction
+        )
       }
     )
 
@@ -1391,7 +1409,10 @@ describe('processOutcomeForBillingRun - usage credit grants', async () => {
         }
       )
 
-      return await processOutcomeForBillingRun(event, transaction)
+      return await processOutcomeForBillingRun(
+        { input: event },
+        transaction
+      )
     })
 
     // Assertions
@@ -1571,7 +1592,10 @@ describe('processOutcomeForBillingRun - usage credit grants', async () => {
         }
       )
 
-      return await processOutcomeForBillingRun(event, transaction)
+      return await processOutcomeForBillingRun(
+        { input: event },
+        transaction
+      )
     })
 
     // Assertions: similar to "Once" grant, as the first grant is always issued.
@@ -1756,7 +1780,7 @@ describe('processOutcomeForBillingRun - usage credit grants', async () => {
       )
 
       return await processOutcomeForBillingRun(
-        firstEvent,
+        { input: firstEvent },
         transaction
       )
     })
@@ -1810,7 +1834,7 @@ describe('processOutcomeForBillingRun - usage credit grants', async () => {
       )
 
       return await processOutcomeForBillingRun(
-        secondEvent,
+        { input: secondEvent },
         transaction
       )
     })

--- a/platform/flowglad-next/src/trigger/stripe/payment-intent-canceled.ts
+++ b/platform/flowglad-next/src/trigger/stripe/payment-intent-canceled.ts
@@ -14,7 +14,7 @@ export const stripePaymentIntentCanceledTask = task({
       return comprehensiveAdminTransaction(
         async ({ transaction }) => {
           return await processOutcomeForBillingRun(
-            payload,
+            { input: payload },
             transaction
           )
         }

--- a/platform/flowglad-next/src/trigger/stripe/payment-intent-payment-failed.ts
+++ b/platform/flowglad-next/src/trigger/stripe/payment-intent-payment-failed.ts
@@ -17,7 +17,7 @@ export const stripePaymentIntentPaymentFailedTask = task({
       return comprehensiveAdminTransaction(
         async ({ transaction }) => {
           return await processOutcomeForBillingRun(
-            payload,
+            { input: payload },
             transaction
           )
         }

--- a/platform/flowglad-next/src/trigger/stripe/payment-intent-requires-action.ts
+++ b/platform/flowglad-next/src/trigger/stripe/payment-intent-requires-action.ts
@@ -17,7 +17,7 @@ export const stripePaymentIntentRequiresActionTask = task({
       return comprehensiveAdminTransaction(
         async ({ transaction }) => {
           return await processOutcomeForBillingRun(
-            payload,
+            { input: payload },
             transaction
           )
         }

--- a/platform/flowglad-next/src/trigger/stripe/payment-intent-succeeded.ts
+++ b/platform/flowglad-next/src/trigger/stripe/payment-intent-succeeded.ts
@@ -32,7 +32,7 @@ export const stripePaymentIntentSucceededTask = task({
       const result = await comprehensiveAdminTransaction(
         async ({ transaction }) => {
           return await processOutcomeForBillingRun(
-            payload,
+            { input: payload },
             transaction
           )
         }


### PR DESCRIPTION
Change to the function signature for processOutcomeForBillingRun (and all references) to allow adjustment parameters to be passed in. Part of the changes that need to happen for adjust subscription

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed processOutcomeForBillingRun to accept a params object { input, adjustmentParams } to enable passing subscription adjustment data through billing run processing without changing behavior.

- **Refactors**
  - Updated all callers (billingRunHelpers, Stripe trigger tasks, tests) to pass { input } and threaded adjustmentParams in executeBillingRun.
  - Added ProcessOutcomeForBillingRunParams and used SubscriptionItem types for adjustmentParams.

- **Migration**
  - Update direct calls to: processOutcomeForBillingRun({ input, adjustmentParams? }, transaction).
  - adjustmentParams supports newSubscriptionItems and adjustmentDate.

<sup>Written for commit bb7d0ab8abb9edbbc696e7a3557b72f9aeb3d75c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined billing payment processing by restructuring parameter handling for improved internal code organization and maintainability. Updated function signatures and all corresponding callsites to use a unified parameter object pattern for consistency across billing operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->