### PR TITLE
feat: add fee breakdown metadata to Stripe Payment Intent

### DIFF
--- a/platform/flowglad-next/src/utils/stripe.test.ts
+++ b/platform/flowglad-next/src/utils/stripe.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import type { FeeCalculation } from '@/db/schema/feeCalculations'
+import { buildFeeMetadata } from './stripe'
+
+describe('buildFeeMetadata', () => {
+  /**
+   * buildFeeMetadata only accesses these specific fields from FeeCalculation.Record:
+   * - flowgladFeePercentage
+   * - morSurchargePercentage
+   * - internationalFeePercentage
+   * - taxAmountFixed
+   * - stripeTaxCalculationId
+   *
+   * We create a minimal mock with just these fields.
+   */
+  const baseFeeCalculation = {
+    flowgladFeePercentage: '2.9',
+    morSurchargePercentage: '1.1',
+    internationalFeePercentage: '1.5',
+    taxAmountFixed: 850,
+    stripeTaxCalculationId: 'taxcalc_abc123',
+  } as unknown as FeeCalculation.Record
+
+  it('returns an empty object when feeCalculation is undefined', () => {
+    const result = buildFeeMetadata(undefined)
+
+    expect(result).toEqual({})
+  })
+
+  it('returns fee breakdown with all fields populated for a complete fee calculation', () => {
+    const result = buildFeeMetadata(baseFeeCalculation)
+
+    expect(result).toEqual({
+      flowglad_fee_percentage: '2.9',
+      mor_surcharge_percentage: '1.1',
+      international_fee_percentage: '1.5',
+      tax_amount: '850',
+      stripe_tax_calculation_id: 'taxcalc_abc123',
+    })
+  })
+
+  it('returns undefined for stripe_tax_calculation_id when it is null in the fee calculation', () => {
+    const feeCalculation = {
+      ...baseFeeCalculation,
+      stripeTaxCalculationId: null,
+    } as unknown as FeeCalculation.Record
+
+    const result = buildFeeMetadata(feeCalculation)
+
+    expect(result).toEqual({
+      flowglad_fee_percentage: '2.9',
+      mor_surcharge_percentage: '1.1',
+      international_fee_percentage: '1.5',
+      tax_amount: '850',
+      stripe_tax_calculation_id: undefined,
+    })
+  })
+
+  it('returns zero values as strings for Platform orgs without MoR surcharge or tax', () => {
+    const platformFeeCalculation = {
+      ...baseFeeCalculation,
+      morSurchargePercentage: '0',
+      taxAmountFixed: 0,
+      internationalFeePercentage: '0',
+      stripeTaxCalculationId: null,
+    } as unknown as FeeCalculation.Record
+
+    const result = buildFeeMetadata(platformFeeCalculation)
+
+    expect(result).toEqual({
+      flowglad_fee_percentage: '2.9',
+      mor_surcharge_percentage: '0',
+      international_fee_percentage: '0',
+      tax_amount: '0',
+      stripe_tax_calculation_id: undefined,
+    })
+  })
+
+  it('converts taxAmountFixed integer to string representation', () => {
+    const feeCalculation = {
+      ...baseFeeCalculation,
+      taxAmountFixed: 12345,
+    } as unknown as FeeCalculation.Record
+
+    const result = buildFeeMetadata(feeCalculation)
+
+    expect(result.tax_amount).toBe('12345')
+    expect(typeof result.tax_amount).toBe('string')
+  })
+
+  it('handles notaxoverride_ calculation IDs for zero-tax scenarios', () => {
+    const feeCalculation = {
+      ...baseFeeCalculation,
+      taxAmountFixed: 0,
+      stripeTaxCalculationId: 'notaxoverride_xyz789',
+    } as unknown as FeeCalculation.Record
+
+    const result = buildFeeMetadata(feeCalculation)
+
+    expect(result.stripe_tax_calculation_id).toBe(
+      'notaxoverride_xyz789'
+    )
+    expect(result.tax_amount).toBe('0')
+  })
+})


### PR DESCRIPTION
## What Does this PR Do?

Implements PR 6 from the Fee Calculation MoR Support gameplan: adds fee breakdown metadata to Stripe Payment Intents. This includes `flowglad_fee_percentage`, `mor_surcharge_percentage`, `international_fee_percentage`, `tax_amount`, and `stripe_tax_calculation_id` in payment intent metadata for all payment intent creation functions (checkout sessions and billing runs).

This provides visibility into fee details in the Stripe dashboard for debugging and support purposes.

**Changes:**
- Added `feeMetadataSchema` and `buildFeeMetadata()` helper function
- Updated 4 payment intent creation functions to include fee metadata
- Added comprehensive unit tests for the fee metadata builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fee breakdown metadata to Stripe Payment Intents for checkout sessions and billing runs to surface fee details in Stripe for easier debugging and support.

- **New Features**
  - Added feeMetadataSchema and buildFeeMetadata helper.
  - Included flowglad_fee_percentage, mor_surcharge_percentage, international_fee_percentage, tax_amount, and stripe_tax_calculation_id in PI metadata across all creation paths.
  - Serialized values to strings and handled null IDs and zero-tax scenarios.
  - Added unit tests for buildFeeMetadata.

<sup>Written for commit 4d2d452f62a566b07d47d1f57b4ba2b92a0a1e83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fee breakdown details (percentages, surcharges, and taxes) are now automatically tracked and included with Stripe payment records.

* **Tests**
  * Added comprehensive test coverage for fee metadata handling in payment processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->