### PR TITLE
ci: replace Docker Compose with GitHub Actions service containers

### DIFF
--- a/.github/workflows/flowglad-next-sharded-unit-tests.yml
+++ b/.github/workflows/flowglad-next-sharded-unit-tests.yml
@@ -38,6 +38,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+          --health-start-period 10s
 
     defaults:
       run:

--- a/platform/flowglad-next/src/db/client.ts
+++ b/platform/flowglad-next/src/db/client.ts
@@ -4,9 +4,8 @@ import postgres from 'postgres'
 import { format } from 'sql-formatter'
 import core from '@/utils/core'
 
-const TEST_DB_URL = 'postgresql://test:test@localhost:5432/test_db'
 const dbUrl = core.IS_TEST
-  ? TEST_DB_URL
+  ? core.TEST_DB_URL
   : core.envVariable('DATABASE_URL')
 /**
  * Very important to set prepare to false when connecting to a Supabase DB

--- a/platform/flowglad-next/src/scripts/migrate.ts
+++ b/platform/flowglad-next/src/scripts/migrate.ts
@@ -10,10 +10,8 @@ const projectDir = process.cwd()
 // To load env vars in a script
 loadEnvConfig(projectDir)
 
-const TEST_DB_URL = 'postgresql://test:test@localhost:5432/test_db'
-
 const dbUrl = core.IS_TEST
-  ? TEST_DB_URL
+  ? core.TEST_DB_URL
   : core.envVariable('DATABASE_URL')
 
 const client = postgres(dbUrl, {

--- a/platform/flowglad-next/src/utils/core.ts
+++ b/platform/flowglad-next/src/utils/core.ts
@@ -144,6 +144,13 @@ export const IS_PROD =
 export const IS_TEST =
   (process.env.NODE_ENV === 'test' || process.env.FORCE_TEST_MODE) &&
   process.env.VERCEL_ENV !== 'production'
+
+/**
+ * Test database URL used by both local docker-compose and CI service containers.
+ * Both environments provide PostgreSQL at localhost:5432 with identical credentials.
+ */
+export const TEST_DB_URL =
+  'postgresql://test:test@localhost:5432/test_db'
 export const IS_DEV =
   !IS_PROD && process.env.NODE_ENV === 'development'
 
@@ -532,6 +539,7 @@ export const safeZodSanitizedString = z
 export const core = {
   IS_PROD,
   IS_TEST,
+  TEST_DB_URL,
   DEV_ENVIRONMENT_NOTIF_PREFIX,
   NEXT_PUBLIC_APP_URL,
   notEmptyOrNil,


### PR DESCRIPTION
## What Does this PR Do?

Replace the unreliable `ndeloof/install-compose-action` with native GitHub Actions service containers for PostgreSQL. This eliminates intermittent "docker-compose: command not found" failures and simplifies the CI pipeline by using built-in GitHub Actions infrastructure.

**Changes:**
- Added PostgreSQL 15 service container with health checks
- Removed third-party Docker Compose installation action
- Simplified database setup to direct migrations call
- Removed redundant teardown step (auto-cleanup by service containers)

Local development workflow remains unchanged; docker-compose.test.yml and test scripts are preserved for local use.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Docker Compose in CI with a GitHub Actions PostgreSQL service container to eliminate intermittent “docker-compose: command not found” errors and simplify the test pipeline.

- **Refactors**
  - Added PostgreSQL 15 service container with health checks, including a 10s health-start-period.
  - Removed ndeloof/install-compose-action and related setup/teardown steps.
  - Run migrations directly with bun run migrations:push (NODE_ENV=test).
  - Consolidated TEST_DB_URL into core.ts and updated db client and migration script.
  - Kept docker-compose.test.yml for local use; no local workflow changes.

<sup>Written for commit b6eb703b9770137f1fe1bbb632b06926ec5e6c5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized test database configuration for improved maintainability.
  * Updated CI/CD workflow to streamline test execution with improved database service management.
  * Refactored database migration handling to execute separately before test runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->