### PR TITLE
fix: default error status to 500 when undefined

### DIFF
--- a/packages/server/src/requestHandler.ts
+++ b/packages/server/src/requestHandler.ts
@@ -169,7 +169,7 @@ export const requestHandler = <TRequest = unknown>(
       }
       if ((error as any).message) {
         return {
-          status: (error as any).status,
+          status: (error as any).status ?? 500,
           error: { message: (error as any).message },
         }
       }


### PR DESCRIPTION
## What Does this PR Do?

Fixes a bug where errors with a message but no status property cause Express to crash and return a generic HTML error page instead of a proper JSON response.

When an error (e.g., from a database or third-party library) has `message` but no `status` property, the request handler now defaults to HTTP 500 instead of passing `undefined` to Express. This ensures clients receive clean JSON error responses with the original error message rather than an HTML stack trace.

**Before**: Returns HTML error page with "Invalid status code: undefined"
**After**: Returns JSON `{"error":{"message":"Database connection failed"}}` with HTTP 500

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default error status to 500 when undefined to prevent Express from crashing and returning an HTML error page. Clients now consistently get a JSON error response with the original message.

<sup>Written for commit 6a678eaefac0d1c2d036aa6254c0477682d6de7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling to ensure consistent HTTP status codes are returned for unexpected errors, improving application reliability and error response consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->