### PR TITLE
fix: add deterministic sort tiebreaker for invoice line items

### DIFF
--- a/platform/flowglad-next/src/utils/invoiceHelpers.ts
+++ b/platform/flowglad-next/src/utils/invoiceHelpers.ts
@@ -133,17 +133,14 @@ export const updateInvoiceTransaction = async (
   return {
     invoice: updatedInvoice,
     /**
-     * Sort the invoice line items by createdAt
-     * ascending to consistent ordering of the line items
+     * Sort the invoice line items by createdAt ascending,
+     * with id as a tiebreaker for consistent ordering
      */
-    invoiceLineItems: updatedInvoiceLineItems
-      .slice()
-      .sort((a, b) =>
-        a.createdAt < b.createdAt
-          ? -1
-          : a.createdAt > b.createdAt
-            ? 1
-            : 0
-      ),
+    invoiceLineItems: updatedInvoiceLineItems.slice().sort((a, b) => {
+      if (a.createdAt < b.createdAt) return -1
+      if (a.createdAt > b.createdAt) return 1
+      // When createdAt is equal, use id as tiebreaker for deterministic ordering
+      return a.id.localeCompare(b.id)
+    }),
   }
 }


### PR DESCRIPTION
## Problem

The test `should handle mixed changes to line items` in `invoiceHelpers.test.ts` was failing intermittently with:

```
AssertionError: expected 'New Item 3' to be 'Modified Item 1'
```

## Root Cause

The invoice line items were sorted by `createdAt`, but when two items have the same timestamp (which happens when database operations occur within the same millisecond), the sort order was **non-deterministic** because the comparator returned `0`.

## Solution

Added `id` as a tiebreaker when `createdAt` values are equal, ensuring the sort is always deterministic:

```typescript
invoiceLineItems: updatedInvoiceLineItems.slice().sort((a, b) => {
  if (a.createdAt < b.createdAt) return -1
  if (a.createdAt > b.createdAt) return 1
  // When createdAt is equal, use id as tiebreaker for deterministic ordering
  return a.id.localeCompare(b.id)
}),
```

## Testing

- [x] `bun check` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make invoice line item sorting deterministic by using id as a tiebreaker when createdAt timestamps are equal. Fixes flaky ordering that caused intermittent test failures.

- **Bug Fixes**
  - Sort by createdAt ascending, with id as the tiebreaker on equal timestamps.
  - Eliminates intermittent failure in invoiceHelpers.test.ts for mixed line item changes.

<sup>Written for commit 23095e40457e29fcd361de01a2ae04e63cd00bc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

