### PR TITLE
fix: redirect to sign-in page immediately after logout

### DIFF
--- a/platform/flowglad-next/src/components/navigation/SideNavigation.tsx
+++ b/platform/flowglad-next/src/components/navigation/SideNavigation.tsx
@@ -430,7 +430,15 @@ export const SideNavigation = () => {
                 id: organization.id,
                 name: organization.name,
               }}
-              onSignOut={() => signOut()}
+              onSignOut={() =>
+                signOut({
+                  fetchOptions: {
+                    onSuccess: () => {
+                      router.push('/sign-in')
+                    },
+                  },
+                })
+              }
             />
           )}
         </div>


### PR DESCRIPTION
## What Does this PR Do?

Fixes logout redirect behavior so users are immediately redirected to the sign-in page when they click logout, instead of remaining on the current page until manually refreshing. The signOut() function now includes a fetchOptions callback that redirects to /sign-in upon successful completion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect users to the sign-in page immediately after logout so they don’t stay on the current page.
Updated SideNavigation to call signOut with fetchOptions.onSuccess that pushes to /sign-in.

<sup>Written for commit b233bfedb12970653fa4586a5bda056d7070e900. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the sign-out experience with automatic redirection to the sign-in page after successful sign-out, ensuring a smoother session management flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->