### PR TITLE
fix: usage events bulk route config

### DIFF
--- a/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
+++ b/platform/flowglad-next/src/app/api/v1/[...path]/route.ts
@@ -38,7 +38,10 @@ import { productsRouteConfigs } from '@/server/routers/productsRouter'
 import { purchasesRouteConfigs } from '@/server/routers/purchasesRouter'
 import { subscriptionItemFeaturesRouteConfigs } from '@/server/routers/subscriptionItemFeaturesRouter'
 import { subscriptionsRouteConfigs } from '@/server/routers/subscriptionsRouter'
-import { usageEventsRouteConfigs } from '@/server/routers/usageEventsRouter'
+import {
+  usageEventsBulkRouteConfig,
+  usageEventsRouteConfigs,
+} from '@/server/routers/usageEventsRouter'
 import { usageMetersRouteConfigs } from '@/server/routers/usageMetersRouter'
 import { webhooksRouteConfigs } from '@/server/routers/webhooksRouter'
 import { createApiContext } from '@/server/trpcContext'
@@ -106,6 +109,7 @@ const routes: Record<string, RouteConfig> = {
   ...setupPricingModelRouteConfig,
   ...refundPaymentRouteConfig,
   ...customerBillingRouteConfig,
+  ...usageEventsBulkRouteConfig,
   ...discountsRouteConfigs,
   ...productsRouteConfigs,
   ...subscriptionItemFeaturesRouteConfigs,

--- a/platform/flowglad-next/src/server/routers/usageEventsRouter.routeConfigs.test.ts
+++ b/platform/flowglad-next/src/server/routers/usageEventsRouter.routeConfigs.test.ts
@@ -5,7 +5,10 @@ import {
   validateRouteConfigStructure,
   validateStandardCrudMappings,
 } from './routeConfigs.test-utils'
-import { usageEventsRouteConfigs } from './usageEventsRouter'
+import {
+  usageEventsBulkRouteConfig,
+  usageEventsRouteConfigs,
+} from './usageEventsRouter'
 
 describe('usageEventsRouteConfigs', () => {
   // Helper function to find route config in the array
@@ -92,6 +95,34 @@ describe('usageEventsRouteConfigs', () => {
       // Test mapParams with matches only (simulate route handler slicing)
       const result = routeConfig!.mapParams(['test-id'])
       expect(result).toEqual({ id: 'test-id' })
+    })
+
+    it('should map POST /usage-events/bulk to usageEvents.bulkInsert procedure', () => {
+      const routeConfig =
+        usageEventsBulkRouteConfig['POST /usage-events/bulk']
+
+      expect(routeConfig).toBeDefined()
+      expect(routeConfig.procedure).toBe('usageEvents.bulkInsert')
+
+      // Test pattern matching
+      expect(routeConfig.pattern.test('usage-events/bulk')).toBe(true)
+      expect(
+        routeConfig.pattern.test('usage-events/bulk/extra')
+      ).toBe(false)
+      expect(routeConfig.pattern.test('usage-events')).toBe(false)
+
+      // Test mapParams with body
+      const testBody = {
+        usageEvents: [
+          {
+            subscriptionId: 'sub_123',
+            amount: 100,
+            priceId: 'price_456',
+          },
+        ],
+      }
+      const result = routeConfig.mapParams([], testBody)
+      expect(result).toEqual(testBody)
     })
   })
 

--- a/platform/flowglad-next/src/server/routers/usageEventsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/usageEventsRouter.ts
@@ -29,7 +29,10 @@ import {
 import { idInputSchema } from '@/db/tableUtils'
 import { protectedProcedure } from '@/server/trpc'
 import { PriceType } from '@/types'
-import { generateOpenApiMetas } from '@/utils/openapi'
+import {
+  generateOpenApiMetas,
+  type RouteConfig,
+} from '@/utils/openapi'
 import {
   createUsageEventWithSlugSchema,
   ingestAndProcessUsageEvent,
@@ -43,6 +46,15 @@ const { openApiMetas, routeConfigs } = generateOpenApiMetas({
 })
 
 export const usageEventsRouteConfigs = routeConfigs
+
+export const usageEventsBulkRouteConfig: Record<string, RouteConfig> =
+  {
+    'POST /usage-events/bulk': {
+      procedure: 'usageEvents.bulkInsert',
+      pattern: /^usage-events\/bulk$/,
+      mapParams: (_, body) => body,
+    },
+  }
 
 export const createUsageEvent = protectedProcedure
   .meta(openApiMetas.POST)


### PR DESCRIPTION
## What Does this PR Do?
- fix 404 on bulk insert usage events by adding custom route config
- add tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 404 errors on POST /usage-events/bulk by adding an explicit route config that maps to usageEvents.bulkInsert. Adds tests to ensure correct routing and parameter mapping.

- **Bug Fixes**
  - Added usageEventsBulkRouteConfig for POST /usage-events/bulk (pattern: ^usage-events/bulk$) with body pass-through to usageEvents.bulkInsert.
  - Registered the bulk route in the API v1 router and added tests for mapping, pattern matching, and mapParams.

<sup>Written for commit 31abee84fb71b6bdcd1121089029f4b9b04131c8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bulk usage events endpoint enabling efficient batch processing of multiple usage events in a single request, improving data ingestion performance.

* **Tests**
  * Added comprehensive test coverage for the new bulk usage events endpoint to ensure correct functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->