### PR TITLE
New feature testing pt2

### DIFF
--- a/platform/flowglad-next/src/server/mutations/resetPassword.test.ts
+++ b/platform/flowglad-next/src/server/mutations/resetPassword.test.ts
@@ -1,0 +1,148 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import { sql } from 'drizzle-orm'
+import { adminTransaction } from '@/db/adminTransaction'
+import { user } from '@/db/schema/betterAuthSchema'
+import { router } from '@/server/trpc'
+import { resetPassword } from './resetPassword'
+import { auth } from '@/utils/auth'
+import core from '@/utils/core'
+
+// Mock auth.api.forgetPassword
+vi.mock('@/utils/auth', () => ({
+  auth: {
+    api: {
+      forgetPassword: vi.fn(),
+    },
+  },
+}))
+
+// Create a test router with the resetPassword procedure
+const testRouter = router({
+  resetPassword,
+})
+
+describe('resetPassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(async () => {
+    // Clean up test users
+    await adminTransaction(async ({ transaction }) => {
+      await transaction.delete(user).where(sql`email LIKE 'test-reset-%'`)
+    })
+  })
+
+  it('should send password reset email when user exists', async () => {
+    const testEmail = `test-reset-${core.nanoid()}@test.com`
+    const userId = `bau_${core.nanoid()}`
+
+    // Create a test user
+    await adminTransaction(async ({ transaction }) => {
+      await transaction.insert(user).values({
+        id: userId,
+        email: testEmail,
+        name: 'Test User',
+        role: 'user',
+        emailVerified: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+    })
+
+    // Mock forgetPassword to succeed
+    vi.mocked(auth.api.forgetPassword).mockResolvedValue({
+      success: true,
+    } as any)
+
+    const ctx = {} as any
+    const caller = testRouter.createCaller(ctx)
+    const result = await caller.resetPassword({ email: testEmail })
+
+    expect(auth.api.forgetPassword).toHaveBeenCalledWith({
+      body: {
+        email: testEmail,
+        redirectTo: '/sign-in/reset-password',
+      },
+    })
+    expect(result).toEqual({
+      success: true,
+      message:
+        'If an account exists with this email, a password reset link has been sent',
+    })
+  })
+
+  it('should return success message even when user does not exist', async () => {
+    const nonExistentEmail = `test-reset-nonexistent-${core.nanoid()}@test.com`
+
+    const ctx = {} as any
+    const caller = testRouter.createCaller(ctx)
+    const result = await caller.resetPassword({ email: nonExistentEmail })
+
+    expect(auth.api.forgetPassword).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      success: true,
+      message:
+        'If an account exists with this email, a password reset link has been sent',
+    })
+  })
+
+  it('should return success message even when forgetPassword fails', async () => {
+    const testEmail = `test-reset-${core.nanoid()}@test.com`
+    const userId = `bau_${core.nanoid()}`
+
+    // Create a test user
+    await adminTransaction(async ({ transaction }) => {
+      await transaction.insert(user).values({
+        id: userId,
+        email: testEmail,
+        name: 'Test User',
+        role: 'user',
+        emailVerified: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+    })
+
+    // Mock forgetPassword to fail
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    vi.mocked(auth.api.forgetPassword).mockRejectedValue(
+      new Error('Failed to send email')
+    )
+
+    const ctx = {} as any
+    const caller = testRouter.createCaller(ctx)
+    const result = await caller.resetPassword({ email: testEmail })
+
+    expect(auth.api.forgetPassword).toHaveBeenCalled()
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to send password reset email:',
+      expect.any(Error)
+    )
+    expect(result).toEqual({
+      success: true,
+      message:
+        'If an account exists with this email, a password reset link has been sent',
+    })
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('should validate email format', async () => {
+    const ctx = {} as any
+    const caller = testRouter.createCaller(ctx)
+
+    await expect(
+      caller.resetPassword({ email: 'invalid-email' })
+    ).rejects.toThrow()
+  })
+})

--- a/platform/flowglad-next/src/server/mutations/resetPassword.ts
+++ b/platform/flowglad-next/src/server/mutations/resetPassword.ts
@@ -9,11 +9,16 @@ export const resetPassword = publicProcedure
   .mutation(async ({ input }) => {
     const { email } = input
 
-    const userExists = await adminTransaction(
-      async ({ transaction }) => {
-        return selectBetterAuthUserByEmail(email, transaction)
-      }
-    )
+    let userExists = false
+    try {
+      await adminTransaction(async ({ transaction }) => {
+        await selectBetterAuthUserByEmail(email, transaction)
+        userExists = true
+      })
+    } catch {
+      // User doesn't exist - swallow error to prevent user enumeration
+      userExists = false
+    }
 
     if (userExists) {
       try {


### PR DESCRIPTION
## What Does this PR Do?
Fixes a security bug in the `resetPassword` mutation that allowed user enumeration by throwing an error when an email did not exist. It now gracefully handles non-existent users by returning a generic success message.

This PR also adds comprehensive tests for the `resetPassword` mutation, covering:
*   Sending reset emails for existing users.
*   Preventing user enumeration for non-existent users.
*   Handling failures from the external password reset API.
*   Email format validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-e191413b-a50c-4c6a-8a35-e89816d71996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e191413b-a50c-4c6a-8a35-e89816d71996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stopped user enumeration in resetPassword by returning a generic success message for any email and handling failures without leaking account existence. Added tests for existing and non-existent users, external API failures, and email validation.

- **Bug Fixes**
  - Wrapped user lookup in a transaction with try/catch; swallow errors when the email doesn’t exist.
  - Call auth.api.forgetPassword only when a user exists; on failure, log the error and still return success.

<sup>Written for commit 5f4e60d41f31d6ec34f69891622c7dc95e1b36c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

