### PR TITLE
Hide variant names in behavior test invariants

### DIFF
--- a/platform/flowglad-next/src/test/behaviorTest/behaviorTests/checkout.behavior.test.ts
+++ b/platform/flowglad-next/src/test/behaviorTest/behaviorTests/checkout.behavior.test.ts
@@ -102,11 +102,9 @@ behaviorTest({
     { behavior: applyDiscountBehavior },
     {
       behavior: provideBillingAddressBehavior,
-      invariants: async (result, combination) => {
-        const customerResidencyDep = CustomerResidencyDep.get(
-          combination.CustomerResidencyDep
-        )
-        const discountDep = DiscountDep.get(combination.DiscountDep)
+      invariants: async (result, getDep) => {
+        const customerResidencyDep = getDep(CustomerResidencyDep)
+        const discountDep = getDep(DiscountDep)
 
         // Billing address saved on checkout session
         expect(result.updatedCheckoutSession.billingAddress).toEqual(
@@ -162,8 +160,8 @@ behaviorTest({
     { behavior: authenticateUserBehavior },
     {
       behavior: createOrganizationBehavior,
-      invariants: async (result, combination) => {
-        const countryDep = CountryDep.get(combination.CountryDep)
+      invariants: async (result, getDep) => {
+        const countryDep = getDep(CountryDep)
 
         // Platform organizations use their country's currency
         expect(result.organization.defaultCurrency).toBe(
@@ -177,8 +175,8 @@ behaviorTest({
     { behavior: completeStripeOnboardingBehavior },
     {
       behavior: createProductWithPriceBehavior,
-      invariants: async (result, combination) => {
-        const countryDep = CountryDep.get(combination.CountryDep)
+      invariants: async (result, getDep) => {
+        const countryDep = getDep(CountryDep)
 
         // Platform prices use the organization's currency
         expect(result.price.currency).toBe(
@@ -191,10 +189,8 @@ behaviorTest({
     { behavior: applyDiscountBehavior },
     {
       behavior: provideBillingAddressBehavior,
-      invariants: async (result, combination) => {
-        const customerResidencyDep = CustomerResidencyDep.get(
-          combination.CustomerResidencyDep
-        )
+      invariants: async (result, getDep) => {
+        const customerResidencyDep = getDep(CustomerResidencyDep)
 
         // Billing address saved on checkout session
         expect(result.updatedCheckoutSession.billingAddress).toEqual(
@@ -251,10 +247,8 @@ behaviorTest({
     { behavior: applyDiscountBehavior },
     {
       behavior: provideBillingAddressBehavior,
-      invariants: async (result, combination) => {
-        const customerResidencyDep = CustomerResidencyDep.get(
-          combination.CustomerResidencyDep
-        )
+      invariants: async (result, getDep) => {
+        const customerResidencyDep = getDep(CustomerResidencyDep)
 
         // Fee calculation exists for MoR
         expect(result.feeCalculation).not.toBeNull()
@@ -312,10 +306,8 @@ behaviorTest({
     { behavior: applyDiscountBehavior },
     {
       behavior: provideBillingAddressBehavior,
-      invariants: async (result, combination) => {
-        const customerResidencyDep = CustomerResidencyDep.get(
-          combination.CustomerResidencyDep
-        )
+      invariants: async (result, getDep) => {
+        const customerResidencyDep = getDep(CustomerResidencyDep)
 
         // Fee calculation exists for MoR
         expect(result.feeCalculation).not.toBeNull()

--- a/platform/flowglad-next/src/test/behaviorTest/behaviorTests/userSignUp.behavior.test.ts
+++ b/platform/flowglad-next/src/test/behaviorTest/behaviorTests/userSignUp.behavior.test.ts
@@ -236,11 +236,11 @@ behaviorTest({
       behavior: createOrganizationBehavior,
       invariants: async (
         result: CreateOrganizationResult,
-        combination
+        getDep
       ) => {
         await commonOrgInvariants(result)
 
-        const countryDep = CountryDep.get(combination.CountryDep)
+        const countryDep = getDep(CountryDep)
 
         // Platform organizations use their country's currency
         expect(result.organization.defaultCurrency).toBe(

--- a/platform/flowglad-next/src/test/behaviorTest/index.ts
+++ b/platform/flowglad-next/src/test/behaviorTest/index.ts
@@ -90,6 +90,7 @@ export type {
   DependencyCombination,
   DependencyFactory,
   DescribeFunction,
+  GetDepFn,
   ResolvedDependencies,
   TeardownFn,
 } from './types'


### PR DESCRIPTION
## Summary

Replace the `combination` parameter in behavior test invariants with a `getDep` function that retrieves dependency instances without exposing variant identifiers. This prevents conditional assertions like `if (combination.CountryDep === 'us')` and enforces the principle that all invariants must hold for every permutation of the dependencies specified.

## Changes

- Added `GetDepFn` type for retrieving dependency instances by class
- Updated `ChainStep.invariants` to receive `getDep` instead of `combination`
- Created `getDep` function in behavior test runner that handles dependency resolution
- Updated all existing test invariants to use `getDep(DepClass)` instead of `DepClass.get(combination.DepClass)`

## Motivation

The combination object exposed variant names, creating an anti-pattern where tests would dispatch based on which variant was selected. This defeats the purpose of universal invariants in behavior tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the combination parameter in behavior test invariants with a getDep function that returns dependency instances without exposing variant names. This prevents conditional assertions by variant and enforces invariants that hold across all dependency permutations.

- **Refactors**
  - Added GetDepFn type to fetch dependency instances by class.
  - Changed ChainStep.invariants signature to (result, getDep).
  - Implemented getDep in the test runner to resolve instances safely.
  - Updated behavior tests to use getDep(DepClass) instead of DepClass.get(combination.DepClass).

- **Migration**
  - Update invariants from (result, combination) to (result, getDep).
  - Replace DepClass.get(combination.DepClass) with getDep(DepClass) in assertions.

<sup>Written for commit adeff5661692ce0965f1d4d6650e606a9f01cbfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

