### PR TITLE
Fix post-payment route incorrectly rejecting setup intents without purchases

### DIFF
--- a/platform/flowglad-next/src/app/purchase/post-payment/route.tsx
+++ b/platform/flowglad-next/src/app/purchase/post-payment/route.tsx
@@ -287,17 +287,6 @@ export const GET = async (request: NextRequest) => {
 
     const { purchase } = result
 
-    if (!purchase) {
-      return Response.json(
-        {
-          success: false,
-        },
-        {
-          status: 400,
-        }
-      )
-    }
-
     let url = result.url
     if (isNil(url) && result.checkoutSession) {
       url = new URL(
@@ -306,28 +295,34 @@ export const GET = async (request: NextRequest) => {
       )
     }
 
-    const purchaseId = purchase.id
-    const priceId = purchase.priceId
-    const { product } = await adminTransaction(
-      async ({ transaction }) => {
-        const [{ product }] =
-          await selectPriceProductAndOrganizationByPriceWhere(
-            {
-              id: priceId,
-            },
-            transaction
-          )
-        return { product }
-      }
-    )
-
     /**
-     * As the purchase session cookie is no longer needed, delete it.
+     * Only run purchase-specific logic when a purchase exists.
+     * Some setup intent flows (AddPaymentMethod, ActivateSubscription,
+     * terminal checkout sessions) legitimately have null purchases.
      */
-    await deleteCheckoutSessionCookie({
-      purchaseId: purchase.id,
-      productId: product.id,
-    })
+    if (purchase) {
+      const priceId = purchase.priceId
+      const { product } = await adminTransaction(
+        async ({ transaction }) => {
+          const [{ product }] =
+            await selectPriceProductAndOrganizationByPriceWhere(
+              {
+                id: priceId,
+              },
+              transaction
+            )
+          return { product }
+        }
+      )
+
+      /**
+       * As the purchase session cookie is no longer needed, delete it.
+       */
+      await deleteCheckoutSessionCookie({
+        purchaseId: purchase.id,
+        productId: product.id,
+      })
+    }
 
     return Response.redirect(url, 303)
   } catch (error) {


### PR DESCRIPTION
## What Does this PR Do?

Fixes the post-payment route that was incorrectly returning 400 errors for legitimate setup intent flows that don't create purchases (AddPaymentMethod, ActivateSubscription, and terminal checkout sessions). The route now only applies purchase-specific logic when a purchase exists, allowing all flows to redirect successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the post-payment route so setup intent flows without purchases no longer return 400 and now redirect successfully.

- **Bug Fixes**
  - Run purchase-specific logic (product lookup and cookie deletion) only when a purchase exists.
  - Support AddPaymentMethod, ActivateSubscription, and terminal checkout sessions that have null purchases.

<sup>Written for commit 175df3bcb0dcdc384b842639a227171e84a58c2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of the post-payment process to gracefully handle edge cases in checkout scenarios without interrupting the redirect flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->