### PR TITLE
fix: improve error handling for MoR-only countries and input validation

### DIFF
--- a/platform/flowglad-next/src/server/queries/getFundsFlowEligibilityForCountry.ts
+++ b/platform/flowglad-next/src/server/queries/getFundsFlowEligibilityForCountry.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { countryCodeSchema } from '@/db/commonZodSchema'
 import { protectedProcedure } from '@/server/trpc'
 import { StripeConnectContractType } from '@/types'
 import { getEligibleFundsFlowsForCountry } from '@/utils/countries'
@@ -6,7 +7,7 @@ import { getEligibleFundsFlowsForCountry } from '@/utils/countries'
 export const getFundsFlowEligibilityForCountry = protectedProcedure
   .input(
     z.object({
-      countryCode: z.string(),
+      countryCode: countryCodeSchema,
     })
   )
   .output(

--- a/platform/flowglad-next/src/utils/organizationHelpers.ts
+++ b/platform/flowglad-next/src/utils/organizationHelpers.ts
@@ -119,6 +119,16 @@ export const createOrganizationTransaction = async (
     )
   }
 
+  // In production, check if country is MoR-only (not eligible for Platform)
+  if (
+    core.IS_PROD &&
+    !eligibleFlows.includes(StripeConnectContractType.Platform)
+  ) {
+    throw new Error(
+      `Country ${country.code} is not yet supported in production. Only countries eligible for Platform funds flow are currently supported.`
+    )
+  }
+
   const stripeConnectContractType = core.IS_PROD
     ? StripeConnectContractType.Platform
     : (requestedStripeConnectContractType ??


### PR DESCRIPTION
- Add explicit check for MoR-only countries in production with clearer error message
- Add stricter input validation for countryCode parameter (min/max 2 chars, trim, uppercase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve country code validation and add a production-only guard that blocks MoR-only countries with a clear error. Prevents unsupported funds flow selection during org creation.

- **Bug Fixes**
  - Enforce 2-letter countryCode with trim and uppercase in getFundsFlowEligibilityForCountry.
  - In production, throw a clear error when the country isn’t eligible for Platform funds flow (MoR-only).

<sup>Written for commit 3ec1ad2f8efd924847bc22fb44bf131f0888d876. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

