### PR TITLE
fix: correct checkout_sessions policy name and fix llm-prompts syntax

### DIFF
--- a/platform/flowglad-next/drizzle-migrations/0264_freezing_sister_grimm.sql
+++ b/platform/flowglad-next/drizzle-migrations/0264_freezing_sister_grimm.sql
@@ -29,4 +29,5 @@ ALTER POLICY "Enable read for own organizations (usage_credit_balance_adjustment
 ALTER POLICY "Enable read for own organizations (usage_credits)" ON "usage_credits" TO merchant USING ("organization_id" = current_organization_id());--> statement-breakpoint
 ALTER POLICY "Enable read for own organizations (usage_events)" ON "usage_events" TO merchant USING ("customer_id" in (select "id" from "customers" where "organization_id"=current_organization_id()));--> statement-breakpoint
 ALTER POLICY "Enable read for own organizations (usage_meters)" ON "usage_meters" TO merchant USING ("organization_id" = current_organization_id());--> statement-breakpoint
-ALTER POLICY "Enable read for own organizations (webhooks)" ON "webhooks" TO merchant USING ("organization_id" = current_organization_id());
+ALTER POLICY "Enable read for own organizations (webhooks)" ON "webhooks" TO merchant USING ("organization_id" = current_organization_id());--> statement-breakpoint
+ALTER POLICY "Enable all actions for discounts in own organization" ON "checkout_sessions" RENAME TO "Enable all actions for checkout_sessions in own organization";

--- a/platform/flowglad-next/llm-prompts/new-db-table.md
+++ b/platform/flowglad-next/llm-prompts/new-db-table.md
@@ -61,7 +61,7 @@ Here's what you need to do, assuming the table is named "UnicornRiders" (the act
         constructUniqueIndex(TABLE_NAME, [table.email]),
         pgPolicy('Enable read for own organizations', {
           as: 'permissive',
-          to: merchantRole,,
+          to: merchantRole,
           for: 'all',
           using: sql`"organization_id" in (select "organization_id" from "memberships" where "user_id" = requesting_user_id() union select current_organization_id() where current_auth_type() = 'api_key')`,
         }),

--- a/platform/flowglad-next/src/db/schema/checkoutSessions.ts
+++ b/platform/flowglad-next/src/db/schema/checkoutSessions.ts
@@ -131,7 +131,7 @@ export const checkoutSessions = pgTable(
       constructIndex(TABLE_NAME, [table.discountId]),
       constructIndex(TABLE_NAME, [table.customerId]),
       merchantPolicy(
-        'Enable all actions for discounts in own organization',
+        'Enable all actions for checkout_sessions in own organization',
         {
           as: 'permissive',
           to: 'all',


### PR DESCRIPTION
- Rename misleading policy name from "Enable all actions for discounts in own organization" to "Enable all actions for checkout_sessions in own organization" on checkout_sessions table
- Add RENAME migration statement to properly rename the policy in the database
- Fix double comma syntax error in llm-prompts/new-db-table.md (line 64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed a misleading checkout_sessions RLS policy and fixed a small syntax error in a doc. The migration updates the DB policy name to match the schema.

- **Bug Fixes**
  - Renamed policy to "Enable all actions for checkout_sessions in own organization" in schema.
  - Added ALTER POLICY RENAME in migration for checkout_sessions.
  - Fixed double comma in llm-prompts/new-db-table.md.

<sup>Written for commit 44ff004472523aa3e3cf147ff0bf80fe36ee05a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

