### PR TITLE
proposed price tests to 1279

### DIFF
--- a/platform/flowglad-next/src/db/tableMethods/priceMethods.test.ts
+++ b/platform/flowglad-next/src/db/tableMethods/priceMethods.test.ts
@@ -1916,13 +1916,11 @@ describe('priceMethods.ts', () => {
           (p) => p.type === PriceType.Usage
         )
 
-        expect(subscriptionPrice).toBeTruthy()
         expect(subscriptionPrice!.productId).toBe(product.id)
         expect(subscriptionPrice!.pricingModelId).toBe(
           product.pricingModelId
         )
 
-        expect(usagePrice).toBeTruthy()
         expect(usagePrice!.productId).toBeNull()
         expect(usagePrice!.usageMeterId).toBe(usageMeter.id)
         expect(usagePrice!.pricingModelId).toBe(


### PR DESCRIPTION
## What Does this PR Do?

### `insertPrice` tests (2 new tests added):
1. **`should derive pricingModelId from usage meter for usage prices`** - Verifies that when inserting a usage price, the `pricingModelId` is correctly derived from the usage meter
2. **`should set productId to null for usage prices`** - Verifies that usage prices have `productId: null` and correctly store the `usageMeterId`

### `bulkInsertPrices` tests (1 new test added):
1. **`should handle mixed usage and subscription prices`** - Verifies that bulk inserting a combination of subscription prices (with `productId`) and usage prices (with `productId: null`) works correctly, with each price type deriving its `pricingModelId` from the appropriate source

### `selectPricesAndProductsForOrganization` tests (3 new tests added):
1. **`should return null product for usage prices`** - Verifies that when querying usage prices, the `product` field is `null`
2. **`should return product for subscription prices`** - Verifies that when querying subscription prices, the `product` field contains the associated product record
3. **`should return both usage and subscription prices for an organization`** - Verifies that the query correctly returns both price types with appropriate `product` values (null for usage, populated for subscription)

All new tests pass. Note that there's one pre-existing failing test (`does not throw an error when adding and updating a price to be default when another default price exists`) that was already in the codebase - this is unrelated to the PR 2 changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added tests to validate usage vs subscription price behavior and org-level price/product queries, aligning with Linear 1279 requirements. Covers pricingModelId derivation from usage meters, productId null for usage, mixed-type bulk inserts, and correct product results in selectPricesAndProductsForOrganization (null for usage, present for subscription).

<sup>Written for commit b72f0a09ccf8ef34f5c5c63fa531e573357cc680. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

