### PR TITLE
Minor: gitignore tags files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ playground/react-native/prisma/database.sqlite
 
 # openapi diffing
 temp-openapi**.json
+
+/tags


### PR DESCRIPTION
## What Does this PR Do?

the `ctags` program indexes source code in a ./tags file. This should be
gitignored.
<!-- Please provide a clear and concise description of the changes in this PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add /tags to .gitignore to ignore ctags-generated index files. Prevents accidental commits of local tags files.

<sup>Written for commit 5ed41967bfede211c9ef06976bb32328bbcbb420. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore patterns for development tooling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->