### PR TITLE
feat: add clientCreateUsageEvent schema and action key

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@flowglad/javascript",

--- a/packages/server/src/subrouteHandlers/index.ts
+++ b/packages/server/src/subrouteHandlers/index.ts
@@ -38,4 +38,14 @@ export const routeToHandlerMap: {
       },
     }
   },
+  [FlowgladActionKey.CreateUsageEvent]: async () => {
+    return {
+      data: {},
+      status: 501,
+      error: {
+        code: 'Not Implemented',
+        json: {},
+      },
+    }
+  },
 }

--- a/packages/shared/src/types/sdk.ts
+++ b/packages/shared/src/types/sdk.ts
@@ -11,6 +11,7 @@ export enum FlowgladActionKey {
   UncancelSubscription = 'subscriptions/uncancel',
   CreateSubscription = 'subscriptions/create',
   UpdateCustomer = 'customers/update',
+  CreateUsageEvent = 'usage-events/create',
 }
 
 export enum HTTPMethod {

--- a/platform/flowglad-next/bun.lock
+++ b/platform/flowglad-next/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "flowglad-next",


### PR DESCRIPTION
## What Does this PR Do?

Adds the schema and action key infrastructure for client-side usage event creation. Introduces `FlowgladActionKey.CreateUsageEvent` and `clientCreateUsageEventSchema` which allows developers to call `createUsageEvent` from the client with auto-resolved defaults (subscriptionId, amount, transactionId). Includes placeholder server handler (501 Not Implemented) as this is PR 1 of a 3-PR implementation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds client-side usage event creation via a new action key and schema, with server-resolved defaults for common fields. The server route is stubbed and returns 501 until the follow-up implementation.

- **New Features**
  - Added FlowgladActionKey.CreateUsageEvent and wired validator to clientCreateUsageEventSchema.
  - Schema requires exactly one identifier (priceId | priceSlug | usageMeterId | usageMeterSlug) and auto-resolves subscriptionId, amount (default 1), and transactionId; server handler added returning 501 for now.

<sup>Written for commit 8e6cacd8ab364e02e190e724d025288a04fbb401. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added schema validation, type definitions, and server handler registration for usage event creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->