### PR TITLE
fix: add livemode filter to discount lookup in attemptDiscountCode

### DIFF
--- a/platform/flowglad-next/src/server/mutations/attemptDiscountCode.ts
+++ b/platform/flowglad-next/src/server/mutations/attemptDiscountCode.ts
@@ -47,6 +47,7 @@ export const attemptDiscountCode = publicProcedure
           {
             code: input.code,
             organizationId: checkoutSession.organizationId,
+            livemode: checkoutSession.livemode,
           },
           transaction
         )


### PR DESCRIPTION
## What Does this PR Do?

Adds the `livemode` filter to the discount lookup query in the `attemptDiscountCode` mutation to prevent test mode discounts from being applied to live mode checkouts (and vice versa). Since `adminTransaction` bypasses RLS policies, the application layer must explicitly enforce test/live data isolation.

## Security Impact

Fixes a data isolation vulnerability where customers in live checkouts could apply test mode discount codes with unauthorized discount amounts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a livemode filter to the discount lookup in attemptDiscountCode so discounts only apply in the same mode (live or test). This prevents test codes from applying to live checkouts and enforces mode isolation even when adminTransaction bypasses RLS.

<sup>Written for commit b83fe1ad227814ad852005286cbf5fe5dc8a46e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discount code validation to correctly align with the current checkout session environment, ensuring discounts are applied consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->