### PR TITLE
fix: rm e.stopPropagation

### DIFF
--- a/platform/flowglad-next/src/app/finance/discounts/columns.tsx
+++ b/platform/flowglad-next/src/app/finance/discounts/columns.tsx
@@ -3,9 +3,8 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import { sentenceCase } from 'change-case'
 // Icons come next
-import { Pencil, Trash2 } from 'lucide-react'
+import { Pencil } from 'lucide-react'
 import * as React from 'react'
-import DeleteDiscountModal from '@/components/forms/DeleteDiscountModal'
 import EditDiscountModal from '@/components/forms/EditDiscountModal'
 import StatusBadge from '@/components/StatusBadge'
 // UI components last
@@ -94,15 +93,13 @@ export const columns: ColumnDef<DiscountTableRowData>[] = [
       const name = row.getValue('name') as string
       const discountId = row.original.discount.id
       return (
-        <div onClick={(e) => e.stopPropagation()}>
-          <DataTableLinkableCell
-            href={`/finance/discounts/${discountId}`}
-          >
-            <div className="truncate" title={name}>
-              {name}
-            </div>
-          </DataTableLinkableCell>
-        </div>
+        <DataTableLinkableCell
+          href={`/finance/discounts/${discountId}`}
+        >
+          <div className="truncate" title={name}>
+            {name}
+          </div>
+        </DataTableLinkableCell>
       )
     },
     size: 150,

--- a/platform/flowglad-next/src/app/finance/purchases/columns.tsx
+++ b/platform/flowglad-next/src/app/finance/purchases/columns.tsx
@@ -55,15 +55,13 @@ export const columns: ColumnDef<PurchaseTableRowData>[] = [
       const name = row.getValue('name') as string
       const purchaseId = row.original.purchase.id
       return (
-        <div onClick={(e) => e.stopPropagation()}>
-          <DataTableLinkableCell
-            href={`/finance/purchases/${purchaseId}`}
-          >
-            <div className="truncate" title={name}>
-              {name}
-            </div>
-          </DataTableLinkableCell>
-        </div>
+        <DataTableLinkableCell
+          href={`/finance/purchases/${purchaseId}`}
+        >
+          <div className="truncate" title={name}>
+            {name}
+          </div>
+        </DataTableLinkableCell>
       )
     },
   },
@@ -81,13 +79,11 @@ export const columns: ColumnDef<PurchaseTableRowData>[] = [
           ? original.customer.email
           : original.customer.name
       return (
-        <div onClick={(e) => e.stopPropagation()}>
-          <DataTableLinkableCell
-            href={`/customers/${original.customer.id}`}
-          >
-            {displayName}
-          </DataTableLinkableCell>
-        </div>
+        <DataTableLinkableCell
+          href={`/customers/${original.customer.id}`}
+        >
+          {displayName}
+        </DataTableLinkableCell>
       )
     },
   },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes table cell click behavior by removing e.stopPropagation wrappers in Discounts and Purchases columns. Links now work cleanly with row navigation.

- **Bug Fixes**
  - Discounts: Name cell uses DataTableLinkableCell directly for correct navigation.
  - Purchases: Name and Customer cells use DataTableLinkableCell directly.
  - Cleanup: Removed unused Trash2 and DeleteDiscountModal imports.

<sup>Written for commit 68ba526a7482d0e8822d34996c67b0c06a70170b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

