### PR TITLE
dynamic sdk versions during integration (experimental)

### DIFF
--- a/platform/flowglad-next/src/prompts/integration-fragments/integration-core.md
+++ b/platform/flowglad-next/src/prompts/integration-fragments/integration-core.md
@@ -53,7 +53,7 @@ Update `{PACKAGE_FILE}` to add the Flowglad SDK packages. Prefer using published
 
 {PACKAGE_DEPENDENCIES_CODE}
 
-Note: the Flowglad SDKs are currently for Typescript only. The current latest version is 0.16.2.
+Note: the Flowglad SDKs are currently for Typescript only. The current latest versions are provided below.
 
 Here's what they should install depending on their project:
 - Next.js: @flowglad/nextjs

--- a/platform/flowglad-next/src/utils/pricingModels/integration-guides/constructIntegrationGuide.ts
+++ b/platform/flowglad-next/src/utils/pricingModels/integration-guides/constructIntegrationGuide.ts
@@ -109,6 +109,26 @@ ${yaml.stringify(pricingModelData)}
 `
 }
 
+export const getLatestSdkVersionsFragment = async () => {
+  const [nextjs, react, server] = await Promise.all([
+    getNpmPackageVersion('@flowglad/nextjs'),
+    getNpmPackageVersion('@flowglad/react'),
+    getNpmPackageVersion('@flowglad/server'),
+  ])
+
+  return `The following are the latest version for Flowglad's NPM packages (sdks)\n"@flowglad/nextjs": ${nextjs}\n"@flowglad/react":${react}\n"@flowglad/server": ${server}`
+}
+
+const getNpmPackageVersion = async (name: string) => {
+  const res = await fetch(`https://registry.npmjs.org/${name}`)
+
+  if (!res.ok) return null
+
+  const data = await res.json()
+
+  return data['dist-tags'].latest
+}
+
 /**
  * Strips markdown code block tags from the beginning and end of text.
  * Handles both ```markdown and ``` variants.
@@ -482,6 +502,7 @@ export const constructIntegrationGuideStream = async function* ({
   )
 
   const otherFragments = [
+    await getLatestSdkVersionsFragment(),
     await constructBackendIntegrationFragment({
       isBackendJavascript,
     }),


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->
Exploring the possibilty of dynamically getting sdk versions while generating custom integration prompts.

related to #1242 and #1241 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch the latest Flowglad SDK versions from npm during integration guide generation, replacing the hardcoded version. This keeps guides accurate and reduces manual updates.

- New Features
  - Added getLatestSdkVersionsFragment to pull latest versions for @flowglad/nextjs, @flowglad/react, and @flowglad/server from the npm registry.
  - Injected the versions fragment into constructIntegrationGuideStream so prompts display current versions.
  - Updated integration-core.md to reference dynamic versions instead of a fixed number.

<sup>Written for commit 7045b94246023c1f44a40f50dc098d568abfa9b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

