### PR TITLE
fix: allow null purchase in setup intent post-payment flows

### DIFF
--- a/platform/flowglad-next/src/app/purchase/post-payment/route.tsx
+++ b/platform/flowglad-next/src/app/purchase/post-payment/route.tsx
@@ -317,14 +317,12 @@ export const GET = async (request: NextRequest) => {
 
       /**
        * As the purchase session cookie is no longer needed, delete it.
-       * Skip if the price/product lookup fails (data inconsistency).
+       * Always delete the purchase cookie; only include productId if lookup succeeded.
        */
-      if (priceResult) {
-        await deleteCheckoutSessionCookie({
-          purchaseId: purchase.id,
-          productId: priceResult.product.id,
-        })
-      }
+      await deleteCheckoutSessionCookie({
+        purchaseId: purchase.id,
+        productId: priceResult?.product.id,
+      })
     }
 
     return Response.redirect(url, 303)


### PR DESCRIPTION
## What Does this PR Do?

Fixes a bug where the post-payment redirect route incorrectly returned 400 errors for legitimate setup intent flows that don't create purchases. Setup intents for AddPaymentMethod, ActivateSubscription, and terminal checkout sessions should redirect successfully instead of failing.

The fix conditionally runs purchase-specific logic (product lookup and cookie deletion) only when a purchase exists, then always redirects to the success URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the post-payment redirect to handle setup intents that don’t create purchases. These flows now skip purchase-only steps and redirect to the success URL instead of returning 400.

- **Bug Fixes**
  - Removed 400 when purchase is null; always redirect with 303 to the success URL.
  - Run product lookup and checkout session cleanup only when a purchase exists; always delete the purchase cookie and include productId only if the price/product lookup succeeds.

<sup>Written for commit a9cfd9dd6acb2ca7735ef6e1a0999101a8bfce35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-payment robustness: handles missing or inconsistent purchase data without failing user redirects.
  * Ensures checkout session state is cleared when a purchase exists; only attaches product details if a price/product lookup succeeds.
  * Adds error logging and preserves existing redirect behavior for safer recovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->