### PR TITLE
Fix dashboard revenue loading state padding alignment

### DIFF
--- a/platform/flowglad-next/src/components/ActiveSubscribersChart.tsx
+++ b/platform/flowglad-next/src/components/ActiveSubscribersChart.tsx
@@ -315,7 +315,7 @@ export const ActiveSubscribersChart = ({
 
       <div className="px-4 mt-1">
         {isLoading ? (
-          <Skeleton className="w-36 h-12" />
+          <Skeleton className="w-36 h-7" />
         ) : (
           <p className="text-xl font-semibold text-foreground">
             {formattedSubscriberValue}

--- a/platform/flowglad-next/src/components/RecurringRevenueChart.tsx
+++ b/platform/flowglad-next/src/components/RecurringRevenueChart.tsx
@@ -133,7 +133,7 @@ export const RecurringRevenueChart = ({
   return (
     <div className="w-full h-full">
       <div className="flex flex-row gap-2 justify-between px-4">
-        <div className="text-foreground w-fit flex items-center flex-row">
+        <div className="text-foreground w-fit flex items-center flex-row min-h-6">
           <p className="whitespace-nowrap">
             Monthly Recurring Revenue
           </p>
@@ -142,7 +142,7 @@ export const RecurringRevenueChart = ({
 
       <div className="px-4 mt-1">
         {isLoading ? (
-          <Skeleton className="w-36 h-12" />
+          <Skeleton className="w-36 h-7" />
         ) : (
           <p className="text-xl font-semibold text-foreground">
             {formattedMRRValue}

--- a/platform/flowglad-next/src/components/RevenueChart.tsx
+++ b/platform/flowglad-next/src/components/RevenueChart.tsx
@@ -332,7 +332,7 @@ export function RevenueChart({
 
       <div className="px-4 mt-1">
         {isLoading ? (
-          <Skeleton className="w-36 h-12" />
+          <Skeleton className="w-36 h-7" />
         ) : (
           <p className="text-xl font-semibold text-foreground">
             {formattedRevenueValue}


### PR DESCRIPTION
## What Does this PR Do?

Fixes misaligned padding on the Revenue chart's loading state. Moved the `px-4` padding class to the outer container wrapper so both the skeleton loading state and loaded content have consistent left/right padding, matching the pattern used in the Monthly Recurring Revenue chart.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed Revenue chart loading padding and aligned skeleton heights to match text. Padding moved to the outer container; skeletons use h-7; MRR label adds min-h-6 for consistent header alignment.

<sup>Written for commit 90215c10d570f07122d4fec627e50e4ada78b5e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced loading placeholder heights across revenue, active subscribers, and recurring revenue charts for a tighter, more compact loading appearance.
  * Improved spacing and added a minimum header height for chart labels to ensure consistent alignment.
  * Simplified revenue display rendering for cleaner, more consistent typography and visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->