### PR TITLE
Propagate Stripe Tax fields to payments

### DIFF
--- a/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
+++ b/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
@@ -613,6 +613,10 @@ export const executeBillingRunCalculationAndBookkeepingSteps = async (
     refunded: false,
     refundedAmount: 0,
     refundedAt: null,
+    subtotal: feeCalculation.pretaxTotal,
+    taxAmount: feeCalculation.taxAmountFixed,
+    stripeTaxCalculationId: feeCalculation.stripeTaxCalculationId,
+    stripeTaxTransactionId: feeCalculation.stripeTaxTransactionId,
     /**
      * Sometimes billing details address is nested.
      * othertimes it is not. Try nested first, then fallback to non-nested.

--- a/platform/flowglad-next/src/utils/paymentHelpers.ts
+++ b/platform/flowglad-next/src/utils/paymentHelpers.ts
@@ -155,6 +155,10 @@ export const retryPaymentTransaction = async (
       refunded: false,
       refundedAmount: 0,
       refundedAt: null,
+      subtotal: payment.subtotal,
+      taxAmount: payment.taxAmount,
+      stripeTaxCalculationId: payment.stripeTaxCalculationId,
+      stripeTaxTransactionId: payment.stripeTaxTransactionId,
       stripeChargeId: stripeIdFromObjectOrId(
         paymentIntent.latest_charge!
       ),


### PR DESCRIPTION
## What Does this PR Do?
Copies Stripe Tax (calculation/transaction IDs), subtotal, and tax amount from FeeCalculations onto Payments for billing runs and webhook-created payments.
Adds a regression test covering the MoR billing run path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates Stripe Tax fields from fee calculations to payments so payments include subtotal, tax amount, and Stripe Tax calculation/transaction IDs for billing runs and checkout sessions.

- **Bug Fixes**
  - Add subtotal, taxAmount, stripeTaxCalculationId, and stripeTaxTransactionId to payments created/upserted from billing runs and webhook charge events.
  - Preserve these fields in retryPaymentTransaction.
  - Add regression test for Merchant of Record billing run path.

<sup>Written for commit dccc7dedd08d40d02f3c5eaf0eefcca433471edc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced payment records to capture Stripe Tax calculation identifiers and amounts across billing runs, checkout sessions, and payment retries.

* **Tests**
  * Added test coverage for Stripe Tax calculation field propagation in MerchantOfRecord contract scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->