### PR TITLE
feat: add the eye-icon in the signup and the signin pages

### DIFF
--- a/platform/flowglad-next/src/app/sign-in/page.tsx
+++ b/platform/flowglad-next/src/app/sign-in/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { zodResolver } from '@hookform/resolvers/zod'
-import {Loader2, Eye, EyeOff } from 'lucide-react'
+import { Eye, EyeOff, Loader2 } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -19,13 +19,11 @@ import {
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { signInSchema } from '@/lib/schemas'
 import { cn } from '@/lib/utils'
 import { authClient, signIn } from '@/utils/authClient'
-import { signInSchema } from '@/lib/schemas'
 
 export default function SignIn() {
- 
-
   type SigninValues = z.infer<typeof signInSchema>
 
   const {
@@ -141,9 +139,15 @@ export default function SignIn() {
                   type="button"
                   onClick={() => setShowPassword((s) => !s)}
                   className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground"
-                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  aria-label={
+                    showPassword ? 'Hide password' : 'Show password'
+                  }
                 >
-                  {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+                  {showPassword ? (
+                    <EyeOff size={16} />
+                  ) : (
+                    <Eye size={16} />
+                  )}
                 </button>
               </div>
               <ErrorLabel error={errors.password} />

--- a/platform/flowglad-next/src/app/sign-up/page.tsx
+++ b/platform/flowglad-next/src/app/sign-up/page.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod'
 import type { ErrorContext } from 'better-auth/react'
-import { Loader2, Eye, EyeOff } from 'lucide-react' 
+import { Eye, EyeOff, Loader2 } from 'lucide-react'
 
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
@@ -37,14 +37,11 @@ export default function SignUp() {
     mode: 'onSubmit',
   })
 
-  
- 
   const router = useRouter()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [showPassword, setShowPassword] = useState(false)
 
-  
   const signupFetchOptions = {
     onResponse: () => {
       setLoading(false)
@@ -134,9 +131,15 @@ export default function SignUp() {
                   type="button"
                   onClick={() => setShowPassword((s) => !s)}
                   className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground"
-                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  aria-label={
+                    showPassword ? 'Hide password' : 'Show password'
+                  }
                 >
-                  {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+                  {showPassword ? (
+                    <EyeOff size={16} />
+                  ) : (
+                    <Eye size={16} />
+                  )}
                 </button>
               </div>
               <ErrorLabel error={errors.password} />

--- a/platform/flowglad-next/src/lib/schemas.ts
+++ b/platform/flowglad-next/src/lib/schemas.ts
@@ -14,12 +14,9 @@ export const signupSchema = z
     message: 'Passwords do not match',
   })
 
-
-export  const signInSchema = z.object({
-      email: z
-         
-        .email({ message: 'Please enter a valid email' }),
-      password: z
-        .string()
-        .min(1, { message: 'Please enter your password' }),
-    })
+export const signInSchema = z.object({
+  email: z.email({ message: 'Please enter a valid email' }),
+  password: z
+    .string()
+    .min(1, { message: 'Please enter your password' }),
+})


### PR DESCRIPTION
solves #1075 
added the eye icon to see the password in login pages
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->
<img width="672" height="642" alt="image" src="https://github.com/user-attachments/assets/8362b910-5b28-4a96-85e8-2337df9c9ade" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a show/hide password toggle to the sign-in and sign-up forms to improve usability. Also removes unused image upload code and centralizes the sign-in validation schema.

- **New Features**
  - Password visibility toggle on sign-in and sign-up with accessible button.

- **Refactors**
  - Move sign-in Zod schema to src/lib/schemas.ts and use it in the sign-in page.
  - Remove unused image state/handlers from sign-up.
  - Clean up unused imports and components.

<sup>Written for commit 59d2667c595e55eaabb1c5f2f23d90c9c06e9f91. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password visibility toggles (eye icons) on sign-in and sign-up pages with accessible controls to show/hide passwords.

* **Improvements**
  * Sign-up flow simplified by removing image upload, streamlining registration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->