### PR TITLE
feat: instrument Svix webhook operations with OpenTelemetry tracing

### DIFF
--- a/platform/flowglad-next/src/utils/svix.ts
+++ b/platform/flowglad-next/src/utils/svix.ts
@@ -1,11 +1,49 @@
+/**
+ * Svix webhook dispatch utilities.
+ *
+ * Svix is a third-party service that handles reliable webhook delivery to customer endpoints.
+ * This module wraps Svix API calls to manage applications (per-organization containers),
+ * endpoints (customer-configured URLs), and message dispatch. All operations are instrumented
+ * with OpenTelemetry tracing to measure webhook-related latency.
+ *
+ * @see https://www.svix.com/
+ */
+
+import { type Span, SpanKind } from '@opentelemetry/api'
 import { type ApplicationOut, Svix } from 'svix'
 import { Application } from 'svix/dist/api/application'
+import { ApiException } from 'svix/dist/util'
 import type { Event } from '@/db/schema/events'
 import type { Organization } from '@/db/schema/organizations'
 import type { Webhook } from '@/db/schema/webhooks'
+import { withSpan } from '@/utils/tracing'
 import { generateHmac } from './backendCore'
 import core from './core'
 
+const withSvixSpan = async <T>(
+  operation: string,
+  attributes: Record<string, string | number | boolean | undefined>,
+  fn: (span: Span) => Promise<T>
+): Promise<T> => {
+  return withSpan(
+    {
+      spanName: `svix.${operation}`,
+      tracerName: 'svix',
+      kind: SpanKind.CLIENT,
+      attributes: {
+        'svix.operation': operation,
+        ...attributes,
+      },
+    },
+    fn
+  )
+}
+
+/**
+ * Create a Svix client configured from the `SVIX_API_KEY` environment variable.
+ *
+ * @returns A Svix client instance initialized with the value of `SVIX_API_KEY`.
+ */
 export function svix() {
   return new Svix(core.envVariable('SVIX_API_KEY'))
 }
@@ -63,6 +101,15 @@ export function getSvixEndpointId(params: {
   })
 }
 
+/**
+ * Ensures a Svix application exists for the given organization and livemode.
+ *
+ * Attempts to fetch a Svix application by its deterministic ID and creates a new application with a name derived from the organization if no existing application is found. The OpenTelemetry span used for the operation is annotated with the attribute `svix.created` set to `true` when a new application is created and `false` when an existing application is returned.
+ *
+ * @param organization - Organization record used to compute the Svix application ID and display name
+ * @param livemode - When `true`, use the live-mode application ID; when `false`, use the test-mode application ID
+ * @returns The existing or newly created Svix application
+ */
 export async function findOrCreateSvixApplication(params: {
   organization: Organization.Record
   livemode: boolean
@@ -73,22 +120,49 @@ export async function findOrCreateSvixApplication(params: {
     organization,
     livemode,
   })
-  let app: ApplicationOut | undefined
-  try {
-    app = await svix().application.get(applicationId)
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.log('error', error)
-  }
-  if (app) {
-    return app
-  }
-  return await svix().application.create({
-    name: `${organization.name} - (${organization.id} - ${modeSlug})`,
-    uid: applicationId,
-  })
+  return withSvixSpan(
+    'application.findOrCreate',
+    {
+      'svix.org_id': organization.id,
+    },
+    async (span) => {
+      let app: ApplicationOut | undefined
+      try {
+        app = await svix().application.get(applicationId)
+      } catch (error) {
+        // Only treat 404 (not found) as a signal to create a new application
+        // Rethrow other errors (network, auth, rate limits, etc.)
+        if (error instanceof ApiException && error.code === 404) {
+          // Application not found, will create below
+        } else {
+          // eslint-disable-next-line no-console
+          console.error('Svix application.get error', error)
+          throw error
+        }
+      }
+      if (app) {
+        span.setAttributes({ 'svix.created': false })
+        return app
+      }
+      span.setAttributes({ 'svix.created': true })
+      return await svix().application.create({
+        name: `${organization.name} - (${organization.id} - ${modeSlug})`,
+        uid: applicationId,
+      })
+    }
+  )
 }
 
+/**
+ * Create a Svix endpoint for the given webhook and organization.
+ *
+ * Ensures the corresponding Svix application exists for the webhook's livemode, then creates and returns an endpoint configured with the webhook's URL and filter types.
+ *
+ * @param params.organization - The organization record used to derive the Svix application ID
+ * @param params.webhook - The webhook record whose URL, livemode, and filterTypes are used to create the endpoint
+ * @returns The created Svix endpoint object
+ * @throws If no application ID can be derived for the organization and webhook livemode
+ */
 export async function createSvixEndpoint(params: {
   organization: Organization.Record
   webhook: Webhook.Record
@@ -101,53 +175,89 @@ export async function createSvixEndpoint(params: {
   if (!applicationId) {
     throw new Error('No application ID found')
   }
-  await findOrCreateSvixApplication({
-    organization,
-    livemode: webhook.livemode,
-  })
-  const endpointId = getSvixEndpointId({
-    organization,
-    webhook,
-    livemode: webhook.livemode,
-  })
-  const endpoint = await svix().endpoint.create(applicationId, {
-    uid: endpointId,
-    url: webhook.url,
-    filterTypes: webhook.filterTypes,
-  })
-  return endpoint
+  return withSvixSpan(
+    'endpoint.create',
+    {
+      'svix.app_id': applicationId,
+    },
+    async () => {
+      await findOrCreateSvixApplication({
+        organization,
+        livemode: webhook.livemode,
+      })
+      const endpointId = getSvixEndpointId({
+        organization,
+        webhook,
+        livemode: webhook.livemode,
+      })
+      const endpoint = await svix().endpoint.create(applicationId, {
+        uid: endpointId,
+        url: webhook.url,
+        filterTypes: webhook.filterTypes,
+      })
+      return endpoint
+    }
+  )
 }
 
+/**
+ * Update the Svix endpoint for a webhook using the organization's Svix application.
+ *
+ * @param params.webhook - Webhook record whose `url`, `filterTypes`, `active`, and `livemode` are applied to the endpoint
+ * @param params.organization - Organization record used to derive or create the Svix application
+ * @returns The updated Svix endpoint object
+ * @throws Error if the corresponding Svix application cannot be found or created
+ */
 export async function updateSvixEndpoint(params: {
   webhook: Webhook.Record
   organization: Organization.Record
 }) {
   const { webhook, organization } = params
-  const application = await findOrCreateSvixApplication({
+  const applicationId = getSvixApplicationId({
     organization,
     livemode: webhook.livemode,
   })
-  if (!application) {
-    throw new Error('No application found')
-  }
   const endpointId = getSvixEndpointId({
     organization,
     webhook,
     livemode: webhook.livemode,
   })
-
-  const endpoint = await svix().endpoint.patch(
-    application.id,
-    endpointId,
+  return withSvixSpan(
+    'endpoint.update',
     {
-      url: webhook.url,
-      filterTypes: webhook.filterTypes,
-      disabled: !webhook.active,
+      'svix.app_id': applicationId,
+      'svix.endpoint_id': endpointId,
+    },
+    async () => {
+      const application = await findOrCreateSvixApplication({
+        organization,
+        livemode: webhook.livemode,
+      })
+      if (!application) {
+        throw new Error('No application found')
+      }
+      const endpoint = await svix().endpoint.patch(
+        application.id,
+        endpointId,
+        {
+          url: webhook.url,
+          filterTypes: webhook.filterTypes,
+          disabled: !webhook.active,
+        }
+      )
+      return endpoint
     }
   )
-  return endpoint
 }
 
+/**
+ * Send the provided event to Svix for the given organization.
+ *
+ * @param event - The event record to deliver; its `livemode` and `type` determine routing and metadata.
+ * @param organization - The organization record used to derive the Svix application identifier.
+ *
+ * @throws If no Svix application ID can be derived for the organization and event livemode.
+ */
 export async function sendSvixEvent(params: {
   event: Event.Record
   organization: Organization.Record
@@ -160,23 +270,39 @@ export async function sendSvixEvent(params: {
   if (!applicationId) {
     throw new Error('No application ID found')
   }
-  await svix().message.create(
-    applicationId,
+  return withSvixSpan(
+    'message.create',
     {
-      eventType: event.type,
-      eventId: event.hash,
-      payload: event.payload,
+      'svix.app_id': applicationId,
+      'svix.event_type': event.type,
     },
-    {
-      idempotencyKey: event.hash,
+    async () => {
+      await svix().message.create(
+        applicationId,
+        {
+          eventType: event.type,
+          eventId: event.hash,
+          payload: event.payload,
+        },
+        {
+          idempotencyKey: event.hash,
+        }
+      )
     }
   )
 }
 
+/**
+ * Retrieve the Svix signing secret for a webhook endpoint associated with an organization.
+ *
+ * @param webhook - The webhook record identifying the endpoint and its livemode
+ * @param organization - The organization that owns the endpoint
+ * @returns An object containing the endpoint's signing secret in the `key` property
+ */
 export async function getSvixSigningSecret(params: {
   webhook: Webhook.Record
   organization: Organization.Record
-}) {
+}): Promise<{ key: string }> {
   const { webhook, organization } = params
   const endpointId = getSvixEndpointId({
     organization,
@@ -187,9 +313,18 @@ export async function getSvixSigningSecret(params: {
     organization,
     livemode: webhook.livemode,
   })
-  const secret = await svix().endpoint.getSecret(
-    applicationId,
-    endpointId
+  return withSvixSpan(
+    'endpoint.getSecret',
+    {
+      'svix.app_id': applicationId,
+      'svix.endpoint_id': endpointId,
+    },
+    async () => {
+      const secret = await svix().endpoint.getSecret(
+        applicationId,
+        endpointId
+      )
+      return secret
+    }
   )
-  return secret
 }


### PR DESCRIPTION
## What Does this PR Do?

Adds OpenTelemetry distributed tracing spans to all Svix webhook operations to measure webhook dispatch latency. Implements a `withSvixSpan` helper that wraps each operation with CLIENT spans tracking application IDs, endpoint IDs, event types, and creation status where applicable. All traces follow PII guidelines, excluding endpoint URLs and signing secrets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Instrumented all Svix webhook operations with OpenTelemetry tracing to measure webhook dispatch latency and improve observability. Also improves error handling for application creation and adds type safety.

- **New Features**
  - Tracing added to application.findOrCreate, endpoint.create, endpoint.update, message.create, and endpoint.getSecret.
  - Captures app_id, endpoint_id, org_id, event_type, and created flag where relevant.
  - Excludes sensitive data like endpoint URLs and signing secrets.
  - Uses CLIENT spans with svix.* names for consistent trace data.

- **Refactors**
  - Added docstrings and explicit types in svix utilities for clarity.

<sup>Written for commit 10ed7b671a90c2922bd1bd930dbf2a77b94205c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public APIs to create and update webhook endpoints, find-or-create Svix applications, send events, and retrieve webhook signing secrets.
* **Chores**
  * Added internal tracing around Svix operations to improve observability, attaching operation and span attributes for better monitoring and diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->