### PR TITLE
Fix invoice reminder email link

### DIFF
--- a/platform/flowglad-next/bun.lock
+++ b/platform/flowglad-next/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "flowglad-next",

--- a/platform/flowglad-next/src/email-templates/customer-invoice-reminder.test.tsx
+++ b/platform/flowglad-next/src/email-templates/customer-invoice-reminder.test.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { InvoiceReminderEmail } from './customer-invoice-reminder'
+
+describe('InvoiceReminderEmail', () => {
+  it('renders an absolute invoice view link with the public route', () => {
+    const { getByRole } = render(
+      <InvoiceReminderEmail
+        organizationName="Test Organization"
+        customerEmail="customer@example.com"
+        customerName="Customer"
+        invoice={{
+          id: 'inv_123',
+          organizationId: 'org_123',
+          invoiceNumber: 'INV-123',
+        }}
+        livemode={false}
+      />
+    )
+
+    const viewInvoiceLink = getByRole('link', {
+      name: /view invoice/i,
+    })
+
+    expect(viewInvoiceLink).toHaveAttribute(
+      'href',
+      'http://localhost:3000/invoice/view/org_123/inv_123'
+    )
+  })
+})

--- a/platform/flowglad-next/src/email-templates/customer-invoice-reminder.tsx
+++ b/platform/flowglad-next/src/email-templates/customer-invoice-reminder.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import { emailBaseUrl } from '@/utils/core'
+import { EmailButton } from './components/EmailButton'
+import TestModeBanner from './components/TestBanner'
+import {
+  EmailLayout,
+  Header,
+  Paragraph,
+  Signature,
+} from './components/themed'
+
+export interface InvoiceReminderEmailProps {
+  organizationName: string
+  organizationLogoUrl?: string
+  customerName?: string
+  customerEmail: string
+  invoice: {
+    id: string
+    organizationId: string
+    invoiceNumber?: string
+  }
+  livemode: boolean
+}
+
+export const InvoiceReminderEmail = ({
+  organizationName,
+  organizationLogoUrl,
+  customerName,
+  customerEmail,
+  invoice,
+  livemode,
+}: InvoiceReminderEmailProps) => {
+  const displayName = customerName || customerEmail
+  const invoiceUrl = `${emailBaseUrl}/invoice/view/${invoice.organizationId}/${invoice.id}`
+
+  return (
+    <EmailLayout previewText="Invoice Reminder" variant="customer">
+      <TestModeBanner livemode={livemode} />
+      <Header
+        title="Invoice Reminder"
+        organizationLogoUrl={organizationLogoUrl}
+        variant="customer"
+      />
+      <Paragraph variant="customer">Hi {displayName},</Paragraph>
+      <Paragraph variant="customer">
+        This is a reminder that you have an outstanding invoice
+        {invoice.invoiceNumber ? ` (#${invoice.invoiceNumber})` : ''}.
+      </Paragraph>
+      <EmailButton href={invoiceUrl} testId="view-invoice-link">
+        View Invoice →
+      </EmailButton>
+      <Signature
+        greeting="Best,"
+        name={organizationName}
+        greetingDataTestId="signature-best"
+        nameDataTestId="signature-org-name"
+      />
+    </EmailLayout>
+  )
+}
+
+export default InvoiceReminderEmail

--- a/platform/flowglad-next/src/utils/core.ts
+++ b/platform/flowglad-next/src/utils/core.ts
@@ -492,7 +492,21 @@ const NEXT_PUBLIC_APP_URL = IS_TEST
   ? LOCALHOST_URL
   : process.env.NEXT_PUBLIC_APP_URL || LOCALHOST_URL
 
-export const emailBaseUrl = NEXT_PUBLIC_APP_URL
+const normalizeAbsoluteBaseUrl = (urlBase: string): string => {
+  const trimmed = urlBase.trim().replace(/\/+$/, '')
+  if (
+    trimmed.startsWith('http://') ||
+    trimmed.startsWith('https://')
+  ) {
+    return trimmed
+  }
+  const protocol = trimmed.includes('localhost') ? 'http' : 'https'
+  return `${protocol}://${trimmed}`
+}
+
+export const emailBaseUrl = normalizeAbsoluteBaseUrl(
+  NEXT_PUBLIC_APP_URL
+)
 
 export const customerBillingPortalURL = (params: {
   organizationId: string


### PR DESCRIPTION
## What Does this PR Do?
Fixes the customer invoice reminder email "View Invoice" link by using a protocol-safe base URL and the correct `/invoice/view/:organizationId/:invoiceId` route. Adds a dedicated `InvoiceReminderEmail` template and a regression test to ensure the rendered link is an absolute URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the customer invoice reminder email “View Invoice” link to use a protocol-safe absolute URL and the correct /invoice/view/:organizationId/:invoiceId route. Adds a dedicated InvoiceReminderEmail template and a test to prevent regressions.

- **Bug Fixes**
  - Normalize NEXT_PUBLIC_APP_URL with a helper that adds the correct protocol (http for localhost, https otherwise) and trims trailing slashes; use it as emailBaseUrl.
  - Build the email link with the public /invoice/view/:organizationId/:invoiceId route and add a regression test to assert an absolute URL.

<sup>Written for commit 5c663232e70f71de72bc3ed65b32ce6d1ddd7a2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added invoice reminder email template with support for organization branding, customer names, and direct invoice viewing links.

* **Tests**
  * Added comprehensive unit test coverage for the invoice reminder email component.

* **Improvements**
  * Enhanced URL normalization to properly handle email configuration base URLs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->