### PR TITLE
fix: better names for premade pricing models

### DIFF
--- a/platform/flowglad-next/src/utils/organizationHelpers.ts
+++ b/platform/flowglad-next/src/utils/organizationHelpers.ts
@@ -125,7 +125,7 @@ export const createOrganizationTransaction = async (
   } = await createPricingModelBookkeeping(
     {
       pricingModel: {
-        name: 'Default',
+        name: 'Pricing Model',
         isDefault: true,
       },
     },
@@ -141,7 +141,7 @@ export const createOrganizationTransaction = async (
   } = await createPricingModelBookkeeping(
     {
       pricingModel: {
-        name: 'Default (testmode)',
+        name: '[TEST] Pricing Model',
         isDefault: true,
       },
     },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the premade default pricing models for clearer, less confusing names in the UI. During organization creation, "Default" becomes "Pricing Model" and "Default (testmode)" becomes "[TEST] Pricing Model".

<sup>Written for commit d4ee951d0ba71e24b519d10590203f756adcb73a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pricing model naming conventions for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->