### PR TITLE
fix: always show tax line for MOR checkouts with dash for zero tax

### DIFF
--- a/platform/flowglad-next/src/components/checkout/total-billing-details.tsx
+++ b/platform/flowglad-next/src/components/checkout/total-billing-details.tsx
@@ -19,6 +19,7 @@ import {
   type CurrencyCode,
   type Nullish,
   PriceType,
+  StripeConnectContractType,
 } from '@/types'
 import {
   calculateDiscountAmount,
@@ -38,6 +39,7 @@ const BillingLine = ({
   isLoading = false,
   className,
   testId,
+  showDashWhenZero = false,
 }: {
   label: string
   amount: number
@@ -45,7 +47,16 @@ const BillingLine = ({
   isLoading?: boolean
   className?: string
   testId?: string
+  showDashWhenZero?: boolean
 }) => {
+  const displayValue =
+    showDashWhenZero && amount === 0
+      ? '-'
+      : stripeCurrencyAmountToHumanReadableCurrencyAmount(
+          currency,
+          amount
+        )
+
   return (
     <div
       className={cn('flex justify-between items-center', className)}
@@ -58,10 +69,7 @@ const BillingLine = ({
           className="text-sm font-medium text-gray-900"
           data-testid={testId}
         >
-          {stripeCurrencyAmountToHumanReadableCurrencyAmount(
-            currency,
-            amount
-          )}
+          {displayValue}
         </span>
       )}
     </div>
@@ -161,7 +169,12 @@ export const TotalBillingDetails = React.forwardRef<
     subscriptionDetails,
     feeCalculation,
     flowType,
+    sellerOrganization,
   } = checkoutPageContext
+
+  const isMerchantOfRecord =
+    sellerOrganization?.stripeConnectContractType ===
+    StripeConnectContractType.MerchantOfRecord
 
   // Don't render for add payment method flow
   if (flowType === CheckoutFlowType.AddPaymentMethod) {
@@ -255,12 +268,13 @@ export const TotalBillingDetails = React.forwardRef<
           />
         )}
 
-      {taxAmount != null && taxAmount > 0 && (
+      {(taxAmount != null || isMerchantOfRecord) && (
         <BillingLine
           label="Tax"
-          amount={taxAmount}
+          amount={taxAmount ?? 0}
           currency={currency}
           isLoading={editCheckoutSessionLoading}
+          showDashWhenZero
         />
       )}
 


### PR DESCRIPTION
## What Does this PR Do?

This PR fixes an issue where the tax line would disappear when switching between countries with different tax amounts in MOR (Merchant of Record) checkouts. Now, the tax line always displays for MOR organizations, showing a dash (-) when the tax amount is zero.

The fix adds a `showDashWhenZero` prop to the `BillingLine` component and checks if the seller organization is MOR to determine whether to always show the tax line, improving transparency about tax calculation during the checkout flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show the tax line in MOR checkouts and display a dash (-) when tax is zero. Fixes the tax row disappearing when switching countries and makes tax calculation status clear.

- **Bug Fixes**
  - Always render “Tax” for Merchant of Record organizations (StripeConnectContractType.MerchantOfRecord).
  - Added showDashWhenZero to BillingLine to display “-” when amount is 0; pass 0 when tax is null for MOR.
  - Keep existing behavior for non-MOR: show tax line only when taxAmount > 0.

<sup>Written for commit 0fc94846ebaaad249c03404382d25f51fb76433c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated billing details display to show dashes for zero amounts, providing clearer visual representation in checkout totals.
  * Enhanced tax line rendering logic for improved accuracy in billing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->