### PR TITLE
fix(server): validate subscription ownership in createUsageEvent

### DIFF
--- a/packages/server/src/subrouteHandlers/usageEventHandlers.ts
+++ b/packages/server/src/subrouteHandlers/usageEventHandlers.ts
@@ -51,6 +51,22 @@ export const createUsageEvent: SubRouteHandler<
       }
     }
 
+    // Validate subscription ownership (align with bulkCreateUsageEvents)
+    const customerSubscriptionIds =
+      billing.currentSubscriptions?.map((sub) => sub.id) ?? []
+    if (!customerSubscriptionIds.includes(subscriptionId)) {
+      return {
+        data: {},
+        status: 403,
+        error: {
+          code: 'forbidden',
+          json: {
+            message: `Subscription ${subscriptionId} is not found among the customer's current subscriptions`,
+          },
+        },
+      }
+    }
+
     const resolvedParams = {
       ...params.data,
       subscriptionId,


### PR DESCRIPTION
## What Does this PR Do?

Adds subscription ownership validation to the single `createUsageEvent` handler to prevent unauthorized usage event creation. This aligns with existing validation in `bulkCreateUsageEvents` and closes a security gap where authenticated users could create usage events against subscriptions belonging to other customers.

The handler now validates that the provided `subscriptionId` belongs to the requesting customer before creating the usage event, returning a 403 Forbidden error if the subscription is not found among the customer's current subscriptions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate subscription ownership in createUsageEvent to block unauthorized usage event creation. If the subscriptionId isn’t in the customer’s current subscriptions, return 403 Forbidden, matching bulkCreateUsageEvents behavior.

<sup>Written for commit b403e098eac93c2f6d7364f74c57ac2b53f8cee9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Usage event creation now validates that the targeted subscription belongs to the requesting customer; unauthorized subscription requests return a forbidden error.

* **Tests**
  * Comprehensive test coverage added for create-usage-event flows, including subscription validation, default parameter handling, HTTP method checks, and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->