### PR TITLE
configure oidc

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,8 +16,8 @@ on:
     types: [closed]
     branches:
       - main
-  # Also allow manual triggering via GitHub Actions UI
-  workflow_dispatch:
+    if: >
+      (github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && (contains(github.event.pull_request.title, 'chore: version packages') || contains(github.event.pull_request.labels.*.name, 'release'))))
 
 permissions:
   id-token: write # Required for OIDC


### PR DESCRIPTION
## What Does this PR Do?
use OIDC for npm publishing, see [npm docs](https://docs.npmjs.com/trusted-publishers) and [github blog](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/).







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch npm publishing to GitHub OIDC by adding id-token: write, workflow_dispatch, and updating npm to the latest version in the release workflow. Enables trusted publisher auth and removes long-lived npm tokens.

<sup>Written for commit c9d97cb0ee796d5f333435e65e842b3806562fb9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release workflow configuration to enhance reliability and security of the deployment process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->