### PR TITLE
refactor(prices): PR 3 - use type guards in business logic

### DIFF
--- a/platform/flowglad-next/src/subscriptions/createSubscription/initializers.ts
+++ b/platform/flowglad-next/src/subscriptions/createSubscription/initializers.ts
@@ -1,3 +1,4 @@
+import { Price } from '@/db/schema/prices'
 import type { SubscriptionItem } from '@/db/schema/subscriptionItems'
 import type { Subscription } from '@/db/schema/subscriptions'
 import { isPriceTypeSubscription } from '@/db/tableMethods/priceMethods'
@@ -236,7 +237,10 @@ export const insertSubscriptionAndItems = async (
   } = params
   // Usage prices have productId: null (they belong to usage meters, not products)
   // Only check product association for non-usage prices
-  if (price.productId !== null && price.productId !== product.id) {
+  if (
+    Price.clientHasProductId(price) &&
+    price.productId !== product.id
+  ) {
     throw new Error(
       `insertSubscriptionAndItems: Price ${price.id} is not associated with product ${product.id}`
     )


### PR DESCRIPTION
## Summary

- Replace direct `price.productId !== null` check with `Price.clientHasProductId` type guard in `insertSubscriptionAndItems`
- Standardizes on the type guard pattern as specified in the gameplan for PR 3

This is the final piece of PR 3 from the gameplan. The summary document noted that most type guard implementations were already completed in PR 1 - this PR addresses the one remaining location in `initializers.ts` that was using a direct null check instead of the type guard.

## Changes

- `src/subscriptions/createSubscription/initializers.ts`: Use `Price.clientHasProductId(price)` instead of `price.productId !== null`

## Why the type guard is preferred

Per the gameplan:
1. **Self-documenting**: Makes intent clear that we're checking for product-type prices
2. **Type-safe**: TypeScript narrows `productId` to `string` after the guard passes
3. **Centralized logic**: The determination of which prices have products is in one place

## Test plan

- [x] `bun run check` passes (lint, typecheck, registry validation)
- [ ] Existing tests pass (subscription creation behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardize subscription creation logic to use the Price.clientHasProductId type guard instead of a direct null check. Improves clarity and TypeScript narrowing with no behavior change.

- **Refactors**
  - platform/flowglad-next/src/subscriptions/createSubscription/initializers.ts: use Price.clientHasProductId(price) when validating product association in insertSubscriptionAndItems.

<sup>Written for commit fe451b1ebf2b0d4ab5b22772b7fc89e6492406b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

