### PR TITLE
feat: sdk createUsageEvent with usage meter

### DIFF
--- a/packages/shared/src/actions.test.ts
+++ b/packages/shared/src/actions.test.ts
@@ -238,6 +238,21 @@ describe('createUsageEventSchema', () => {
     expect(result.success).toBe(true)
   })
 
+  it('accepts valid input with usageMeterId', () => {
+    const input = { ...validBaseParams, usageMeterId: 'meter_123' }
+    const result = createUsageEventSchema.safeParse(input)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts valid input with usageMeterSlug', () => {
+    const input = {
+      ...validBaseParams,
+      usageMeterSlug: 'my-meter-slug',
+    }
+    const result = createUsageEventSchema.safeParse(input)
+    expect(result.success).toBe(true)
+  })
+
   it('rejects input with both priceId and priceSlug', () => {
     const input = {
       ...validBaseParams,
@@ -248,7 +263,57 @@ describe('createUsageEventSchema', () => {
     expect(result.success).toBe(false)
   })
 
-  it('rejects input with neither priceId nor priceSlug', () => {
+  it('rejects input with both usageMeterId and usageMeterSlug', () => {
+    const input = {
+      ...validBaseParams,
+      usageMeterId: 'meter_123',
+      usageMeterSlug: 'my-meter-slug',
+    }
+    const result = createUsageEventSchema.safeParse(input)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects input with priceId and usageMeterId', () => {
+    const input = {
+      ...validBaseParams,
+      priceId: 'price_123',
+      usageMeterId: 'meter_123',
+    }
+    const result = createUsageEventSchema.safeParse(input)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects input with priceId and usageMeterSlug', () => {
+    const input = {
+      ...validBaseParams,
+      priceId: 'price_123',
+      usageMeterSlug: 'my-meter-slug',
+    }
+    const result = createUsageEventSchema.safeParse(input)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects input with priceSlug and usageMeterId', () => {
+    const input = {
+      ...validBaseParams,
+      priceSlug: 'my-price-slug',
+      usageMeterId: 'meter_123',
+    }
+    const result = createUsageEventSchema.safeParse(input)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects input with priceSlug and usageMeterSlug', () => {
+    const input = {
+      ...validBaseParams,
+      priceSlug: 'my-price-slug',
+      usageMeterSlug: 'my-meter-slug',
+    }
+    const result = createUsageEventSchema.safeParse(input)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects input with neither priceId, priceSlug, usageMeterId, nor usageMeterSlug', () => {
     const result = createUsageEventSchema.safeParse(validBaseParams)
     expect(result.success).toBe(false)
   })

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -101,16 +101,41 @@ const baseUsageEventFields = z.object({
 const usageEventWithPriceId = baseUsageEventFields.extend({
   priceId: z.string(),
   priceSlug: z.never().optional(), // Explicitly disallow
+  usageMeterId: z.never().optional(), // Explicitly disallow
+  usageMeterSlug: z.never().optional(), // Explicitly disallow
 })
 
 const usageEventWithPriceSlug = baseUsageEventFields.extend({
   priceSlug: z.string(),
   priceId: z.never().optional(), // Explicitly disallow
+  usageMeterId: z.never().optional(), // Explicitly disallow
+  usageMeterSlug: z.never().optional(), // Explicitly disallow
 })
 
+const usageEventWithUsageMeterId = baseUsageEventFields.extend({
+  usageMeterId: z.string(),
+  priceId: z.never().optional(), // Explicitly disallow
+  priceSlug: z.never().optional(), // Explicitly disallow
+  usageMeterSlug: z.never().optional(), // Explicitly disallow
+})
+
+const usageEventWithUsageMeterSlug = baseUsageEventFields.extend({
+  usageMeterSlug: z.string(),
+  priceId: z.never().optional(), // Explicitly disallow
+  priceSlug: z.never().optional(), // Explicitly disallow
+  usageMeterId: z.never().optional(), // Explicitly disallow
+})
+
+/**
+ * Schema for creating a usage event. You must provide exactly one identifier:
+ * - `priceId` or `priceSlug`: For price-based usage tracking
+ * - `usageMeterId` or `usageMeterSlug`: For usage meter-based tracking
+ */
 export const createUsageEventSchema = z.union([
   usageEventWithPriceId,
   usageEventWithPriceSlug,
+  usageEventWithUsageMeterId,
+  usageEventWithUsageMeterSlug,
 ])
 
 export type CreateUsageEventParams = z.infer<


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add usage meter support to SDK createUsageEvent. You can now create usage events using a usageMeterId or usageMeterSlug, with validation to prevent mixing price and meter identifiers.

- **New Features**
  - Accepts usageMeterId or usageMeterSlug in createUsageEventSchema.
  - Enforces exactly one identifier: priceId/priceSlug or usageMeterId/usageMeterSlug.
  - Tests added for valid inputs and all invalid combinations.

<sup>Written for commit 4083482275d204cff9ad53a7b1e5acb2d66070c2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating usage events with usage meter identifiers as alternatives to price identifiers.
  * Implemented validation to ensure exactly one identifier type (price-based or usage-meter-based) is provided per usage event.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->