### PR TITLE
Instrument database transactions with OpenTelemetry tracing

### DIFF
--- a/platform/flowglad-next/src/db/adminTransaction.ts
+++ b/platform/flowglad-next/src/db/adminTransaction.ts
@@ -120,10 +120,10 @@ export async function comprehensiveAdminTransaction<T>(
 
         // Set additional attributes after transaction completes
         span.setAttributes({
-          'db.has_events': (output.eventsToInsert?.length ?? 0) > 0,
-          'db.has_ledger_commands':
-            !!output.ledgerCommand ||
-            (output.ledgerCommands?.length ?? 0) > 0,
+          'db.events_count': output.eventsToInsert?.length ?? 0,
+          'db.ledger_commands_count': output.ledgerCommand
+            ? 1
+            : (output.ledgerCommands?.length ?? 0),
         })
 
         // Validate that only one of ledgerCommand or ledgerCommands is provided

--- a/platform/flowglad-next/src/db/authenticatedTransaction.ts
+++ b/platform/flowglad-next/src/db/authenticatedTransaction.ts
@@ -182,10 +182,10 @@ export async function comprehensiveAuthenticatedTransaction<T>(
 
         // Set additional attributes after transaction completes
         span.setAttributes({
-          'db.has_events': (output.eventsToInsert?.length ?? 0) > 0,
-          'db.has_ledger_commands':
-            !!output.ledgerCommand ||
-            (output.ledgerCommands?.length ?? 0) > 0,
+          'db.events_count': output.eventsToInsert?.length ?? 0,
+          'db.ledger_commands_count': output.ledgerCommand
+            ? 1
+            : (output.ledgerCommands?.length ?? 0),
         })
 
         // Validate that only one of ledgerCommand or ledgerCommands is provided


### PR DESCRIPTION
## What Does this PR Do?

Adds OpenTelemetry tracing spans to all database transaction wrapper functions to measure database operation latency within TRPC calls. Instruments `authenticatedTransaction`, `comprehensiveAuthenticatedTransaction`, `adminTransaction`, and `comprehensiveAdminTransaction` with contextual attributes including transaction type, user ID, organization ID, livemode, and post-transaction event/ledger command information.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OpenTelemetry spans to all database transaction helpers to measure latency and add useful context in tRPC calls. This improves observability for authenticated and admin flows without changing behavior.

- **New Features**
  - Wrapped authenticatedTransaction, comprehensiveAuthenticatedTransaction, adminTransaction, and comprehensiveAdminTransaction with withSpan.
  - Named spans (e.g., db.authenticatedTransaction) under tracer db.transaction and use SpanKind.CLIENT.
  - Set count attributes after completion (db.events_count, db.ledger_commands_count).
  - Normalized livemode handling via effectiveLivemode.

<sup>Written for commit 1b73636de9b12b95b98559aea3c5d5f0dbf6e940. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

