### PR TITLE
fix: prevent terminal invoice modification via ID mismatch

### DIFF
--- a/platform/flowglad-next/src/utils/invoiceHelpers.ts
+++ b/platform/flowglad-next/src/utils/invoiceHelpers.ts
@@ -44,6 +44,11 @@ export const updateInvoiceTransaction = async (
   livemode: boolean,
   transaction: DbTransaction
 ) => {
+  if (invoice.id !== id) {
+    throw new Error(
+      `ID mismatch: parameter id (${id}) does not match invoice.id (${invoice.id})`
+    )
+  }
   const existingInvoice = await selectInvoiceById(id, transaction)
   if (invoiceIsInTerminalState(existingInvoice)) {
     throw new Error(


### PR DESCRIPTION
## What Does this PR Do?

Fixes a security vulnerability in `updateInvoiceTransaction` where attackers could bypass terminal state validation by passing mismatched invoice IDs. The fix enforces that the `id` parameter must match `invoice.id` before proceeding with any updates. Includes comprehensive test coverage for both the exploit scenario and legitimate updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents modification of terminal invoices by enforcing that updateInvoiceTransaction requires id to match invoice.id. Closes a security gap where a non-terminal ID could be used to bypass validation and update a terminal invoice.

- **Bug Fixes**
  - Added an early ID equality check that throws “ID mismatch” before any updates, with tests covering the exploit scenario and valid updates.

<sup>Written for commit 1328724602364ad42ad0564cc42a2dd07d5e2d0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to invoice update transactions to prevent processing errors when invoice identifiers do not match, ensuring data consistency.

* **Tests**
  * Added test suite covering ID mismatch detection and successful invoice update scenarios with matching identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->