### PR TITLE
bump sdk version in integration prompt

### DIFF
--- a/platform/flowglad-next/src/prompts/integration-fragments/integration-core.md
+++ b/platform/flowglad-next/src/prompts/integration-fragments/integration-core.md
@@ -53,7 +53,7 @@ Update `{PACKAGE_FILE}` to add the Flowglad SDK packages. Prefer using published
 
 {PACKAGE_DEPENDENCIES_CODE}
 
-Note: the Flowglad SDKs are currently for Typescript only. The current latest version is 0.13.0.
+Note: the Flowglad SDKs are currently for Typescript only. The current latest version is 0.16.2.
 
 Here's what they should install depending on their project:
 - Next.js: @flowglad/nextjs


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

Quick fix for the outdated sdk version in the core custom integration prompt.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the core custom integration prompt to reference Flowglad SDK v0.16.2 (was 0.13.0) so users install the correct TypeScript packages.

<sup>Written for commit a0bc2f8121639863e94707100cd186017f4d9ea2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SDK version reference in documentation to reflect the latest version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->