### PR TITLE
fix: store API key environment in metadata

### DIFF
--- a/platform/flowglad-next/src/db/databaseAuthentication.ts
+++ b/platform/flowglad-next/src/db/databaseAuthentication.ts
@@ -68,7 +68,7 @@ async function keyVerify(key: string): Promise<KeyVerifyResult> {
     // Extract environment from key prefix (sk_live_ or sk_test_)
     const environment =
       (result.meta?.environment as string | undefined) ||
-      (key.includes('_live_') ? 'live' : 'test')
+      (key.includes('_live') ? 'live' : 'test')
     return {
       keyType: meta.type,
       userId: userIdFromUnkeyMeta(meta),

--- a/platform/flowglad-next/src/db/schema/apiKeys.ts
+++ b/platform/flowglad-next/src/db/schema/apiKeys.ts
@@ -177,6 +177,7 @@ export const secretApiKeyMetadataSchema = z.object({
   type: z.literal(FlowgladApiKeyType.Secret),
   userId: z.string(),
   organizationId: z.string().optional(),
+  environment: z.enum(['live', 'test']).optional(),
 })
 
 export const apiKeyMetadataSchema = secretApiKeyMetadataSchema

--- a/platform/flowglad-next/src/utils/unkey.ts
+++ b/platform/flowglad-next/src/utils/unkey.ts
@@ -111,7 +111,7 @@ export const verifyApiKey = async (
             (verificationResponse.data.meta?.environment as
               | string
               | undefined) ||
-            (apiKey.includes('_live_') ? 'live' : 'test'),
+            (apiKey.includes('_live') ? 'live' : 'test'),
           requestId: verificationResponse.meta.requestId,
         }
         const verificationResult: VerifyApiKeyResult = {
@@ -208,6 +208,7 @@ export const secretApiKeyInputToUnkeyInput = (
   const unparsedMeta: ApiKey.SecretMetadata = {
     userId: params.userId,
     type: FlowgladApiKeyType.Secret,
+    environment: apiEnvironment,
   }
   const secretMeta = secretApiKeyMetadataSchema.parse(unparsedMeta)
 


### PR DESCRIPTION
## What Does this PR Do?

Fixes a critical bug where live API keys were misidentified as test keys due to incorrect environment detection logic. The key prefix format is `sk_liveXXXX` but the fallback check was looking for `'_live_'` (with trailing underscore).

This fix:
- Stores the environment ('live' or 'test') in API key metadata during creation
- Updates the metadata schema to include the optional environment field
- Corrects the fallback string check for legacy keys without metadata

The environment is now reliably extracted from Unkey metadata, preventing data isolation issues where live keys could access test data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misidentification of live API keys as test keys by storing the environment in metadata and correcting the legacy fallback check. Prevents live keys from accessing test data.

- **Bug Fixes**
  - Store environment ('live' or 'test') in API key metadata on creation.
  - Add optional environment field to the metadata schema.
  - Update fallback detection to check for '_live' (not '_live_') for legacy keys.

<sup>Written for commit 5a1c4b1967bb788dbd5927f595e9962e03f44696. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

