### PR TITLE
chore: changeset log 0.16.0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,6 +9,7 @@
   "updateInternalDependencies": "patch",
   "ignore": [
     "@flowglad/playground-express",
-    "@flowglad/playground-generation-based-subscription"
+    "@flowglad/playground-generation-based-subscription",
+    "@flowglad/playground-react-native"
   ]
 }

--- a/.changeset/long-hounds-speak.md
+++ b/.changeset/long-hounds-speak.md
@@ -1,0 +1,93 @@
+---
+"@flowglad/express": minor
+"@flowglad/nextjs": minor
+"@flowglad/react": minor
+"@flowglad/server": minor
+"@flowglad/shared": minor
+---
+
+### Better Auth Plugin Support
+
+- [27e64bb6](https://github.com/flowglad/flowglad/commit/27e64bb6): Add Better Auth plugin integration for FlowgladServer and Next.js
+  - New `flowgladBetterAuthPlugin` available in `@flowglad/server/better-auth` and `@flowglad/nextjs/better-auth`
+  - Supports both user and organization-based customer types
+  - Customizable customer extraction via `getCustomer` function
+  - Automatic session management and customer creation
+  - Works seamlessly with Better Auth's plugin system
+
+### React Native Compatibility
+
+- [a0c7f482](https://github.com/flowglad/flowglad/commit/a0c7f482): Improve React Native compatibility in `@flowglad/react`
+  - Updated `FlowgladContext` and `FlowgladProvider` for React Native environments
+  - Removed browser-specific exports that don't work in React Native
+  - Improved cross-platform compatibility
+
+### Express Integration Migration
+
+- [2c212876](https://github.com/flowglad/flowglad/commit/2c212876): Move Express logic from `@flowglad/express` to `@flowglad/server/express`
+  - Express functionality now available via `@flowglad/server/express` subpath export
+  - New exports: `createExpressRouteHandler` and `createFlowgladExpressRouter`
+  - `@flowglad/express` package deprecated (see below)
+  - Migration: `import { createFlowgladExpressRouter } from '@flowglad/server/express'`
+
+### Create Subscription doNotCharge Support
+
+- [2fb21a4d](https://github.com/flowglad/flowglad/commit/2fb21a4d): Add `doNotCharge` parameter support for creating subscriptions
+  - Allows creating subscriptions without immediately charging the customer
+  - Useful for trial periods, free plans, or deferred billing scenarios
+  - Added comprehensive test coverage
+
+### Express Package Deprecation
+
+- [731a91eb](https://github.com/flowglad/flowglad/commit/731a91eb): Mark `@flowglad/express` package as deprecated
+  - Package continues to work but is no longer actively maintained
+  - Users should migrate to `@flowglad/server/express`
+  - Deprecation notice added to README and CHANGELOG
+
+### Type Resolution Improvements
+
+- [704ea9e5](https://github.com/flowglad/flowglad/commit/704ea9e5): Add `typesVersions` for Node module resolution compatibility
+  - Enables proper TypeScript resolution for subpath exports (express, better-auth)
+  - Ensures Node.js module resolution works correctly with TypeScript
+
+- [e27365b8](https://github.com/flowglad/flowglad/commit/e27365b8): Add express to tsconfig.declarations.json for type generation
+  - Ensures TypeScript declaration files are properly generated for Express exports
+
+### Documentation Updates
+
+- [16448962](https://github.com/flowglad/flowglad/commit/16448962): Update Express integration docs for deprecation
+  - Updated documentation to reflect Express migration
+  - Added migration guide references
+  - Updated examples to use new `@flowglad/server/express` import path
+
+## Updated Dependencies
+
+- `@flowglad/server`: Added `better-auth` and `express` as optional peer dependencies
+- All packages remain at version 0.15.1 in their CHANGELOGs
+
+## Breaking Changes
+
+⚠️ **None** - All changes are additive or deprecation notices. The deprecated `@flowglad/express` package continues to work, but users are encouraged to migrate to `@flowglad/server/express`.
+
+## Migration Guide
+
+### Express Users
+
+**Before:**
+```typescript
+import { createFlowgladExpressRouter } from '@flowglad/express'
+```
+
+**After:**
+```typescript
+import { createFlowgladExpressRouter } from '@flowglad/server/express'
+```
+
+### Better Auth Users
+
+**New Feature:**
+```typescript
+import { flowgladBetterAuthPlugin } from '@flowglad/server/better-auth'
+// or for Next.js
+import { flowgladBetterAuthPlugin } from '@flowglad/nextjs/better-auth'
+```

--- a/playground/react-native/package.json
+++ b/playground/react-native/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "flowglad-rn-example",
+  "name": "@flowglad/playground-react-native",
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {


### PR DESCRIPTION
## What Does this PR Do?
- changeset for 0.16.0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 0.16.0 changeset and release notes. Also renames the React Native playground package and ignores it in Changesets.

- **New Features**
  - Better Auth plugin for server and Next.js.
  - React Native compatibility updates in @flowglad/react.
  - Create subscription with doNotCharge support.
  - TypeScript typesVersions for subpath exports.

- **Migration**
  - Express moved to @flowglad/server/express.
  - Update imports: from @flowglad/express to @flowglad/server/express.

<sup>Written for commit 82639ed52d7b7c271b30856129952740eab88c7d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Better Auth plugin integration for FlowgladServer and Next.js with customer-type support and automatic session management
  * Create subscription doNotCharge support enabling deferred billing
  * React Native compatibility improvements

* **Deprecations**
  * Express package deprecated; migration guidance provided to server/express alternative

* **Documentation**
  * Added migration guides for Express and Better Auth users
  * Type resolution improvements and documentation updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->