### PR TITLE
fix: allow setup intent flow to complete shared post-payment logic

### DIFF
--- a/platform/flowglad-next/src/app/purchase/post-payment/route.tsx
+++ b/platform/flowglad-next/src/app/purchase/post-payment/route.tsx
@@ -278,20 +278,6 @@ export const GET = async (request: NextRequest) => {
         setupIntentId,
         request,
       })
-      if (setupIntentResult.url) {
-        return Response.redirect(setupIntentResult.url, 303)
-      }
-
-      if (!setupIntentResult.purchase) {
-        return Response.json(
-          {
-            success: false,
-          },
-          {
-            status: 400,
-          }
-        )
-      }
       result = setupIntentResult
     } else {
       throw new Error(


### PR DESCRIPTION
## What Does this PR Do?

Fixes a bug where setup intent flows were redirecting early, bypassing critical post-payment logic. This prevented users from having their purchase access sessions created and checkout session cookies deleted.

The setup intent path now flows through the same shared post-payment logic as payment_intent and checkout_session paths, ensuring all users get immediate access to their purchased content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed setup intent flow by removing the early redirect so it completes shared post-payment logic, creating purchase access sessions and clearing checkout session cookies. This aligns setup intents with payment_intent and checkout_session paths for consistent access after checkout.

- **Bug Fixes**
  - Removed early redirect and 400 handling in purchase/post-payment route for setup intents.

<sup>Written for commit e51760923154c79ac20af7deaa8c00d196c2578f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-payment flow handling for payment setup scenarios to ensure proper redirect and error handling through a unified process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->