### PR TITLE
fix: prevent $0 payment records for fully paid invoices

### DIFF
--- a/platform/flowglad-next/src/subscriptions/billingRunHelpers.test.ts
+++ b/platform/flowglad-next/src/subscriptions/billingRunHelpers.test.ts
@@ -2160,6 +2160,82 @@ describe('billingRunHelpers', async () => {
       )
     })
 
+    it('succeeds without Stripe IDs when amountToCharge is 0 (prior payments fully cover amount)', async () => {
+      // Setup: Create a billing period item with a known price
+      const knownPrice = 10000 // $100 in cents
+      await adminTransaction(async ({ transaction }) => {
+        await updateBillingPeriodItem(
+          {
+            id: staticBillingPeriodItem.id,
+            unitPrice: knownPrice,
+            type: SubscriptionItemType.Static,
+          },
+          transaction
+        )
+      })
+
+      // Create an invoice for this billing period
+      const testInvoice = await setupInvoice({
+        billingPeriodId: billingPeriod.id,
+        customerId: customer.id,
+        organizationId: organization.id,
+        priceId: staticPrice.id,
+      })
+
+      // Create an existing payment that FULLY covers the totalDueAmount
+      await setupPayment({
+        stripeChargeId: 'ch_fullcover_nostripe_' + core.nanoid(),
+        status: PaymentStatus.Succeeded,
+        amount: knownPrice, // Full amount - should result in amountToCharge = 0
+        livemode: billingPeriod.livemode,
+        customerId: customer.id,
+        organizationId: organization.id,
+        stripePaymentIntentId:
+          'pi_fullcover_nostripe_' + core.nanoid(),
+        invoiceId: testInvoice.id,
+        paymentMethod: paymentMethod.type,
+        billingPeriodId: billingPeriod.id,
+        subscriptionId: billingPeriod.subscriptionId,
+        paymentMethodId: paymentMethod.id,
+      })
+
+      // Remove Stripe IDs - this should NOT cause failure when amountToCharge is 0
+      // This is the key difference from the previous test: we're verifying that
+      // the amountToCharge <= 0 guard comes BEFORE Stripe ID validation
+      await adminTransaction(async ({ transaction }) => {
+        await updatePaymentMethod(
+          {
+            id: paymentMethod.id,
+            stripePaymentMethodId: null,
+          },
+          transaction
+        )
+      })
+
+      // Execute the billing run - should succeed, not throw
+      const result = await adminTransaction(({ transaction }) =>
+        executeBillingRunCalculationAndBookkeepingSteps(
+          billingRun,
+          transaction
+        )
+      )
+
+      // Verify the scenario worked correctly
+      expect(result.totalDueAmount).toBeGreaterThan(0)
+      expect(result.amountToCharge).toBe(0)
+      expect(result.payment).toBeUndefined()
+      expect(result.invoice.status).toBe(InvoiceStatus.Paid)
+
+      // Verify the billing run is marked as succeeded
+      const updatedBillingRun = await adminTransaction(
+        ({ transaction }) =>
+          selectBillingRunById(billingRun.id, transaction)
+      )
+      expect(updatedBillingRun.status).toBe(
+        BillingRunStatus.Succeeded
+      )
+    })
+
     it('should throw an error if customer has no stripe customer ID', async () => {
       // Update customer to remove stripe customer ID
       await adminTransaction(async ({ transaction }) => {

--- a/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
+++ b/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
@@ -615,25 +615,12 @@ export const executeBillingRunCalculationAndBookkeepingSteps = async (
     }
   }
 
-  const stripeCustomerId = customer.stripeCustomerId
-  const stripePaymentMethodId = paymentMethod.stripePaymentMethodId
-  if (!stripeCustomerId) {
-    throw new Error(
-      `Cannot run billing for a billing period with a customer that does not have a stripe customer id.` +
-        ` Customer: ${customer.id}; Billing Period: ${billingPeriod.id}`
-    )
-  }
-  if (!stripePaymentMethodId) {
-    throw new Error(
-      `Cannot run billing for a billing period with a payment method that does not have a stripe payment method id.` +
-        `Payment Method: ${paymentMethod.id}; Billing Period: ${billingPeriod.id}`
-    )
-  }
-
   /**
    * Guard: Only create a payment record if there's actually an amount to charge.
    * This prevents orphaned $0 payment records when the invoice is already fully
    * paid via credits or prior payments (amountToCharge = 0).
+   * This check must come BEFORE Stripe ID validation since we don't need
+   * Stripe IDs when there's nothing to charge.
    * See: https://github.com/flowglad/flowglad/issues/1317
    */
   if (amountToCharge <= 0) {
@@ -659,6 +646,21 @@ export const executeBillingRunCalculationAndBookkeepingSteps = async (
       amountToCharge,
       payments,
     }
+  }
+
+  const stripeCustomerId = customer.stripeCustomerId
+  const stripePaymentMethodId = paymentMethod.stripePaymentMethodId
+  if (!stripeCustomerId) {
+    throw new Error(
+      `Cannot run billing for a billing period with a customer that does not have a stripe customer id.` +
+        ` Customer: ${customer.id}; Billing Period: ${billingPeriod.id}`
+    )
+  }
+  if (!stripePaymentMethodId) {
+    throw new Error(
+      `Cannot run billing for a billing period with a payment method that does not have a stripe payment method id.` +
+        `Payment Method: ${paymentMethod.id}; Billing Period: ${billingPeriod.id}`
+    )
   }
 
   const paymentInsert: Payment.Insert = {


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

fixes: #1317 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents $0 payment records for fully paid invoices and fixes a hydration mismatch in the organization form by using stable form item IDs.

- **Bug Fixes**
  - Billing: Skip payment when amountToCharge <= 0 and process the period via processNoMoreDueForBillingPeriod. Move this guard before Stripe ID validation so $0 cases succeed without Stripe IDs.
  - Forms: Add an optional formItemId to FormItem and set it on organization fields (name, country, payment processing, codebase overview, referral) to keep IDs stable across SSR/CSR.

<sup>Written for commit afd531f34429936ebe936c4f06af6d2aaee0fa52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented creation of payment records when amount to charge is zero; invoices and billing runs now transition to paid/succeeded states without initiating a payment flow.

* **Tests**
  * Added tests confirming that when existing payments fully cover dues, no new payment is created and billing/invoice states update as expected, including variants with and without payment provider IDs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->