### PR TITLE
feat: sdk hasPurchased helper function

### DIFF
--- a/packages/react/src/FlowgladContext.tsx
+++ b/packages/react/src/FlowgladContext.tsx
@@ -11,6 +11,7 @@ import {
   constructCheckUsageBalance,
   constructGetPrice,
   constructGetProduct,
+  constructHasPurchased,
   FlowgladActionKey,
   flowgladActionValidators,
   type UncancelSubscriptionParams,
@@ -74,6 +75,7 @@ export interface NonPresentContextValues {
   createActivateSubscriptionCheckoutSession: null
   checkFeatureAccess: null
   checkUsageBalance: null
+  hasPurchased: null
   pricingModel: null
   billingPortalUrl: null
   reload: null
@@ -122,6 +124,7 @@ const notPresentContextValues: NonPresentContextValues = {
   createActivateSubscriptionCheckoutSession: null,
   checkFeatureAccess: null,
   checkUsageBalance: null,
+  hasPurchased: null,
   pricingModel: null,
   billingPortalUrl: null,
   reload: null,
@@ -410,6 +413,10 @@ export const FlowgladContextProvider = (
     const checkUsageBalance = constructCheckUsageBalance(
       billingData.currentSubscriptions ?? []
     )
+    const hasPurchased = constructHasPurchased(
+      billingData.catalog,
+      billingData.purchases
+    )
 
     return (
       <FlowgladContext.Provider
@@ -450,6 +457,7 @@ export const FlowgladContextProvider = (
             }),
           checkFeatureAccess,
           checkUsageBalance,
+          hasPurchased,
           getProduct,
           getPrice,
           reload: () => Promise.resolve(),
@@ -541,6 +549,10 @@ export const FlowgladContextProvider = (
       }
       const getProduct = constructGetProduct(billingData.catalog)
       const getPrice = constructGetPrice(billingData.catalog)
+      const hasPurchased = constructHasPurchased(
+        billingData.catalog,
+        billingData.purchases
+      )
       value = {
         loaded: true,
         loadBilling,
@@ -552,6 +564,7 @@ export const FlowgladContextProvider = (
         createActivateSubscriptionCheckoutSession,
         getProduct,
         getPrice,
+        hasPurchased,
         checkFeatureAccess: constructCheckFeatureAccess(
           billingData.currentSubscriptions ?? []
         ),

--- a/packages/server/src/FlowgladServer.ts
+++ b/packages/server/src/FlowgladServer.ts
@@ -11,6 +11,7 @@ import {
   constructCheckUsageBalance,
   constructGetPrice,
   constructGetProduct,
+  constructHasPurchased,
   createActivateSubscriptionCheckoutSessionSchema,
   createAddPaymentMethodCheckoutSessionSchema,
   createProductCheckoutSessionSchema,
@@ -98,6 +99,10 @@ export class FlowgladServer {
       ),
       getProduct: constructGetProduct(rawBilling.catalog),
       getPrice: constructGetPrice(rawBilling.catalog),
+      hasPurchased: constructHasPurchased(
+        rawBilling.catalog,
+        rawBilling.purchases
+      ),
     }
   }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -42,5 +42,6 @@ export {
   constructCheckUsageBalance,
   constructGetPrice,
   constructGetProduct,
+  constructHasPurchased,
   getBaseURL,
 } from './utils'

--- a/packages/shared/src/types/sdk.ts
+++ b/packages/shared/src/types/sdk.ts
@@ -96,6 +96,14 @@ export type BillingWithChecks = CustomerRetrieveBillingResponse & {
    * @returns The price, or null if the price is not found
    */
   getPrice: (priceSlug: string) => Price | null
+
+  /**
+   * @experimental
+   * Checks if a customer has purchased a specific product, based on the product's slug
+   * @param productSlug - The slug of the product to check
+   * @returns True if the customer has purchased the product, false otherwise
+   */
+  hasPurchased: (productSlug: string) => boolean
 }
 
 export type SubscriptionExperimentalFields =

--- a/playground/generation-based-subscription/src/app/home-client.tsx
+++ b/playground/generation-based-subscription/src/app/home-client.tsx
@@ -20,6 +20,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { CheckCircle2 } from 'lucide-react'
 
 // Mock images to cycle through
 const mockImages = [
@@ -150,6 +151,15 @@ export function HomeClient() {
   )
   const hasOptionalTopUps = !!billing.checkFeatureAccess(
     'optional_credit_top_ups'
+  )
+
+  // Check if customer has purchased top-up products by product slug
+  // This is a bit of a strange use case, but is just demonstrating how to use the hasPurchased function
+  const hasPurchasedFastGenTopUp = billing.hasPurchased(
+    'fast_generation_top_ups'
+  )
+  const hasPurchasedHDVideoTopUp = billing.hasPurchased(
+    'hd_video_minute_top_ups'
   )
 
   // Calculate progress for usage meters - get slug from price using priceId
@@ -592,10 +602,15 @@ export function HomeClient() {
                               handlePurchaseFastGenerationTopUp
                             }
                             variant="secondary"
-                            className="w-full transition-transform hover:-translate-y-px"
+                            className="w-full transition-transform hover:-translate-y-px relative"
                             disabled={!hasOptionalTopUps}
                           >
-                            Buy Fast Generations ($4.00 for 80)
+                            <span className="flex items-center justify-center gap-2">
+                              Buy Fast Generations ($4.00 for 80)
+                              {hasPurchasedFastGenTopUp && (
+                                <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
+                              )}
+                            </span>
                           </Button>
                         </span>
                       </TooltipTrigger>
@@ -613,10 +628,15 @@ export function HomeClient() {
                           <Button
                             onClick={handlePurchaseHDVideoTopUp}
                             variant="secondary"
-                            className="w-full transition-transform hover:-translate-y-px"
+                            className="w-full transition-transform hover:-translate-y-px relative"
                             disabled={!hasOptionalTopUps}
                           >
-                            Buy HD Video Minutes ($10.00 for 10 min)
+                            <span className="flex items-center justify-center gap-2">
+                              Buy HD Video Minutes ($10.00 for 10 min)
+                              {hasPurchasedHDVideoTopUp && (
+                                <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
+                              )}
+                            </span>
                           </Button>
                         </span>
                       </TooltipTrigger>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a hasPurchased helper to the SDK to check if a customer has bought a product by slug. Updated React and server contexts to expose it, and the playground UI now shows purchase state for top-ups.

- **New Features**
  - Added constructHasPurchased in shared utils (catalog + purchases -> boolean by productSlug).
  - Exposed hasPurchased in FlowgladContext and FlowgladServer via BillingWithChecks.
  - Added hasPurchased to SDK types and re-exported.
  - Playground: shows a checkmark on Fast Generations and HD Video top-up buttons when purchased.

<sup>Written for commit b29143419250d77f1f9e400473461647608323a6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to check if customers have purchased specific products
  * Added visual indicators (checkmarks) in the UI to display purchased top-ups

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->