### PR TITLE
fix: remove duplicate HTTP spans from @vercel/otel

### DIFF
--- a/platform/flowglad-next/src/instrumentation.ts
+++ b/platform/flowglad-next/src/instrumentation.ts
@@ -47,24 +47,12 @@ export async function register() {
       serviceName:
         process.env.FLOWGLAD_OTEL_SERVICE_NAME || 'flowglad-api',
       traceSampler: sampler,
-      instrumentationConfig: {
-        fetch: {
-          ignoreUrls: [
-            // Don't trace OTEL exporter calls to BetterStack.
-            // This prevents recursive tracing where the exporter's HTTP calls
-            // appear as slow spans in traces.
-            //
-            // TODO: When we move off Vercel, switch to an OpenTelemetry Collector
-            // sidecar pattern instead. The app would export to localhost:4318
-            // (fast, no network latency) and the collector handles batching,
-            // retries, and forwarding to BetterStack. This eliminates the need
-            // for ignoreUrls and reduces export overhead in the application.
-            /betterstackdata\.com/,
-            /logs\.betterstack\.com/,
-            /in-otel\.logs\.betterstack\.com/,
-          ],
-        },
-      },
+      // Disable @vercel/otel's fetch instrumentation to avoid duplicate spans.
+      // Sentry's @opentelemetry/instrumentation-http (initialized in sentry.server.config.ts)
+      // already instruments HTTP/fetch requests with standard semantic conventions.
+      // If we move off Sentry, re-enable this by removing the line below or setting
+      // instrumentations: ['fetch'] to restore HTTP span creation.
+      instrumentations: [],
     })
   } finally {
     // Restore original variables for trigger.dev to use


### PR DESCRIPTION
## What Does this PR Do?

Disables @vercel/otel's fetch instrumentation to eliminate duplicate HTTP spans. Sentry's @opentelemetry/instrumentation-http already provides comprehensive HTTP instrumentation with standard OpenTelemetry semantic conventions. The duplicate spans were creating noise in traces and complicating trace analysis. Includes a comment documenting how to re-enable if we move off Sentry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled @vercel/otel fetch instrumentation to remove duplicate HTTP spans and reduce trace noise. HTTP tracing now relies on Sentry’s @opentelemetry/instrumentation-http, following OpenTelemetry semantic conventions.

<sup>Written for commit 8f24ae8dda5af3bf2d29b311aa2ad6ad3c6fbe74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

