### PR TITLE
fix: make invoice line items test order-independent

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@flowglad/javascript",

--- a/platform/flowglad-next/src/utils/invoiceHelpers.test.ts
+++ b/platform/flowglad-next/src/utils/invoiceHelpers.test.ts
@@ -462,13 +462,17 @@ describe('updateInvoiceTransaction', () => {
         )
 
         expect(result.invoiceLineItems).toHaveLength(2)
-        expect(result.invoiceLineItems[0].description).toBe(
-          'Modified Item 1'
+        const modifiedItem = result.invoiceLineItems.find(
+          (item) => item.description === 'Modified Item 1'
         )
-        expect(result.invoiceLineItems[0].price).toBe(1500)
-        expect(result.invoiceLineItems[1].description).toBe(
-          'New Item 3'
+        const newItem = result.invoiceLineItems.find(
+          (item) => item.description === 'New Item 3'
         )
+        expect(modifiedItem).toBeDefined()
+        expect(modifiedItem!.price).toBe(1500)
+        expect(modifiedItem!.quantity).toBe(2)
+        expect(newItem).toBeDefined()
+        expect(newItem!.price).toBe(3000)
       })
     })
   })


### PR DESCRIPTION
## What Does this PR Do?

Fixes a flaky test that was failing intermittently in CI when sharded with other tests. The test was asserting on specific array indices without accounting for non-deterministic ordering when items have the same `createdAt` timestamp. Now uses `find()` to locate items by description instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky invoice line items test by making assertions order-independent. Prevents intermittent CI failures when items share the same createdAt timestamp.

- **Bug Fixes**
  - Validate item fields directly: Modified Item 1 has price 1500 and quantity 2; New Item 3 has price 3000.
  - Add configVersion to bun.lock (no functional impact).

<sup>Written for commit 98b61e145f9a2f45c8b5e5fa76065bcbffc06376. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

