### PR TITLE
fix: rm broken, repetitive, unhelpful link

### DIFF
--- a/platform/docs/sdks/checkout-sessions.mdx
+++ b/platform/docs/sdks/checkout-sessions.mdx
@@ -14,7 +14,7 @@ Flowglad offers three distinct types of checkout sessions, each tailored to diff
 - **Activate Subscription**: You use this when a subscription already exists, but the customer still needs to provide payment details and formally start billing. It will prompt the customer to add or confirm a payment method, pay any outstanding invoices tied to the subscription, and transition the subscription from a pending/credit state to “active,” establishing the billing cycle anchor.
 
 ### Customer Association
-When creating checkout sessions from the SDK, the authenticated customer's ID will be linked automatically to the checkout sesion.
+When creating checkout sessions from the SDK, the authenticated customer's ID will be linked automatically to the checkout session.
 Associating a checkout session with an existing customer record ensures that all billing activities are correctly attributed and avoids potential data discrepancies or the creation of duplicate customer profiles.
 To create anonymous checkout sessions, you can call the [create checkout session API](/api-reference/checkout-sessions/create-checkout-session#option-2) directly with `anonymous` field set to true.
 


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed broken, repetitive links to checkoutSession.ts from the Checkout Session Types docs. This reduces noise and prevents dead-link clicks; no code or API changes.

<sup>Written for commit 3232ba5a55d53b6556614e39739c729a1b10406c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the Checkout Session docs.
  * Clarified customer association benefits to avoid data discrepancies and duplicate profiles.
  * Added guidance on creating anonymous checkout sessions via the API.
  * Minor punctuation and wording polish in the Product checkout description.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->