### PR TITLE
fix: disallow creating usage-products via Create Product UI

### DIFF
--- a/platform/flowglad-next/src/components/forms/PriceFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/PriceFormFields.tsx
@@ -456,9 +456,7 @@ const PriceFormFields = ({
                     <SelectItem value={PriceType.Subscription}>
                       Subscription
                     </SelectItem>
-                    <SelectItem value={PriceType.Usage}>
-                      Usage
-                    </SelectItem>
+                    {/* Usage price type is excluded from product forms */}
                   </SelectContent>
                 </Select>
               </FormControl>


### PR DESCRIPTION
## What Does this PR Do?

Removes the Usage price type option from the Create Product modal, preventing users from creating usage-products through the legacy UI path. Usage pricing is now exclusively managed through the Usage Meter details page, establishing a clearer mental model where usage is about meters and prices, not products.

### Changes
- Removed Usage from PriceFormFields price type dropdown
- Cleaned up unused `hidePriceName` prop
- UI-only restriction (no server-side changes)

🤖 Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Usage price type from the Create Product modal to block creating usage-products via the product flow. This is a UI-only restriction; usage pricing is managed on the Usage Meter details page.

<sup>Written for commit 536d1cfe4ca479c232c5e4f4c36bc50be5333f99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated modal for creating usage-based pricing tied to specific usage meters.

* **Changes**
  * Removed Usage from the standard price type dropdown selector in product pricing forms; usage pricing must now be created through the new modal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->