### PR TITLE
feat: add bulk usage events to sdk

### DIFF
--- a/packages/server/src/FlowgladServer.ts
+++ b/packages/server/src/FlowgladServer.ts
@@ -1,10 +1,11 @@
 import { Flowglad as FlowgladNode } from '@flowglad/node'
 import {
   type BillingWithChecks,
+  type BulkCreateUsageEventsParams,
+  bulkCreateUsageEventsSchema,
   type CancelSubscriptionParams,
   type CreateActivateSubscriptionCheckoutSessionParams,
   type CreateAddPaymentMethodCheckoutSessionParams,
-  type CreateBulkUsageEventsParams,
   type CreateProductCheckoutSessionParams,
   type CreateSubscriptionParams,
   type CreateUsageEventParams,
@@ -15,7 +16,6 @@ import {
   constructHasPurchased,
   createActivateSubscriptionCheckoutSessionSchema,
   createAddPaymentMethodCheckoutSessionSchema,
-  createBulkUsageEventsSchema,
   createProductCheckoutSessionSchema,
   createUsageEventSchema,
   type SubscriptionExperimentalFields,
@@ -364,12 +364,12 @@ export class FlowgladServer {
    * @returns The created usage events.
    * @throws {Error} If any subscription in the bulk request is not owned by the authenticated customer.
    */
-  public createBulkUsageEvents = async (
-    params: CreateBulkUsageEventsParams
+  public bulkCreateUsageEvents = async (
+    params: BulkCreateUsageEventsParams
   ): Promise<{
     usageEvents: FlowgladNode.UsageEvents.UsageEventCreateResponse['usageEvent'][]
   }> => {
-    const parsedParams = createBulkUsageEventsSchema.parse(params)
+    const parsedParams = bulkCreateUsageEventsSchema.parse(params)
 
     // Get billing to access current subscriptions for validation
     const billing = await this.getBilling()

--- a/packages/server/src/FlowgladServerAdmin.ts
+++ b/packages/server/src/FlowgladServerAdmin.ts
@@ -3,8 +3,8 @@ import {
   Flowglad as FlowgladNode,
 } from '@flowglad/node'
 import {
-  type CreateBulkUsageEventsParams,
-  createBulkUsageEventsSchema,
+  type BulkCreateUsageEventsParams,
+  bulkCreateUsageEventsSchema,
 } from '@flowglad/shared'
 
 export class FlowgladServerAdmin {
@@ -92,11 +92,11 @@ export class FlowgladServerAdmin {
    * @returns The created usage events.
    */
   public async bulkCreateUsageEvents(
-    params: CreateBulkUsageEventsParams
+    params: BulkCreateUsageEventsParams
   ): Promise<{
     usageEvents: FlowgladNode.UsageEvents.UsageEventCreateResponse['usageEvent'][]
   }> {
-    const parsedParams = createBulkUsageEventsSchema.parse(params)
+    const parsedParams = bulkCreateUsageEventsSchema.parse(params)
     const usageEvents = parsedParams.usageEvents.map(
       (usageEvent) => ({
         ...usageEvent,

--- a/packages/shared/src/actions.test.ts
+++ b/packages/shared/src/actions.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   billingAddressSchema,
+  bulkCreateUsageEventsSchema,
   cancelSubscriptionSchema,
   createActivateSubscriptionCheckoutSessionSchema,
   createAddPaymentMethodCheckoutSessionSchema,
-  createBulkUsageEventsSchema,
   createProductCheckoutSessionSchema,
   createSubscriptionSchema,
   createUsageEventSchema,
@@ -350,7 +350,7 @@ describe('createUsageEventSchema', () => {
   })
 })
 
-describe('createBulkUsageEventsSchema', () => {
+describe('bulkCreateUsageEventsSchema', () => {
   const validUsageEvent = {
     amount: 100,
     subscriptionId: 'sub_123',
@@ -360,7 +360,7 @@ describe('createBulkUsageEventsSchema', () => {
 
   it('accepts valid input with single usage event', () => {
     const input = { usageEvents: [validUsageEvent] }
-    const result = createBulkUsageEventsSchema.safeParse(input)
+    const result = bulkCreateUsageEventsSchema.safeParse(input)
     expect(result.success).toBe(true)
     if (result.success) {
       expect(result.data.usageEvents).toHaveLength(1)
@@ -381,7 +381,7 @@ describe('createBulkUsageEventsSchema', () => {
         },
       ],
     }
-    const result = createBulkUsageEventsSchema.safeParse(input)
+    const result = bulkCreateUsageEventsSchema.safeParse(input)
     expect(result.success).toBe(true)
     if (result.success) {
       expect(result.data.usageEvents).toHaveLength(3)
@@ -414,13 +414,13 @@ describe('createBulkUsageEventsSchema', () => {
         },
       ],
     }
-    const result = createBulkUsageEventsSchema.safeParse(input)
+    const result = bulkCreateUsageEventsSchema.safeParse(input)
     expect(result.success).toBe(true)
   })
 
   it('rejects empty array', () => {
     const input = { usageEvents: [] }
-    const result = createBulkUsageEventsSchema.safeParse(input)
+    const result = bulkCreateUsageEventsSchema.safeParse(input)
     expect(result.success).toBe(false)
   })
 
@@ -436,17 +436,17 @@ describe('createBulkUsageEventsSchema', () => {
         },
       ],
     }
-    const result = createBulkUsageEventsSchema.safeParse(input)
+    const result = bulkCreateUsageEventsSchema.safeParse(input)
     expect(result.success).toBe(false)
   })
 
   it('rejects missing usageEvents field', () => {
-    const result = createBulkUsageEventsSchema.safeParse({})
+    const result = bulkCreateUsageEventsSchema.safeParse({})
     expect(result.success).toBe(false)
   })
 
   it('rejects invalid usageEvents type', () => {
-    const result = createBulkUsageEventsSchema.safeParse({
+    const result = bulkCreateUsageEventsSchema.safeParse({
       usageEvents: 'not-an-array',
     })
     expect(result.success).toBe(false)

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -145,12 +145,12 @@ export type CreateUsageEventParams = z.infer<
 /**
  * Schema for bulk creating usage events. Takes an array of usage events.
  */
-export const createBulkUsageEventsSchema = z.object({
+export const bulkCreateUsageEventsSchema = z.object({
   usageEvents: z.array(createUsageEventSchema).min(1),
 })
 
-export type CreateBulkUsageEventsParams = z.infer<
-  typeof createBulkUsageEventsSchema
+export type BulkCreateUsageEventsParams = z.infer<
+  typeof bulkCreateUsageEventsSchema
 >
 
 export type CancelSubscriptionParams = z.infer<

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,8 +1,8 @@
 export type {
+  BulkCreateUsageEventsParams,
   CancelSubscriptionParams,
   CreateActivateSubscriptionCheckoutSessionParams,
   CreateAddPaymentMethodCheckoutSessionParams,
-  CreateBulkUsageEventsParams,
   CreateProductCheckoutSessionParams,
   CreateSubscriptionParams,
   CreateUsageEventParams,
@@ -11,10 +11,10 @@ export type {
 } from './actions'
 
 export {
+  bulkCreateUsageEventsSchema,
   cancelSubscriptionSchema,
   createActivateSubscriptionCheckoutSessionSchema,
   createAddPaymentMethodCheckoutSessionSchema,
-  createBulkUsageEventsSchema,
   createProductCheckoutSessionSchema,
   createSubscriptionSchema,
   createUsageEventSchema,


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bulk usage event creation to the server and admin SDKs, allowing multiple events to be created in one request to reduce API calls. Includes ownership checks on the customer-scoped path for safety.

- **New Features**
  - Server SDK: bulkCreateUsageEvents(params)
    - Validates all subscriptionIds belong to the authenticated customer's current subscriptions.
    - Normalizes properties and usageDate to undefined when absent.
    - Calls POST /api/v1/usage-events/bulk.
  - Admin SDK: bulkCreateUsageEvents(params)
    - Normalizes fields and calls POST /api/v1/usage-events/bulk.
  - Shared: Added bulkCreateUsageEventsSchema and BulkCreateUsageEventsParams; exported in index.

<sup>Written for commit 48936002a3b1471c42c80829babaf216610e7f0b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk usage events creation: submit multiple usage events in one request to streamline batch uploads and reduce API overhead.

* **Bug Fixes**
  * Improved handling of usage event timestamps to avoid unexpected defaulting and ensure correct recorded times.
  * Ownership validation added for bulk uploads to ensure events belong to the submitting account.

* **Tests**
  * Added validation tests covering bulk usage event inputs, acceptance cases, and rejection scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->