### PR TITLE
fix: validate HTTP response status in PDF generation

### DIFF
--- a/platform/flowglad-next/src/pdf-generation/generatePDF.ts
+++ b/platform/flowglad-next/src/pdf-generation/generatePDF.ts
@@ -19,7 +19,15 @@ export const generatePdf = async ({
   const browser = await initBrowser()
   try {
     const page = await browser.newPage()
-    await page.goto(url)
+    const response = await page.goto(url)
+
+    if (!response || !response.ok()) {
+      const status = response?.status() ?? 'unknown'
+      const statusText = response?.statusText() ?? 'unknown'
+      throw new Error(
+        `Failed to load page for PDF generation: ${status} ${statusText}. URL: ${url}`
+      )
+    }
 
     logger.info('PDF generated from URL', { url })
     // Generate PDF with embedded fonts


### PR DESCRIPTION
## What Does this PR Do?

Validates the HTTP response status after navigating to the URL in the `generatePdf()` function. If the page returns a non-success status code (4xx, 5xx), the function now throws an error instead of silently generating and uploading a PDF of the error page.

This prevents users from receiving PDFs containing error pages (e.g., "404 Not Found") when the invoice/receipt generation fails due to permissions, deleted records, or routing issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate HTTP response status before generating PDFs. If the page load fails (4xx/5xx or no response), we throw instead of generating/uploading a PDF of the error page.

- **Bug Fixes**
  - Check response.ok() after page.goto(url).
  - Throw an error with status and URL on non-success responses to stop bad PDFs.

<sup>Written for commit 6914558bdfffb9897be6d06f89d0f4d03a947f73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in PDF generation with detailed error messages that include HTTP status information when navigation fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->