### PR TITLE
fix: exclude BetterStack URLs from fetch tracing

### DIFF
--- a/platform/flowglad-next/src/instrumentation.ts
+++ b/platform/flowglad-next/src/instrumentation.ts
@@ -47,6 +47,24 @@ export async function register() {
       serviceName:
         process.env.FLOWGLAD_OTEL_SERVICE_NAME || 'flowglad-api',
       traceSampler: sampler,
+      instrumentationConfig: {
+        fetch: {
+          ignoreUrls: [
+            // Don't trace OTEL exporter calls to BetterStack.
+            // This prevents recursive tracing where the exporter's HTTP calls
+            // appear as slow spans in traces.
+            //
+            // TODO: When we move off Vercel, switch to an OpenTelemetry Collector
+            // sidecar pattern instead. The app would export to localhost:4318
+            // (fast, no network latency) and the collector handles batching,
+            // retries, and forwarding to BetterStack. This eliminates the need
+            // for ignoreUrls and reduces export overhead in the application.
+            /betterstackdata\.com/,
+            /logs\.betterstack\.com/,
+            /in-otel\.logs\.betterstack\.com/,
+          ],
+        },
+      },
     })
   } finally {
     // Restore original variables for trigger.dev to use


### PR DESCRIPTION
## Summary
- Exclude BetterStack data ingestion endpoints from fetch instrumentation to prevent recursive tracing

## Problem
The fetch instrumentation was tracing the OTEL exporter's own HTTP calls to BetterStack, which:
1. Created noise in traces (you don't want to trace the tracing)
2. Added overhead from recursive instrumentation
3. Made the slow OTEL POSTs appear prominently in trace waterfalls

## Solution
Added `ignoreUrls` patterns to the `registerOTel` configuration that exclude:
- `betterstackdata.com` - data ingestion endpoints
- `logs.betterstack.com` - logs endpoints
- `in-otel.logs.betterstack.com` - OTLP ingestion endpoint

## Test plan
- [ ] Deploy and verify BetterStack fetch spans no longer appear in traces
- [ ] Confirm other fetch calls (Stripe, Unkey, etc.) are still traced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude BetterStack ingestion URLs from fetch instrumentation to stop tracing the OTEL exporter’s own HTTP calls. This removes noisy recursive spans and keeps traces focused on app traffic.

- **Bug Fixes**
  - Added fetch.ignoreUrls for:
    - betterstackdata.com
    - logs.betterstack.com
    - in-otel.logs.betterstack.com

<sup>Written for commit f7b1e40390e97a954de701825ea7ff8a7cf7ec11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

