### PR TITLE
PR4: Simplify Stripe Connect onboarding

### DIFF
--- a/platform/flowglad-next/mocks/stripeServer.ts
+++ b/platform/flowglad-next/mocks/stripeServer.ts
@@ -17,6 +17,80 @@ const decodeStatusFromId = (
 
 export const stripeHandlers = [
   http.post(
+    'https://api.stripe.com/v1/accounts',
+    async ({ request }) => {
+      const body = await request.text()
+      const params = new URLSearchParams(body)
+      const country = params.get('country')
+      return HttpResponse.json({
+        id: `acct_${nanoid()}`,
+        object: 'account',
+        country,
+        created: Math.floor(Date.now() / 1000),
+        capabilities: {
+          transfers: 'active',
+          card_payments: params.get(
+            'capabilities[card_payments][requested]'
+          )
+            ? 'active'
+            : 'inactive',
+        },
+      })
+    }
+  ),
+  http.post(
+    'https://api.stripe.com:443/v1/accounts',
+    async ({ request }) => {
+      const body = await request.text()
+      const params = new URLSearchParams(body)
+      const country = params.get('country')
+      return HttpResponse.json({
+        id: `acct_${nanoid()}`,
+        object: 'account',
+        country,
+        created: Math.floor(Date.now() / 1000),
+        capabilities: {
+          transfers: 'active',
+          card_payments: params.get(
+            'capabilities[card_payments][requested]'
+          )
+            ? 'active'
+            : 'inactive',
+        },
+      })
+    }
+  ),
+  http.post(
+    'https://api.stripe.com/v1/account_links',
+    async ({ request }) => {
+      const body = await request.text()
+      const params = new URLSearchParams(body)
+      const account = params.get('account')
+      return HttpResponse.json({
+        id: `al_${nanoid()}`,
+        object: 'account_link',
+        created: Math.floor(Date.now() / 1000),
+        expires_at: Math.floor(Date.now() / 1000) + 60 * 30,
+        url: `https://connect.stripe.com/setup/s/${account ?? nanoid()}`,
+      })
+    }
+  ),
+  http.post(
+    'https://api.stripe.com:443/v1/account_links',
+    async ({ request }) => {
+      const body = await request.text()
+      const params = new URLSearchParams(body)
+      const account = params.get('account')
+      return HttpResponse.json({
+        id: `al_${nanoid()}`,
+        object: 'account_link',
+        created: Math.floor(Date.now() / 1000),
+        expires_at: Math.floor(Date.now() / 1000) + 60 * 30,
+        url: `https://connect.stripe.com/setup/s/${account ?? nanoid()}`,
+      })
+    }
+  ),
+  http.post(
     'https://api.stripe.com/v1/tax/transactions/create_from_calculation',
     async ({ request }) => {
       const body = await request.text()

--- a/platform/flowglad-next/src/app/onboarding/OnboardingStatusTable.tsx
+++ b/platform/flowglad-next/src/app/onboarding/OnboardingStatusTable.tsx
@@ -248,9 +248,7 @@ const OnboardingStatusTable = ({
       }
 
       const { onboardingLink } =
-        await requestStripeConnect.mutateAsync({
-          CountryId: countryId,
-        })
+        await requestStripeConnect.mutateAsync({})
       window.location.href = onboardingLink
     } catch (error) {
       console.error('Failed to request Stripe onboarding link', error)

--- a/platform/flowglad-next/src/db/schema/countries.ts
+++ b/platform/flowglad-next/src/db/schema/countries.ts
@@ -78,9 +78,7 @@ export namespace Country {
 }
 
 export const requestStripeConnectOnboardingLinkInputSchema = z.object(
-  {
-    CountryId: z.string(),
-  }
+  {}
 )
 
 export type RequestStripeConnectOnboardingLinkInput = z.infer<

--- a/platform/flowglad-next/src/server/mutations/requestStripeConnectOnboardingLink.test.ts
+++ b/platform/flowglad-next/src/server/mutations/requestStripeConnectOnboardingLink.test.ts
@@ -1,0 +1,241 @@
+import { HttpResponse, http } from 'msw'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setupOrg } from '@/../seedDatabase'
+import { adminTransaction } from '@/db/adminTransaction'
+import type { Organization } from '@/db/schema/organizations'
+import type { User } from '@/db/schema/users'
+import { insertMembership } from '@/db/tableMethods/membershipMethods'
+import { insertUser } from '@/db/tableMethods/userMethods'
+import { organizationsRouter } from '@/server/routers/organizationsRouter'
+import type { TRPCContext } from '@/server/trpcContext'
+import { CountryCode, StripeConnectContractType } from '@/types'
+import { getSession } from '@/utils/auth'
+import core from '@/utils/core'
+import { stripeServer } from '../../../mocks/stripeServer'
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(() => new Headers()),
+  cookies: vi.fn(() => ({
+    set: vi.fn(),
+    get: vi.fn(),
+    delete: vi.fn(),
+  })),
+}))
+
+vi.mock('@/utils/auth', () => ({
+  auth: {
+    api: {
+      getSession: vi.fn(),
+    },
+  },
+  getSession: vi.fn(),
+}))
+
+const createAuthedContext = async (params: {
+  organization: Organization.Record
+  livemode?: boolean
+}) => {
+  const { organization } = params
+  const livemode = params.livemode ?? true
+
+  const betterAuthId = `ba_test_${core.nanoid()}`
+  const email = `merchant+${core.nanoid()}@example.com`
+
+  const user = await adminTransaction(async ({ transaction }) => {
+    const insertedUser: User.Record = await insertUser(
+      {
+        id: `usr_test_${core.nanoid()}`,
+        email,
+        name: 'Test Merchant',
+        betterAuthId,
+      },
+      transaction
+    )
+
+    await insertMembership(
+      {
+        userId: insertedUser.id,
+        organizationId: organization.id,
+        focused: true,
+        livemode,
+      },
+      transaction
+    )
+
+    return insertedUser
+  })
+
+  vi.mocked(getSession).mockResolvedValue({
+    user: {
+      id: betterAuthId,
+      email,
+    },
+  } as unknown as Awaited<ReturnType<typeof getSession>>)
+
+  const ctx: TRPCContext = {
+    user,
+    path: '',
+    environment: livemode ? 'live' : 'test',
+    livemode,
+    organizationId: organization.id,
+    organization,
+    isApi: false,
+    apiKey: undefined,
+  }
+
+  return { ctx, user }
+}
+
+describe('requestStripeConnectOnboardingLink mutation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.NEXT_PUBLIC_APP_URL = 'https://app.flowglad.com'
+  })
+
+  it('should use organization countryId and stripeConnectContractType', async () => {
+    const orgSetup = await setupOrg({
+      countryCode: CountryCode.GB,
+      stripeConnectContractType: StripeConnectContractType.Platform,
+    })
+    const organization = orgSetup.organization
+    const { ctx } = await createAuthedContext({ organization })
+
+    let lastAccountCreateBody: URLSearchParams | undefined
+    stripeServer.use(
+      http.post(
+        'https://api.stripe.com/v1/accounts',
+        async ({ request }) => {
+          lastAccountCreateBody = new URLSearchParams(
+            await request.text()
+          )
+          return HttpResponse.json({
+            id: `acct_${core.nanoid()}`,
+            object: 'account',
+          })
+        }
+      ),
+      http.post(
+        'https://api.stripe.com:443/v1/accounts',
+        async ({ request }) => {
+          lastAccountCreateBody = new URLSearchParams(
+            await request.text()
+          )
+          return HttpResponse.json({
+            id: `acct_${core.nanoid()}`,
+            object: 'account',
+          })
+        }
+      )
+    )
+
+    const result = await organizationsRouter
+      .createCaller(ctx)
+      .requestStripeConnect({})
+
+    expect(result.onboardingLink).toContain(
+      'https://connect.stripe.com/'
+    )
+    expect(lastAccountCreateBody?.get('country')).toBe(CountryCode.GB)
+  })
+
+  it('should create Platform account with card_payments capability', async () => {
+    const orgSetup = await setupOrg({
+      countryCode: CountryCode.US,
+      stripeConnectContractType: StripeConnectContractType.Platform,
+    })
+    const organization = orgSetup.organization
+    const { ctx } = await createAuthedContext({ organization })
+
+    let lastAccountCreateBody: URLSearchParams | undefined
+    stripeServer.use(
+      http.post(
+        'https://api.stripe.com/v1/accounts',
+        async ({ request }) => {
+          lastAccountCreateBody = new URLSearchParams(
+            await request.text()
+          )
+          return HttpResponse.json({
+            id: `acct_${core.nanoid()}`,
+            object: 'account',
+          })
+        }
+      ),
+      http.post(
+        'https://api.stripe.com:443/v1/accounts',
+        async ({ request }) => {
+          lastAccountCreateBody = new URLSearchParams(
+            await request.text()
+          )
+          return HttpResponse.json({
+            id: `acct_${core.nanoid()}`,
+            object: 'account',
+          })
+        }
+      )
+    )
+
+    await organizationsRouter
+      .createCaller(ctx)
+      .requestStripeConnect({})
+
+    expect(
+      lastAccountCreateBody?.get('capabilities[transfers][requested]')
+    ).toBe('true')
+    expect(
+      lastAccountCreateBody?.get(
+        'capabilities[card_payments][requested]'
+      )
+    ).toBe('true')
+  })
+
+  it('should create MoR account with transfers-only capability', async () => {
+    const orgSetup = await setupOrg({
+      countryCode: CountryCode.US,
+      stripeConnectContractType:
+        StripeConnectContractType.MerchantOfRecord,
+    })
+    const organization = orgSetup.organization
+    const { ctx } = await createAuthedContext({ organization })
+
+    let lastAccountCreateBody: URLSearchParams | undefined
+    stripeServer.use(
+      http.post(
+        'https://api.stripe.com/v1/accounts',
+        async ({ request }) => {
+          lastAccountCreateBody = new URLSearchParams(
+            await request.text()
+          )
+          return HttpResponse.json({
+            id: `acct_${core.nanoid()}`,
+            object: 'account',
+          })
+        }
+      ),
+      http.post(
+        'https://api.stripe.com:443/v1/accounts',
+        async ({ request }) => {
+          lastAccountCreateBody = new URLSearchParams(
+            await request.text()
+          )
+          return HttpResponse.json({
+            id: `acct_${core.nanoid()}`,
+            object: 'account',
+          })
+        }
+      )
+    )
+
+    await organizationsRouter
+      .createCaller(ctx)
+      .requestStripeConnect({})
+
+    expect(
+      lastAccountCreateBody?.get('capabilities[transfers][requested]')
+    ).toBe('true')
+    expect(
+      lastAccountCreateBody?.get(
+        'capabilities[card_payments][requested]'
+      )
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
## What Does this PR Do?
Simplifies the Stripe Connect onboarding request to use the focused organization’s stored country and contract type (no country input). Updates onboarding to call the mutation with empty input and adds MSW coverage + tests for Platform vs MoR account capabilities.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies Stripe Connect onboarding by using the focused organization’s country and contract type; the client now calls the mutation with empty input. Adds MSW handlers and tests to verify capability selection (Platform: transfers + card_payments, MoR: transfers-only) and onboarding link generation.

- **Migration**
  - Ensure organizations have a country set, or onboarding will error with: "Country is required before you can enable payments."
  - Update callers to use requestStripeConnect.mutateAsync({}) (no CountryId).

<sup>Written for commit 388f11e1e1f764283a4fad5e9320171eb8dbd303. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

