### PR TITLE
fix: doNotCharge subscription prevent billing runs and PastDue status in billing period transition

### DIFF
--- a/platform/flowglad-next/src/subscriptions/billingPeriodHelpers.ts
+++ b/platform/flowglad-next/src/subscriptions/billingPeriodHelpers.ts
@@ -320,7 +320,10 @@ export const attemptToTransitionSubscriptionBillingPeriod = async (
     BillingPeriodStatus.Active,
     transaction
   )
-  if (paymentMethodId) {
+  // Only create billing run if payment method exists and doNotCharge is false.
+  // Note: API validation should prevent doNotCharge=true with payment methods,
+  // but we handle this defensively to ensure no billing runs are created.
+  if (paymentMethodId && !subscription.doNotCharge) {
     const paymentMethod = await selectPaymentMethodById(
       paymentMethodId,
       transaction
@@ -347,9 +350,10 @@ export const attemptToTransitionSubscriptionBillingPeriod = async (
       id: subscription.id,
       currentBillingPeriodEnd: newBillingPeriod.endDate,
       currentBillingPeriodStart: newBillingPeriod.startDate,
-      status: paymentMethodId
-        ? SubscriptionStatus.Active
-        : SubscriptionStatus.PastDue,
+      status:
+        paymentMethodId || subscription.doNotCharge
+          ? SubscriptionStatus.Active
+          : SubscriptionStatus.PastDue,
       renews: subscription.renews,
     },
     transaction


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent billing runs and PastDue status for doNotCharge subscriptions during billing period transitions. doNotCharge subscriptions now stay Active and skip billing runs, even if a payment method exists.

- **Bug Fixes**
  - Updated billing period transition to only create a billing run when a payment method exists and doNotCharge is false; status stays Active if either a payment method exists or doNotCharge is true, otherwise becomes PastDue.
  - Added tests for doNotCharge with and without payment methods to ensure no billing run is created, status remains Active, and a new billing period is opened.

<sup>Written for commit 7eeca82e746c8d1207509dc305808edec1ff2255. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of "do not charge" subscriptions during billing transitions. These subscriptions will no longer trigger unnecessary billing runs and will correctly maintain Active status even without payment methods configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->