### PR TITLE
chore: remove unused purchasesRouter session endpoints

### DIFF
--- a/platform/flowglad-next/src/routing-logic/middlewareLogic.test.ts
+++ b/platform/flowglad-next/src/routing-logic/middlewareLogic.test.ts
@@ -629,24 +629,6 @@ describe('middlewareLogic', () => {
         expect(result.proceed).toBe(true)
       })
 
-      it('should allow access to purchase session procedures without session', () => {
-        const paths = [
-          '/api/trpc/purchases.createSession',
-          '/api/trpc/purchases.getSession',
-          '/api/trpc/purchases.updateSession',
-        ]
-        paths.forEach((path) => {
-          const result = middlewareLogic({
-            sessionCookie: null,
-            isProtectedRoute: false,
-            pathName: path,
-            customerBillingPortalOrganizationId: null,
-            req: { nextUrl: `https://example.com${path}` },
-          })
-          expect(result.proceed).toBe(true)
-        })
-      })
-
       it('should allow access to checkoutSessions.public procedures without session', () => {
         const paths = [
           '/api/trpc/checkoutSessions.public.create',

--- a/platform/flowglad-next/src/routing-logic/publicRoutes.test.ts
+++ b/platform/flowglad-next/src/routing-logic/publicRoutes.test.ts
@@ -365,24 +365,6 @@ describe('middlewareLogic - public routes coverage', () => {
       expect(result.proceed).toBe(true)
     })
 
-    it('should allow access to purchase session procedures without session', () => {
-      const paths = [
-        '/api/trpc/purchases.createSession',
-        '/api/trpc/purchases.getSession',
-        '/api/trpc/purchases.updateSession',
-      ]
-      paths.forEach((path) => {
-        const result = middlewareLogic({
-          sessionCookie: null,
-          isProtectedRoute: false,
-          pathName: path,
-          customerBillingPortalOrganizationId: null,
-          req: { nextUrl: `https://example.com${path}` },
-        })
-        expect(result.proceed).toBe(true)
-      })
-    })
-
     it('should allow access to checkoutSessions.public procedures without session', () => {
       const paths = [
         '/api/trpc/checkoutSessions.public.create',

--- a/platform/flowglad-next/src/server/routers/purchasesRouter.ts
+++ b/platform/flowglad-next/src/server/routers/purchasesRouter.ts
@@ -16,8 +16,6 @@ import {
   createPaginatedTableRowOutputSchema,
   idInputSchema,
 } from '@/db/tableUtils'
-import { confirmCheckoutSession } from '@/server/mutations/confirmCheckoutSession'
-import { editCheckoutSession } from '@/server/mutations/editCheckoutSession'
 import { protectedProcedure, router } from '@/server/trpc'
 import { PurchaseStatus } from '@/types'
 import { generateOpenApiMetas } from '@/utils/openapi'
@@ -65,10 +63,6 @@ const getTableRows = protectedProcedure
 export const purchasesRouter = router({
   // Get single purchase
   get: getPurchaseProcedure,
-  // Create purchase
-  // Purchase session management
-  updateSession: editCheckoutSession,
-  confirmSession: confirmCheckoutSession,
   // Table rows for internal UI
   getTableRows,
 })


### PR DESCRIPTION
## Summary
- Remove `updateSession` and `confirmSession` from `purchasesRouter` - these endpoints were dead code, never called by any client
- Remove related test cases that were testing non-existent public routes (`purchases.createSession`, `purchases.getSession`, `purchases.updateSession`)

## Context
During a security audit, these endpoints were flagged because they use `publicProcedure` + `adminTransaction`. However, investigation revealed:
1. They are protected by Clerk middleware (not in `publicRoutes.ts`), so unauthenticated requests get 307 redirects
2. They are never actually called by any client code
3. The equivalent functionality exists in `checkoutSessions.public.*`

Since they're unused duplicate code, removing them is the cleanest solution.

## Test plan
- [x] `bun run check` passes
- [x] Verified no client code references these endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused purchase session endpoints (purchases.updateSession, purchases.confirmSession) and deleted tests for non-existent public routes. These were never called and duplicate checkoutSessions.public, reducing surface area with no behavior change.

<sup>Written for commit 16130ab9856e345aac445ad4308b5308681b2781. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed test cases validating purchase session procedures accessibility.

* **Removals**
  * Removed `updateSession` and `confirmSession` endpoints from the purchases API, eliminating access to session update and confirmation operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->