### PR TITLE
ensure redirect to dashboard after verification

### DIFF
--- a/platform/flowglad-next/src/app/api/billing-portal/verify-otp/route.ts
+++ b/platform/flowglad-next/src/app/api/billing-portal/verify-otp/route.ts
@@ -1,0 +1,108 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import {
+  getCustomerBillingPortalEmail,
+  setCustomerBillingPortalOrganizationId,
+} from '@/utils/customerBillingPortalState'
+
+/**
+ * API Route handler for OTP verification.
+ * Keeps the email secure (never exposed to client) while properly setting
+ * BetterAuth cookies by forwarding them from BetterAuth's response.
+ *
+ * Client sends: { otp, organizationId, customerId }
+ * Server: Validates OTP via BetterAuth, forwards Set-Cookie headers, returns success/error
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { otp, organizationId, customerId } = body
+
+    if (!otp || typeof otp !== 'string' || otp.length !== 6) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid OTP format' },
+        { status: 400 }
+      )
+    }
+
+    if (!organizationId || !customerId) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Missing organizationId or customerId',
+        },
+        { status: 400 }
+      )
+    }
+
+    // Set organization context (BetterAuth needs this)
+    await setCustomerBillingPortalOrganizationId(organizationId)
+
+    // Get email from secure cookie (set during sendOTP)
+    const email = await getCustomerBillingPortalEmail()
+
+    if (!email) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            'Session expired. Please request a new verification code.',
+        },
+        { status: 400 }
+      )
+    }
+
+    // Call BetterAuth's API endpoint directly via HTTP to capture Set-Cookie headers
+    const baseUrl = new URL(request.url).origin
+    const originalCookies = request.headers.get('Cookie') || ''
+    const orgCookie = `customer-billing-organization-id=${organizationId}`
+    const cookieString = originalCookies
+      ? `${originalCookies}; ${orgCookie}`
+      : orgCookie
+
+    const authResponse = await fetch(
+      `${baseUrl}/api/auth/sign-in/email-otp`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: cookieString,
+          Origin: baseUrl,
+        },
+        body: JSON.stringify({ email, otp }),
+      }
+    )
+
+    if (!authResponse.ok) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Invalid or expired verification code.',
+        },
+        { status: 400 }
+      )
+    }
+
+    // Create success response and forward Set-Cookie headers from BetterAuth
+    const response = NextResponse.json({
+      success: true,
+      redirectUrl: `/billing-portal/${organizationId}/${customerId}`,
+    })
+
+    // Forward all Set-Cookie headers from BetterAuth's response
+    const setCookieHeaders = authResponse.headers.getSetCookie()
+    for (const cookie of setCookieHeaders) {
+      response.headers.append('Set-Cookie', cookie)
+    }
+
+    return response
+  } catch (error) {
+    console.error('verify-otp route error:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to verify code. Please try again.',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/platform/flowglad-next/src/routing-logic/publicRoutes.ts
+++ b/platform/flowglad-next/src/routing-logic/publicRoutes.ts
@@ -4,6 +4,7 @@ import core from '@/utils/core'
 const publicRoutes = [
   '/mcp',
   '/billing-portal/(.*)/sign-in',
+  '/api/billing-portal/verify-otp',
   '/sign-in(.*)',
   '/sign-up(.*)',
   '/logout',
@@ -29,7 +30,6 @@ const publicRoutes = [
    */
   '/api/trpc/customerBillingPortal.requestMagicLink',
   '/api/trpc/customerBillingPortal.sendOTPToCustomer',
-  '/api/trpc/customerBillingPortal.verifyOTPForCustomer',
   '/api/trpc/checkoutSessions.public.(.*)',
   '/api/trpc/purchases.requestAccess',
   '/api/trpc/utils.logout',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Redirect users to the billing portal dashboard after OTP verification and when already authenticated, with secure cookie handling to ensure reliable login.

- **Bug Fixes**
  - Redirect to `/billing-portal/:organizationId/:customerId` once OTP is verified or when a valid session exists.
  - Prevent double sends/redirects using refs and a short delay before auto-sending OTP.

- **Refactors**
  - Added secure POST `/api/billing-portal/verify-otp` to call BetterAuth, forward Set-Cookie headers, and return a redirect URL.
  - Updated the sign-in page to use the new API (email stays server-side).
  - Marked the new API as a public route and removed the TRPC `verifyOTPForCustomer` procedure and its public route entry.

<sup>Written for commit 78c82b371c93dd694a9ed2f8d29b79588e7562b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined OTP verification in the billing portal with improved session awareness and automatic redirects
  * Enhanced error handling with clearer messages for verification failures
  * Optimized authentication flow to prevent duplicate operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->