### PR TITLE
Apply usage credits FIFO by expiration

### DIFF
--- a/platform/flowglad-next/src/db/tableMethods/ledgerEntryMethods.ts
+++ b/platform/flowglad-next/src/db/tableMethods/ledgerEntryMethods.ts
@@ -490,6 +490,16 @@ export const aggregateAvailableBalanceForUsageCredit = async (
       ledgerEntries.ledgerAccountId,
       usageCredits.expiresAt
     )
+    /**
+     * Apply usage credits FIFO by expiration date (earliest expiring first) to
+     * minimize waste from credits expiring unused. Non-expiring credits (null
+     * expiresAt) are applied last.
+     */
+    .orderBy(
+      sql`${usageCredits.expiresAt} IS NULL`,
+      asc(usageCredits.expiresAt),
+      asc(ledgerEntries.sourceUsageCreditId)
+    )
 
   // Transform results to match the expected return type
   return results


### PR DESCRIPTION
## What Does this PR Do?
Apply usage credits FIFO by expiration (earliest expiring first, non-expiring last) by ordering the SQL aggregation in `aggregateAvailableBalanceForUsageCredit`. Adds a regression test to lock in the ordering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply usage credits FIFO by expiration to minimize waste: earliest expiring first, non-expiring last. Implemented in aggregateAvailableBalanceForUsageCredit and covered by a regression test.

- **Bug Fixes**
  - Ordered credit aggregation by expiresAt (nulls last), then sourceUsageCreditId.
  - Added a test to lock in the expected ordering.

<sup>Written for commit 326431738569e26e9386dcd686f26f1702bee9c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage credit balance aggregation to prioritize credits by expiration date (earliest-expiring first), with non-expiring credits processed last for more predictable credit consumption.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->