### PR TITLE
[stripe-integration-tests] Patch 5: Tax Calculation Integration Tests

### DIFF
--- a/platform/flowglad-next/src/test/stripeIntegrationHelpers.ts
+++ b/platform/flowglad-next/src/test/stripeIntegrationHelpers.ts
@@ -34,30 +34,6 @@ export const getStripeTestClient = (): Stripe => {
 }
 
 /**
- * Skips the current test if STRIPE_TEST_MODE_SECRET_KEY is not set.
- * Use this at the beginning of integration tests to gracefully skip
- * when credentials are not available.
- *
- * @example
- * ```ts
- * it('should create a customer', async () => {
- *   skipIfNoStripeKey()
- *   // test code...
- * })
- * ```
- */
-export const skipIfNoStripeKey = (): void => {
-  const key = getStripeTestModeSecretKey()
-  if (!key) {
-    // Using describe.skip() at runtime isn't possible, so we throw a special error
-    // that Vitest will treat as a skip when combined with proper test structure
-    throw new Error(
-      'STRIPE_TEST_MODE_SECRET_KEY is not set - skipping integration test'
-    )
-  }
-}
-
-/**
  * Creates a describe block that only runs if Stripe credentials are available.
  * Use this to wrap integration test suites that require Stripe access.
  *

--- a/platform/flowglad-next/src/utils/stripe.integration.test.ts
+++ b/platform/flowglad-next/src/utils/stripe.integration.test.ts
@@ -7,7 +7,11 @@ import {
   getStripeTestClient,
 } from '@/test/stripeIntegrationHelpers'
 import core from '@/utils/core'
-import { createCustomerSessionForCheckout } from '@/utils/stripe'
+import {
+  createCustomerSessionForCheckout,
+  createStripeTaxCalculationByPrice,
+  createStripeTaxTransactionFromCalculation,
+} from '@/utils/stripe'
 
 describeIfStripeKey('Stripe Integration Tests', () => {
   describe('createStripeCustomer', () => {
@@ -130,6 +134,74 @@ describeIfStripeKey('Stripe Integration Tests', () => {
       ).rejects.toThrow(
         'Missing stripeCustomerId for customer session creation'
       )
+    })
+  })
+})
+
+describe('Tax Calculations', () => {
+  describe('createStripeTaxCalculationByPrice', () => {
+    it('returns test calculation in test environment with synthetic response format', async () => {
+      // When IS_TEST is true (which it is in the test environment),
+      // the function returns a synthetic response without making real API calls.
+      // We use minimal mock objects cast via unknown since the function
+      // short-circuits before using most fields.
+      const mockPrice = {
+        id: 'price_test123',
+        currency: 'usd',
+      } as unknown as Parameters<
+        typeof createStripeTaxCalculationByPrice
+      >[0]['price']
+
+      const mockProduct = {
+        id: 'prod_test123',
+      } as unknown as Parameters<
+        typeof createStripeTaxCalculationByPrice
+      >[0]['product']
+
+      const mockBillingAddress = {
+        address: {
+          line1: '354 Oyster Point Blvd',
+          city: 'South San Francisco',
+          state: 'CA',
+          postal_code: '94080',
+          country: 'US',
+        },
+      } as unknown as Parameters<
+        typeof createStripeTaxCalculationByPrice
+      >[0]['billingAddress']
+
+      const result = await createStripeTaxCalculationByPrice({
+        price: mockPrice,
+        billingAddress: mockBillingAddress,
+        discountInclusiveAmount: 1000,
+        product: mockProduct,
+        livemode: false,
+      })
+
+      expect(result.id).toMatch(/^testtaxcalc_/)
+      expect(result.tax_amount_exclusive).toBe(0)
+    })
+  })
+
+  describe('createStripeTaxTransactionFromCalculation', () => {
+    it('returns null when stripeTaxCalculationId is null', async () => {
+      const result = await createStripeTaxTransactionFromCalculation({
+        stripeTaxCalculationId: null,
+        reference: 'test_reference_123',
+        livemode: false,
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null when stripeTaxCalculationId starts with notaxoverride_', async () => {
+      const result = await createStripeTaxTransactionFromCalculation({
+        stripeTaxCalculationId: 'notaxoverride_xyz',
+        reference: 'test_reference_456',
+        livemode: false,
+      })
+
+      expect(result).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## Summary
- Add integration tests for tax calculation functions in `stripe.integration.test.ts`
- Test `createStripeTaxCalculationByPrice` returns synthetic response with id starting with `testtaxcalc_` and `tax_amount_exclusive` of 0 when `IS_TEST` is true
- Test `createStripeTaxTransactionFromCalculation` returns null when `stripeTaxCalculationId` is null or starts with `notaxoverride_`

## Test plan
- [ ] Run `bun run check` to verify lint/typecheck passes
- [ ] Run integration tests with `bun run test:integration:stripe` (requires STRIPE_TEST_MODE_SECRET_KEY)
- [ ] Verify tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added integration tests for Stripe tax calculations to validate test-mode behavior and safe handling.
Tests confirm createStripeTaxCalculationByPrice returns a synthetic id starting with testtaxcalc_ with tax_amount_exclusive 0 when IS_TEST is true, and createStripeTaxTransactionFromCalculation returns null when stripeTaxCalculationId is null or starts with notaxoverride_.

<sup>Written for commit 020d27b52fa8ebd080257879bdd24105ae1a03e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for Stripe integration with improved credential handling
  * Expanded test coverage for Stripe tax calculation and transaction processing features

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->