### PR TITLE
Add adjust-gameplan prompt for updating gameplans

### DIFF
--- a/platform/flowglad-next/llm-prompts/adjust-gameplan.md
+++ b/platform/flowglad-next/llm-prompts/adjust-gameplan.md
@@ -103,7 +103,7 @@ The gameplan has been updated and the following changes affect your patch.
 ### Step 7: Output Summary
 
 Report:
-```
+```text
 Gameplan Updated: {project-name}
 
 Changes Made:
@@ -143,7 +143,7 @@ Files Created:
 - Patch 6: Queued (depends on 5) → will pick up changes via fan-gameplan
 
 **Output**:
-```
+```text
 Gameplan Updated: subscription-adjustments
 
 Changes Made:


### PR DESCRIPTION
## What Does this PR Do?

Adds a new `adjust-gameplan.md` prompt that helps coordinate updates to existing gameplans and propagate changes to active patches. It fetches gameplans from Notion, presents the current state for editing, updates Notion with changes, detects which patches need adjustment, and generates targeted adjustment prompts for in-progress work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new adjust-gameplan prompt that updates an existing gameplan in Notion and propagates changes to active patches by generating targeted adjustment prompts. This reduces manual coordination when plans change mid-flight.

- **New Features**
  - Accept Notion URL or slug and change description, then fetch current content.
  - Apply requested changes and write updates back to Notion.
  - Detect merged and open PRs per project via gh pr list.
  - Classify patches as merged, active, queued, or blocked.
  - Generate patch-specific adjustment prompts for affected active PRs at llm-prompts/patches/{project-name}/patch-{N}-adjustment.md.
  - Output a summary of changes, patch status, and created files.

<sup>Written for commit 9438d82a875283a8235927cc44c17becdf98a488. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for adjusting gameplans, including workflow procedures for locating, updating, and propagating changes across patches with status detection and summary reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->