### PR TITLE
fix: remove /store from paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ const processChatMessage = async (params: { chat: string }) => {
 ```
 
 ## Getting Started
-First, set up a pricing model. You can do so in the [dashboard](https://app.flowglad.com/store/pricing-models) in just a few clicks using a template, that you can then customize to suit your specific needs.
+First, set up a pricing model. You can do so in the [dashboard](https://app.flowglad.com/pricing-models) in just a few clicks using a template, that you can then customize to suit your specific needs.
 
 We currently have templates for the following pricing models:
 - Usage-limit + Subscription Hybrid (like Cursor)

--- a/platform/docs/features/discounts.mdx
+++ b/platform/docs/features/discounts.mdx
@@ -31,7 +31,7 @@ Fixed discount amounts are stored in the smallest unit of a given currency, e.g.
 
 ![title](/images/discounts-modal.jpeg)
 
-You can create discounts from the [Discounts page](https://app.flowglad.com/store/discounts) in your dashboard:
+You can create discounts from the [Discounts page](https://app.flowglad.com/finance/discounts) in your dashboard:
 
 1. Click the "New Discount" button.
 2. Fill out the discount details:

--- a/platform/docs/features/products.mdx
+++ b/platform/docs/features/products.mdx
@@ -9,7 +9,7 @@ Products allow you to group features together to form an offering your customers
 
 ![Product creation modal showing fields for name, description, catalog, and initial price](/images/product-modal.jpeg)
 
-You can see and create products on the [Products page](https://app.flowglad.com/store/products).
+You can see and create products from your pricing model details page.
 
 ## General Information
 

--- a/platform/docs/features/usage.mdx
+++ b/platform/docs/features/usage.mdx
@@ -38,7 +38,7 @@ Here's how to get started with tracking and billing for usage:
 
 ### Step 1: Create a Usage Meter
 
-1.  Navigate to the [Pricing Models](https://app.flowglad.com/store/pricing-models) page in your dashboard and select the pricing model you would like to create the usage meter in.
+1.  Navigate to the [Pricing Models](https://app.flowglad.com/pricing-models) page in your dashboard and select the pricing model you would like to create the usage meter in.
 2.  Click "Create Usage Meter."
 3.  Give your meter a descriptive `name` (e.g., "API Calls," "Active Users").
 4.  Select the `Aggregation Type`:

--- a/platform/flowglad-next/bun.lock
+++ b/platform/flowglad-next/bun.lock
@@ -200,11 +200,11 @@
     },
   },
   "overrides": {
-    "@modelcontextprotocol/sdk": "1.23.0-beta.0",
-    "@react-email/render": "0.0.17",
-    "chromium-bidi": "2.1.2",
     "esbuild": "0.25.0",
+    "chromium-bidi": "2.1.2",
+    "@modelcontextprotocol/sdk": "1.23.0-beta.0",
     "zod": "4.1.5",
+    "@react-email/render": "0.0.17",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],

--- a/platform/flowglad-next/src/app/finance/purchases/[id]/InnerPurchasePage.tsx
+++ b/platform/flowglad-next/src/app/finance/purchases/[id]/InnerPurchasePage.tsx
@@ -69,7 +69,7 @@ const InnerPurchasePage = ({
             <div className="flex flex-col gap-2">
               <div>
                 <Link
-                  href={`/store/products/${product.id}`}
+                  href={`/products/${product.id}`}
                   className="text-sm font-medium hover:underline"
                 >
                   {product.name}

--- a/platform/flowglad-next/src/app/finance/subscriptions/[id]/InnerSubscriptionPage.tsx
+++ b/platform/flowglad-next/src/app/finance/subscriptions/[id]/InnerSubscriptionPage.tsx
@@ -223,7 +223,7 @@ const InnerSubscriptionPage = ({
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <Link
-                              href={`/store/pricing-models/${pricingModel.id}`}
+                              href={`/pricing-models/${pricingModel.id}`}
                               className="hover:underline hover:text-foreground transition-colors"
                             >
                               {pricingModel.name}
@@ -299,7 +299,7 @@ const InnerSubscriptionPage = ({
                     variant="subscription"
                     quantity={item.quantity}
                     renewalDate={renewalDate}
-                    href={`/store/products/${productId}`}
+                    href={`/products/${productId}`}
                   />
                 )
               })}

--- a/platform/flowglad-next/src/app/finance/subscriptions/columns.tsx
+++ b/platform/flowglad-next/src/app/finance/subscriptions/columns.tsx
@@ -132,9 +132,7 @@ export const columns: ColumnDef<Subscription.TableRowData>[] = [
       const product = row.original.product
       return (
         <div>
-          <DataTableLinkableCell
-            href={`/store/products/${product.id}`}
-          >
+          <DataTableLinkableCell href={`/products/${product.id}`}>
             {product.name}
           </DataTableLinkableCell>
         </div>

--- a/platform/flowglad-next/src/app/pricing-models/data-table.tsx
+++ b/platform/flowglad-next/src/app/pricing-models/data-table.tsx
@@ -198,7 +198,7 @@ export function PricingModelsDataTable({
                     return
                   }
                   router.push(
-                    `/store/pricing-models/${row.original.pricingModel.id}`
+                    `/pricing-models/${row.original.pricingModel.id}`
                   )
                 }}
               >

--- a/platform/flowglad-next/src/app/products/[id]/InternalProductDetailsPage.tsx
+++ b/platform/flowglad-next/src/app/products/[id]/InternalProductDetailsPage.tsx
@@ -70,7 +70,7 @@ function InternalProductDetailsPage(
   ]
 
   const handleBreadcrumbClick = () => {
-    router.push(`/store/pricing-models/${pricingModel.id}`)
+    router.push(`/pricing-models/${pricingModel.id}`)
   }
 
   return (

--- a/platform/flowglad-next/src/app/products/data-table.tsx
+++ b/platform/flowglad-next/src/app/products/data-table.tsx
@@ -237,9 +237,7 @@ export function ProductsDataTable({
                   ) {
                     return
                   }
-                  router.push(
-                    `/store/products/${row.original.product.id}`
-                  )
+                  router.push(`/products/${row.original.product.id}`)
                 }}
               >
                 {row.getVisibleCells().map((cell) => (

--- a/platform/flowglad-next/src/app/store/features/[id]/InnerFeatureDetailsPage.tsx
+++ b/platform/flowglad-next/src/app/store/features/[id]/InnerFeatureDetailsPage.tsx
@@ -182,7 +182,7 @@ function InnerFeatureDetailsPage({
           {
             label: (
               <Link
-                href={`/store/pricing-models/${pricingModel.id}`}
+                href={`/pricing-models/${pricingModel.id}`}
                 className="hover:underline hover:text-foreground transition-colors"
               >
                 {pricingModel.name}
@@ -209,9 +209,9 @@ function InnerFeatureDetailsPage({
 
   const handleBreadcrumbClick = () => {
     if (pricingModel) {
-      router.push(`/store/pricing-models/${pricingModel.id}`)
+      router.push(`/pricing-models/${pricingModel.id}`)
     } else {
-      router.push('/store/pricing-models')
+      router.push('/pricing-models')
     }
   }
 

--- a/platform/flowglad-next/src/app/usage-meters/columns.tsx
+++ b/platform/flowglad-next/src/app/usage-meters/columns.tsx
@@ -77,7 +77,7 @@ export const columns: ColumnDef<UsageMeterTableRowData>[] = [
       return (
         <div onClick={(e) => e.stopPropagation()}>
           <DataTableLinkableCell
-            href={`/store/pricing-models/${pricingModelId}`}
+            href={`/pricing-models/${pricingModelId}`}
           >
             {name}
           </DataTableLinkableCell>

--- a/platform/flowglad-next/src/components/forms/CreatePricingModelModal.tsx
+++ b/platform/flowglad-next/src/components/forms/CreatePricingModelModal.tsx
@@ -58,7 +58,7 @@ const CreatePricingModelModal: React.FC<
       onSuccess: ({ pricingModel }) => {
         toast.success('Pricing model created successfully')
         setIsOpen(false)
-        router.push(`/store/pricing-models/${pricingModel.id}`)
+        router.push(`/pricing-models/${pricingModel.id}`)
         resetState()
       },
       onError: (error) => {
@@ -74,7 +74,7 @@ const CreatePricingModelModal: React.FC<
           'Pricing model created from template successfully'
         )
         setIsOpen(false)
-        router.push(`/store/pricing-models/${pricingModel.id}`)
+        router.push(`/pricing-models/${pricingModel.id}`)
         resetState()
       },
       onError: (error) => {

--- a/platform/flowglad-next/src/components/navigation/Breadcrumb.tsx
+++ b/platform/flowglad-next/src/components/navigation/Breadcrumb.tsx
@@ -10,7 +10,7 @@ import { usePathname } from 'next/navigation'
  * This allows certain parts of a URL to become navigable links in the breadcrumb.
  */
 const pathMap: Record<string, string> = {
-  products: '/store/pricing-models',
+  products: '/pricing-models',
   payments: '/finance/payments',
   subscriptions: '/finance/subscriptions',
 }

--- a/playground/generation-based-subscription/README.md
+++ b/playground/generation-based-subscription/README.md
@@ -34,7 +34,7 @@ This project demonstrates the "Generation-Based Subscription Template Pricing Mo
 To use this example project, you'll need to upload the `pricing.yaml` file to your Flowglad dashboard and set it as your default pricing model:
 
 1. Log in to your [Flowglad dashboard](https://flowglad.com)
-2. Navigate to the Pricing Models section [Flowglad pricing models page](https://app.flowglad.com/store/pricing-models)
+2. Navigate to the Pricing Models section [Flowglad pricing models page](https://app.flowglad.com/pricing-models)
 3. Click on Create Pricing Model
 4. Import the `pricing.yaml` file from the root of this project
 5. Once uploaded, set it as your default pricing model in the dashboard settings


### PR DESCRIPTION
## What Does this PR Do?
remove problematic /store from paths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the /store prefix from app routes and docs to match current routing and fix broken links. Navigation and breadcrumbs now point to /pricing-models, /products, and finance pages.

- **Bug Fixes**
  - Updated links in purchases, subscriptions, products, usage meters, and pricing models tables to use /products and /pricing-models.
  - Fixed breadcrumb mapping for products to /pricing-models.
  - Updated docs/READMEs: pricing models now at /pricing-models; discounts at /finance/discounts; removed outdated “store” references.

<sup>Written for commit b35f1957209be26391c98a58acf1a4b885d08188. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

