### PR TITLE
refactor: auto-detect completed patches in fan-gameplan

### DIFF
--- a/platform/flowglad-next/llm-prompts/fan-gameplan.md
+++ b/platform/flowglad-next/llm-prompts/fan-gameplan.md
@@ -12,20 +12,23 @@ I'm providing a gameplan with patches and a dependency graph (includes a **Proje
    - Extract patch numbers from matched titles to build the completed list
    - Example: If you find merged PRs titled `[subscription-adjustments] Patch 1: Add schema` and `[subscription-adjustments] Patch 2: Add API`, then `Completed: [1, 2]`
 
-3. **Auto-detect base branch** by searching for open PRs:
+3. **Detect open PRs** by searching:
    - Run: `gh pr list --state open --search "[{project-name}]" --json number,title,headRefName`
-   - **0 open PRs**: Use `main` as base branch
-   - **1 open PR**: Use that PR's `headRefName` as base branch (and note its number for PR base)
-   - **2+ open PRs**: Stop and report "Waiting for open PRs to merge: [list PR numbers/titles]" — cannot proceed until only 0 or 1 remain open
+   - Build a map of patch number → open PR info (number, headRefName)
 
 4. Parse the dependency graph and identify all **unblocked** patches:
-   - A patch is unblocked if all its dependencies are in the completed list
+   - A patch is unblocked if all its dependencies are either merged OR have an open PR
    - Exclude patches that already have open PRs (detected in step 3)
    - Exclude patches that are already merged (detected in step 2)
 
-5. For each unblocked patch, create `llm-prompts/patches/{project-name}/patch-{N}.md` using this template:
+5. **Determine base branch per patch**: For each unblocked patch, find the open PRs in its dependency chain:
+   - **0 open PRs in chain**: Base branch is `main`
+   - **1 open PR in chain**: Base branch is that PR's `headRefName`
+   - **2+ open PRs in chain**: This patch is blocked — skip it (report why)
 
-```template
+6. For each unblocked patch that passed step 5, create `llm-prompts/patches/{project-name}/patch-{N}.md` using this template:
+
+```markdown
 # [{project-name}] Patch {N}: {Title}
 
 ## Problem Statement
@@ -48,21 +51,21 @@ I'm providing a gameplan with patches and a dependency graph (includes a **Proje
 {Test stubs for this patch only, verbatim from gameplan}
 
 ## Git Instructions
-- Branch from: `{auto-detected base branch from step 3}`
+- Branch from: `{base branch determined in step 5 for this patch}`
 - Branch name: `{project-name}/patch-{N}-{descriptive-slug}`
-- PR base: `{auto-detected base branch from step 3}`
+- PR base: `{base branch determined in step 5 for this patch}`
 - After completing, run `bun run check` to verify lint/typecheck passes.
 - Create a PR with title: "[{project-name}] Patch {N}: {Title}"
 ```
 
-6. Output a summary: "Created prompts for patches: [X, Y, Z]"
+7. Output a summary: "Created prompts for patches: [X, Y, Z]"
 
 ---
 
 ## Dependency Graph Format
 
 The gameplan's dependency graph should follow this format:
-```
+```text
 - Patch 1 -> []
 - Patch 2 -> [1]
 - Patch 3 -> [1]
@@ -76,39 +79,59 @@ Where `[]` means no dependencies, and `[1, 2]` means depends on patches 1 and 2.
 ## Example
 
 Given gameplan with:
-- Project Name: `subscription-adjustments`
-- Dependency graph: Patch 1 -> [], Patch 2 -> [1], Patch 3 -> [1], Patch 4 -> [2, 3]
+- Project Name: `stripe-tests`
+- Dependency graph:
+  - Patch 1 -> []
+  - Patch 2 -> [1]
+  - Patch 3 -> [1, 2]
+  - Patch 4 -> [1, 3]
+  - Patch 5 -> [1]
+  - Patch 6 -> [5]
+  - Patch 7 -> [1]
+  - Patch 8 -> [5, 7]
 
 **Step 2 (detect completed)**:
+```bash
+gh pr list --state merged --search "[stripe-tests]" --json number,title
 ```
-gh pr list --state merged --search "[subscription-adjustments]" --json number,title
-```
-Result: `[{"number": 1234, "title": "[subscription-adjustments] Patch 1: Add schema"}]`
-→ Completed: [1]
+Result: `[{"number": 100, "title": "[stripe-tests] Patch 1: Setup"}, {"number": 101, "title": "[stripe-tests] Patch 2: Core"}]`
+→ Merged: [1, 2]
 
-**Step 3 (detect base branch)**:
+**Step 3 (detect open PRs)**:
+```bash
+gh pr list --state open --search "[stripe-tests]" --json number,title,headRefName
 ```
-gh pr list --state open --search "[subscription-adjustments]" --json number,title,headRefName
+Result:
+```json
+[
+  {"number": 102, "title": "[stripe-tests] Patch 5: Tax tests", "headRefName": "stripe-tests/patch-5-tax"},
+  {"number": 103, "title": "[stripe-tests] Patch 7: Utils", "headRefName": "stripe-tests/patch-7-utils"}
+]
 ```
-Result: `[{"number": 1236, "title": "[subscription-adjustments] Patch 2: Add validation", "headRefName": "subscription-adjustments/patch-2-validation"}]`
-→ 1 open PR, base branch: `subscription-adjustments/patch-2-validation`
+→ Open PRs: {5: "stripe-tests/patch-5-tax", 7: "stripe-tests/patch-7-utils"}
 
 **Step 4 (find unblocked)**:
 - Patch 1: merged (skip)
-- Patch 2: has open PR (skip)
-- Patch 3: depends on [1], patch 1 is merged ✓, no open PR → **unblocked**
-- Patch 4: depends on [2, 3], patch 2 not merged → blocked
+- Patch 2: merged (skip)
+- Patch 3: depends on [1, 2], both merged ✓, no open PR → **candidate**
+- Patch 4: depends on [1, 3], patch 3 not merged/open → blocked
+- Patch 5: has open PR (skip)
+- Patch 6: depends on [5], patch 5 has open PR ✓ → **candidate**
+- Patch 7: has open PR (skip)
+- Patch 8: depends on [5, 7], both have open PRs → **candidate**
 
-Unblocked patches: [3]
+Candidates: [3, 6, 8]
+
+**Step 5 (determine base branch per patch)**:
+- Patch 3: deps [1, 2] — 0 open PRs in chain → base: `main`
+- Patch 6: deps [5] — 1 open PR (#102) in chain → base: `stripe-tests/patch-5-tax`
+- Patch 8: deps [5, 7] — 2 open PRs (#102, #103) in chain → **blocked** (skip)
+
+Proceeding with: [3, 6]
 
 Create:
-- `llm-prompts/patches/subscription-adjustments/patch-3.md`
-
-It should:
-- Branch from `subscription-adjustments/patch-2-validation`
-- Use branch name like `subscription-adjustments/patch-3-add-api`
-- Create PR with base `subscription-adjustments/patch-2-validation`
-- PR titled `[subscription-adjustments] Patch 3: Add API`
+- `llm-prompts/patches/stripe-tests/patch-3.md` (base: `main`)
+- `llm-prompts/patches/stripe-tests/patch-6.md` (base: `stripe-tests/patch-5-tax`)
 
 ---
 


### PR DESCRIPTION
## What Does this PR Do?

Updates the fan-gameplan prompt to automatically detect which patches have been completed by searching for merged patch PRs, and auto-detects the base branch by checking for open PRs. This eliminates the need for users to manually specify the "Completed" list or provide a PR number.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically detects completed patches and the base branch in fan-gameplan by scanning GitHub PRs. Removes the need to manually provide the "Completed" list or a PR number.

- **New Features**
  - Detects completed patches by parsing merged PR titles: "[{project-name}] Patch N: ...".
  - Determines base branch per patch from its dependency chain: main if no open PR in chain; that PR’s headRefName if one; skips the patch if 2+ open PRs are in chain (enables parallel work).
  - Skips patches that are merged or already have open PRs; generates prompts only for unblocked patches.
  - Updates the patch template to use the auto-detected base branch and outputs a summary of created patches.

<sup>Written for commit 3e61a5bfe9efaec174d36f2117551dd9feb21dc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Completed patches are now automatically detected from merged pull requests
  * Base branch selection is automatically determined from open pull requests
  * Enhanced patch generation workflow with improved branch handling

* **Documentation**
  * Updated examples demonstrating new auto-detection capabilities
  * Expanded workflow documentation with concrete command outputs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->