### PR TITLE
feat: support null price on usage events table

### DIFF
--- a/platform/flowglad-next/src/app/customers/[id]/usage-events/columns.tsx
+++ b/platform/flowglad-next/src/app/customers/[id]/usage-events/columns.tsx
@@ -15,7 +15,7 @@ export type UsageEventTableRowData = {
   customer: Customer.ClientRecord
   subscription: Subscription.ClientRecord
   usageMeter: UsageMeter.ClientRecord
-  price: Price.ClientRecord
+  price: Price.ClientRecord | null
 }
 
 export const columns: ColumnDef<UsageEventTableRowData>[] = [
@@ -101,10 +101,13 @@ export const columns: ColumnDef<UsageEventTableRowData>[] = [
   },
   {
     id: 'priceId',
-    accessorFn: (row) => row.price.id,
+    accessorFn: (row) => row.price?.id ?? null,
     header: 'Price',
     cell: ({ row }) => {
-      const priceId = row.getValue('priceId') as string
+      const priceId = row.getValue('priceId') as string | null
+      if (!priceId) {
+        return <div className="text-muted-foreground">-</div>
+      }
       return (
         <div onClick={(e) => e.stopPropagation()}>
           <DataTableCopyableCell copyText={priceId}>

--- a/platform/flowglad-next/src/db/schema/usageEvents.ts
+++ b/platform/flowglad-next/src/db/schema/usageEvents.ts
@@ -332,7 +332,7 @@ export const usageEventsTableRowDataSchema = z.object({
   customer: customerClientSelectSchema,
   subscription: subscriptionClientSelectSchema,
   usageMeter: usageMetersClientSelectSchema,
-  price: pricesClientSelectSchema,
+  price: pricesClientSelectSchema.nullable(),
 })
 
 // Paginated table row input schema

--- a/platform/flowglad-next/src/server/routers/usageEventsRouter.test.ts
+++ b/platform/flowglad-next/src/server/routers/usageEventsRouter.test.ts
@@ -352,7 +352,7 @@ describe('usageEventsRouter', () => {
         expect(enrichedEvent.customer.id).toBe(customer1.id)
         expect(enrichedEvent.subscription.id).toBe(subscription1.id)
         expect(enrichedEvent.usageMeter.id).toBe(usageMeter1.id)
-        expect(enrichedEvent.price.id).toBe(price1.id)
+        expect(enrichedEvent.price?.id).toBe(price1.id)
       })
     })
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow usage events to have no associated price. The table and API now include events with a null price and render a simple placeholder.

- **New Features**
  - Price on usage events is now nullable in the table row schema.
  - selectUsageEventsTableRowData returns events without prices; if a priceId exists but the price record is missing, we throw an error.
  - UI shows “-” in the Price column when no price is set and disables copying.
  - Tests cover mixed events with and without prices.

- **Migration**
  - Update any consumers to handle price being null (Price.ClientRecord | null).

<sup>Written for commit fa8514ccffed4e31069ce827a02c14b1e1d8d4fc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Usage events now support scenarios where price information is unavailable, with the UI displaying a placeholder when pricing data is missing.
  * Enhanced data integrity validation for usage event enrichment to ensure consistency across all related data relationships.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->