### PR TITLE
Include MoR surcharge in total fee

### DIFF
--- a/platform/flowglad-next/src/utils/bookkeeping/fees/common.test.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/fees/common.test.ts
@@ -38,6 +38,7 @@ import {
   calculateTotalDueAmount,
   calculateTotalFeeAmount,
   finalizeFeeCalculation,
+  type TotalFeeAmountInput,
 } from './common'
 
 // Price and Discount Utilities
@@ -307,7 +308,7 @@ describe('calculatePaymentMethodFeeAmount', () => {
 })
 
 describe('calculateTotalFeeAmount', () => {
-  const coreFeeCalculation = {
+  const coreFeeCalculation: TotalFeeAmountInput = {
     baseAmount: 1000,
     discountAmountFixed: 0,
     taxAmountFixed: 90,
@@ -315,7 +316,7 @@ describe('calculateTotalFeeAmount', () => {
     morSurchargePercentage: '0',
     internationalFeePercentage: '0',
     paymentMethodFeeFixed: 59,
-  } as FeeCalculation.Record
+  }
 
   it('calculates total fee with all components', () => {
     const feeCalculation = {
@@ -323,7 +324,7 @@ describe('calculateTotalFeeAmount', () => {
       discountAmountFixed: 100,
       morSurchargePercentage: '0',
       internationalFeePercentage: '2.5',
-    } as FeeCalculation.Record
+    } satisfies TotalFeeAmountInput
     expect(calculateTotalFeeAmount(feeCalculation)).toBe(262)
   })
 
@@ -345,7 +346,7 @@ describe('calculateTotalFeeAmount', () => {
     const feeCalculation = {
       ...coreFeeCalculation,
       discountAmountFixed: -100,
-    } as FeeCalculation.Record
+    } satisfies TotalFeeAmountInput
     expect(calculateTotalFeeAmount(feeCalculation)).toBe(249)
   })
 
@@ -353,7 +354,7 @@ describe('calculateTotalFeeAmount', () => {
     const feeCalculation = {
       ...coreFeeCalculation,
       baseAmount: 0,
-    } as FeeCalculation.Record
+    } satisfies TotalFeeAmountInput
     expect(calculateTotalFeeAmount(feeCalculation)).toBe(149)
   })
 

--- a/platform/flowglad-next/src/utils/bookkeeping/fees/common.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/fees/common.ts
@@ -230,6 +230,20 @@ export interface TaxCalculationResult {
   stripeTaxTransactionId: string | null
 }
 
+export type TotalFeeAmountInput = Omit<
+  Pick<
+    FeeCalculation.Record,
+    | 'baseAmount'
+    | 'discountAmountFixed'
+    | 'flowgladFeePercentage'
+    | 'morSurchargePercentage'
+    | 'internationalFeePercentage'
+    | 'paymentMethodFeeFixed'
+    | 'taxAmountFixed'
+  >,
+  'morSurchargePercentage'
+> & { morSurchargePercentage?: string | null }
+
 export const calculateTaxes = async ({
   discountInclusiveAmount,
   product,
@@ -275,7 +289,7 @@ export const calculateTaxes = async ({
 
 /* Total Fee and Due Amount Calculations */
 export const calculateTotalFeeAmount = (
-  feeCalculation: FeeCalculation.Record
+  feeCalculation: TotalFeeAmountInput
 ): number => {
   const {
     baseAmount,
@@ -292,12 +306,12 @@ export const calculateTotalFeeAmount = (
     'Discount amount fixed'
   )
   validateNumericAmount(
-    parseFloat(morSurchargePercentage),
-    'MoR surcharge percentage'
-  )
-  validateNumericAmount(
     parseFloat(internationalFeePercentage),
     'International fee percentage'
+  )
+  validateNumericAmount(
+    parseFloat(morSurchargePercentage ?? '0'),
+    'MoR surcharge percentage'
   )
   const safeDiscount = discountAmountFixed
     ? Math.max(discountAmountFixed, 0)
@@ -307,13 +321,13 @@ export const calculateTotalFeeAmount = (
     discountInclusiveAmount,
     parseFloat(flowgladFeePercentage!)
   )
-  const morSurchargeFixed = calculatePercentageFee(
-    discountInclusiveAmount,
-    parseFloat(morSurchargePercentage)
-  )
   const intlFixed = calculatePercentageFee(
     discountInclusiveAmount,
     parseFloat(internationalFeePercentage!)
+  )
+  const morSurchargeFixed = calculatePercentageFee(
+    discountInclusiveAmount,
+    parseFloat(morSurchargePercentage ?? '0')
   )
   return Math.round(
     flowFixed +


### PR DESCRIPTION
## What Does this PR Do?
Includes `morSurchargePercentage` in `calculateTotalFeeAmount` so MoR surcharge is charged in the total fee amount.
Adds a unit test covering the surcharge calculation.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MoR surcharge to the total fee calculation so fees include the MoR percentage. Updates tests and input typing to make the calculation safer.

- **Bug Fixes**
  - Include morSurchargePercentage in calculateTotalFeeAmount with numeric validation.
  - Added a unit test and introduced TotalFeeAmountInput for clearer inputs (optional/null MoR supported).

<sup>Written for commit db643d1d126d2005ccd7ae71bd902dc5ed1e60da. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Total fee calculations now include the MoR surcharge percentage by default, producing more accurate totals and handling missing surcharge values gracefully.

* **Updates**
  * Fee calculation inputs and logic refined to treat missing surcharge as zero and incorporate the resulting fixed surcharge in final totals.

* **Tests**
  * Added/updated tests to verify MoR surcharge is included and handled correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->