### PR TITLE
Test Stripe Tax propagation

### DIFF
--- a/platform/flowglad-next/mocks/stripeServer.ts
+++ b/platform/flowglad-next/mocks/stripeServer.ts
@@ -16,7 +16,7 @@ const decodeStatusFromId = (
 }
 
 const paymentIntentStatusToChargeStatus = (
-  status: Stripe.PaymentIntent.Status
+  status: Stripe.PaymentIntent.Status | string
 ): Stripe.Charge.Status => {
   switch (status) {
     case 'succeeded':


### PR DESCRIPTION
## What Does this PR Do?
Adds test coverage for propagating Stripe Tax fields onto Payment records when retrying failed payments and when booking checkout-session payments from PaymentIntent updates. Exports and tests the fee-calculation selection logic to ensure the latest FeeCalculation is chosen for BillingRun vs CheckoutSession paths. Adds missing billing-run assertion for stripeTaxTransactionId. Fixes a Stripe mock typing issue uncovered by TypeScript.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates Stripe Tax fields (subtotal, taxAmount, calculation/transaction IDs) from FeeCalculation to Payment across billing runs, checkout sessions, and payment retries. Adds tests and selection logic to always use the latest FeeCalculation.

- **New Features**
  - Set tax fields on payments during billing runs and when booking payments from PaymentIntent updates.
  - retryPaymentTransaction copies tax fields to the new payment.
  - selectFeeCalculationForPaymentIntent returns the latest FeeCalculation for BillingRun or CheckoutSession.

- **Bug Fixes**
  - Stripe mock: map intent status to charge status, include latest_charge, add confirm endpoints, and loosen status typing to accept strings.

<sup>Written for commit ab2bec5ae72a7d73b042429795365794954f738d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added payment intent confirmation endpoints for streamlined payment processing

* **Improvements**
  * Enhanced payment handling to preserve and propagate Stripe Tax calculation details during payment retries and billing operations
  * Improved payment state mapping for consistent charge status tracking

* **Tests**
  * Added comprehensive test coverage for Stripe Tax field propagation and payment retry scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->