### PR TITLE
docs: add database migrations guidance to CLAUDE.md

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -30,7 +30,8 @@ You run in an environment where `ast-grep` is available; whenever a search requi
 When making database schema changes:
 1. Modify the schema definition files (e.g., files in `platform/flowglad-next/src/db/schema/`)
 2. Run `bun run migrations:generate` from `platform/flowglad-next` to auto-generate the migration SQL
-3. Run `bun run migrations:push` to apply the migrations
+
+**NEVER run `bun run migrations:push`** - applying migrations to the database should only be done by the user, not by agents.
 
 Drizzle Kit analyzes your schema changes and generates the appropriate migration files automatically. Manually created migration files will likely have incorrect formatting, missing metadata, or cause conflicts with the migration system.
 


### PR DESCRIPTION
## What Does this PR Do?

Documents the proper Drizzle ORM migration workflow in CLAUDE.md to prevent agents from manually creating migration files. The project uses `drizzle-kit generate` to auto-generate migrations from schema changes rather than writing them imperatively. This change clarifies that agents should modify schema definitions and run the `migrations:generate` command, which Drizzle Kit will analyze and generate the appropriate migration files automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added database migration guidance to CLAUDE.md so contributors use Drizzle ORM’s auto-generated migrations instead of writing files by hand, and do not apply migrations.

Update schema files, then run: bun run migrations:generate to create SQL. Do not run bun run migrations:push; applying migrations is done by the user.

<sup>Written for commit ecab8f2cb07b551aa476e905f9e2bade16c3d713. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Database Migrations guidance documenting Drizzle ORM migration workflow, including schema changes, generating migrations, and applying them
  * Added explicit warning against creating migrations manually due to compatibility risks
  * Expanded Testing Guidelines with stricter conventions (no mocking of non-networked functions, no .spyOn, no dynamic imports, no stubbed tests, avoid type "any", and explicit per-scenario coverage)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->