### PR TITLE
test: bump pagination timeout to 15s

### DIFF
--- a/platform/flowglad-next/src/db/tableMethods/usageEventMethods.test.ts
+++ b/platform/flowglad-next/src/db/tableMethods/usageEventMethods.test.ts
@@ -287,11 +287,11 @@ describe('selectUsageEventsPaginated', () => {
   })
 
   it('should handle cursor-based pagination correctly', async () => {
-    // Create 10 usage events for organization 1 with staggered timestamps
+    // Create 7 usage events for organization 1 with deterministic, unique timestamps
+    // (enough for two pages of 3 and to keep `hasNextPage` true on the second page)
     const createdEvents = []
-    for (let i = 0; i < 10; i++) {
-      // Add a small delay to ensure different timestamps
-      await new Promise((resolve) => setTimeout(resolve, 10))
+    const baseUsageDateMs = 1_700_000_000_000
+    for (let i = 0; i < 7; i++) {
       const event = await setupUsageEvent({
         organizationId: org1Data.organization.id,
         customerId: customer1.id,
@@ -301,7 +301,7 @@ describe('selectUsageEventsPaginated', () => {
         billingPeriodId: billingPeriod1.id,
         amount: 100 + i,
         transactionId: `txn_cursor_${i}`,
-        usageDate: Date.now() + i * 1000, // Stagger timestamps
+        usageDate: baseUsageDateMs + i, // deterministic ordering without sleeping
       })
       createdEvents.push(event)
     }


### PR DESCRIPTION
## What Does this PR Do?
Increases the timeout for the cursor-based pagination test to 15 seconds to reduce flakiness/timeouts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase timeout to 15s and make the cursor pagination test deterministic to reduce flakiness, avoid timeouts, and speed up.

<sup>Written for commit ad7a023a2f26f923f217846d06ebcfe7eecee75b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended timeout for usage event pagination tests to improve reliability.

---

**Note:** This release contains no user-facing changes or new features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->