### PR TITLE
Improve fan-gameplan prompt to emphasize PR title format

### DIFF
--- a/platform/flowglad-next/llm-prompts/fan-gameplan.md
+++ b/platform/flowglad-next/llm-prompts/fan-gameplan.md
@@ -55,7 +55,15 @@ I'm providing a gameplan with patches and a dependency graph (includes a **Proje
 - Branch name: `{project-name}/patch-{N}-{descriptive-slug}`
 - PR base: `{base branch determined in step 5 for this patch}`
 - After completing, run `bun run check` to verify lint/typecheck passes.
-- Create a PR with title: "[{project-name}] Patch {N}: {Title}"
+
+## PR Title (CRITICAL)
+**You MUST use this EXACT title format when creating the PR:**
+
+`[{project-name}] Patch {N}: {Title}`
+
+For example: `[redis-cache-helpers] Patch 1: Cache Infrastructure`
+
+Do NOT use conventional commit format (e.g., `feat:`, `fix:`). The bracketed project name and patch number are required for tracking.
 ```
 
 7. Output a summary: "Created prompts for patches: [X, Y, Z]"


### PR DESCRIPTION
## What Does this PR Do?

This PR improves the fan-gameplan prompt to make the required PR title format more prominent and harder to miss. A dedicated "PR Title (CRITICAL)" section now emphasizes the exact format (`[{project-name}] Patch {N}: {Title}`) with explicit warnings against conventional commit format.

This addresses the issue where agents were creating PRs with incorrect titles (e.g., using `feat:` instead of the required bracketed format).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CRITICAL “PR Title” section to the fan-gameplan prompt so the required format is clear and hard to miss. It shows the exact format ([{project-name}] Patch {N}: {Title}) with an example and warns against using conventional commit prefixes (e.g., feat:, fix:).

<sup>Written for commit 2e04d1e41e62bf89c2f15bb451b7898364d184d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

