### PR TITLE
fix circular type dependency

### DIFF
--- a/platform/flowglad-next/src/components/navigation/SidebarBannerCarousel.tsx
+++ b/platform/flowglad-next/src/components/navigation/SidebarBannerCarousel.tsx
@@ -13,22 +13,8 @@ import {
   CarouselItem,
 } from '@/components/ui/carousel'
 import { useSidebar } from '@/components/ui/sidebar'
-import type { BannerId } from '@/config/sidebarBannerConfig'
+import type { BannerSlide } from '@/config/sidebarBannerConfig'
 import { cn } from '@/lib/utils'
-
-export interface BannerSlide {
-  id: BannerId
-  /** Image URL - if provided, will display the image */
-  imageUrl?: string
-  /** Alt text for image */
-  alt?: string
-  /** Link URL */
-  href?: string
-  /** CTA button text (default: "Learn More") */
-  ctaText?: string
-  /** CTA button link - if different from main href */
-  ctaHref?: string
-}
 
 export interface SidebarBannerCarouselProps {
   slides: BannerSlide[]

--- a/platform/flowglad-next/src/config/sidebarBannerConfig.ts
+++ b/platform/flowglad-next/src/config/sidebarBannerConfig.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod'
-import type { BannerSlide } from '@/components/navigation/SidebarBannerCarousel'
 
 /**
  * Valid banner IDs as a const tuple for Zod enum validation.
@@ -20,6 +19,23 @@ const BANNER_IDS = [
 export const bannerIdSchema = z.enum(BANNER_IDS)
 
 export type BannerId = z.infer<typeof bannerIdSchema>
+
+/**
+ * Banner slide configuration for the sidebar carousel.
+ */
+export interface BannerSlide {
+  id: BannerId
+  /** Image URL - if provided, will display the image */
+  imageUrl?: string
+  /** Alt text for image */
+  alt?: string
+  /** Link URL */
+  href?: string
+  /** CTA button text (default: "Learn More") */
+  ctaText?: string
+  /** CTA button link - if different from main href */
+  ctaHref?: string
+}
 
 export const SIDEBAR_BANNER_SLIDES: BannerSlide[] = [
   {


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a circular type dependency in the sidebar banner carousel by moving the BannerSlide interface to sidebarBannerConfig and updating the component to import it. No runtime changes; type-only refactor.

- **Refactors**
  - Moved BannerSlide to sidebarBannerConfig.ts to live alongside BannerId.
  - Updated SidebarBannerCarousel.tsx to import type BannerSlide from config.
  - Removes local BannerSlide to prevent circular imports.

<sup>Written for commit 141f1a0ed0ecfc5a2172442cc1be007d793c0eab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

