### PR TITLE
fix: publish release workflow node compatibility issue

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -76,7 +76,7 @@ jobs:
       # Setup Node.js and configure npm registry authentication
       # NPM_TOKEN secret must be set in repository settings
       - name: Setup Node.js
-        uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a # v3
+        uses: actions/setup-node@v6.1.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the publish-release workflow to Node.js 20 to fix Node 18 issues and stabilize releases. Add manual dispatch with branch input and update checkout/conditions to publish from the selected branch or the merge commit.

<sup>Written for commit 967c5b23499f8ec5093e17e1cec03e231aad22b3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now supports manual triggers with a selectable branch for flexible deployments.
  * Checkout logic updated to determine the correct ref for manual or merged-release runs.
  * Upgraded Node.js runtime from 18 to 20.
  * Workflow permissions adjusted for required write access.
  * Bun setup retained; checkout behavior preserved for full repository context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->