### PR TITLE
Hook data, public route infra

### DIFF
--- a/packages/nextjs/src/nextRouteHandler.ts
+++ b/packages/nextjs/src/nextRouteHandler.ts
@@ -1,4 +1,8 @@
-import { type FlowgladServer, requestHandler } from '@flowglad/server'
+import {
+  type FlowgladServer,
+  type FlowgladServerAdmin,
+  requestHandler,
+} from '@flowglad/server'
 import type { HTTPMethod } from '@flowglad/shared'
 import { type NextRequest, NextResponse } from 'next/server'
 
@@ -23,6 +27,13 @@ export interface NextRouteHandlerOptions {
   flowglad: (
     customerExternalId: string
   ) => Promise<FlowgladServer> | FlowgladServer
+  /**
+   * Optional function that creates a FlowgladServerAdmin instance for public routes.
+   * Required for public routes like pricing-models/default that don't need authentication.
+   *
+   * @returns A FlowgladServerAdmin instance
+   */
+  flowgladAdmin?: () => FlowgladServerAdmin
   /**
    * Function to run when an error occurs.
    */
@@ -102,6 +113,7 @@ export const nextRouteHandler = (
   const {
     getCustomerExternalId,
     flowglad,
+    flowgladAdmin,
     onError,
     beforeRequest,
     afterRequest,
@@ -118,6 +130,7 @@ export const nextRouteHandler = (
       const handler = requestHandler({
         getCustomerExternalId,
         flowglad,
+        flowgladAdmin,
         onError,
         beforeRequest,
         afterRequest,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,3 +8,4 @@ export type {
 export { useBilling } from './FlowgladContext'
 export { FlowgladProvider } from './FlowgladProvider'
 export { humanReadableCurrencyAmount } from './lib/utils'
+export type { FlowgladError, FlowgladHookData } from './types'

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,20 +1,28 @@
-import type Flowglad from '@flowglad/node'
+/**
+ * Standardized error type for Flowglad hooks.
+ */
+export interface FlowgladError {
+  message: string
+  status?: number
+  code?: string
+}
 
-import type { Subscription } from '@flowglad/shared'
-
-export type SubscriptionCardSubscription = Pick<
-  Subscription,
-  | 'id'
-  | 'trialEnd'
-  | 'status'
-  | 'cancelScheduledAt'
-  | 'currentBillingPeriodEnd'
-  | 'interval'
-  | 'intervalCount'
-  | 'canceledAt'
->
-
-export type SubscriptionCardSubscriptionItem = Pick<
-  Flowglad.StandardSubscriptionDetails.SubscriptionItem,
-  'id' | 'unitPrice' | 'quantity' | 'price'
->
+/**
+ * Standardized return type for Flowglad hooks.
+ * Inspired by Better Auth's useSession() return signature.
+ *
+ * @typeParam TData - The type of data returned by the hook
+ * @typeParam TRefetchParams - Optional parameters for the refetch function
+ */
+export interface FlowgladHookData<TData, TRefetchParams = void> {
+  /** The fetched data or null if not yet loaded or on error */
+  data: TData | null
+  /** True during initial load when no data is available yet */
+  isPending: boolean
+  /** True when refetching with stale data available */
+  isRefetching: boolean
+  /** Standardized error object or null if no error */
+  error: FlowgladError | null
+  /** Function to manually trigger a refetch */
+  refetch: (params?: TRefetchParams) => void
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,5 +7,8 @@ export {
   type RequestHandlerOutput,
   requestHandler,
 } from './requestHandler'
-export { routeToHandlerMap } from './subrouteHandlers'
+export {
+  publicRouteToHandlerMap,
+  routeToHandlerMap,
+} from './subrouteHandlers'
 export { verifyWebhook, WebhookVerificationError } from './webhook'

--- a/packages/server/src/requestHandler.test.ts
+++ b/packages/server/src/requestHandler.test.ts
@@ -1,0 +1,185 @@
+import { FlowgladActionKey, HTTPMethod } from '@flowglad/shared'
+import { describe, expect, it, vi } from 'vitest'
+import type { FlowgladServer } from './FlowgladServer'
+import type { FlowgladServerAdmin } from './FlowgladServerAdmin'
+import { requestHandler } from './requestHandler'
+
+describe('requestHandler public route handling', () => {
+  const mockFlowgladServer = {
+    getBilling: vi.fn().mockResolvedValue({}),
+  } as unknown as FlowgladServer
+
+  it('returns status 501 with error message when pricing endpoint called without flowgladAdmin configured', async () => {
+    const handler = requestHandler({
+      getCustomerExternalId: async () => 'user_1',
+      flowglad: () => mockFlowgladServer,
+    })
+
+    const response = await handler(
+      {
+        path: ['pricing-models', 'default'],
+        method: HTTPMethod.GET,
+      },
+      {}
+    )
+
+    expect(response.status).toBe(501)
+    expect((response.error as any).message).toBe(
+      'Public routes require flowgladAdmin option'
+    )
+  })
+
+  it('does not call getCustomerExternalId when flowgladAdmin provided and public route requested', async () => {
+    const getCustomerExternalId = vi.fn()
+    const mockAdmin = {
+      getDefaultPricingModel: async () => ({
+        pricingModel: { id: 'pm_1', name: 'Test Plan', prices: [] },
+      }),
+    } as unknown as FlowgladServerAdmin
+
+    const handler = requestHandler({
+      getCustomerExternalId,
+      flowglad: () => mockFlowgladServer,
+      flowgladAdmin: () => mockAdmin,
+    })
+
+    await handler(
+      {
+        path: ['pricing-models', 'default'],
+        method: HTTPMethod.GET,
+      },
+      {}
+    )
+
+    expect(getCustomerExternalId).not.toHaveBeenCalled()
+  })
+
+  it('returns pricing model data when flowgladAdmin is configured and public route is requested', async () => {
+    const mockAdmin = {
+      getDefaultPricingModel: async () => ({
+        pricingModel: {
+          id: 'pm_123',
+          name: 'Pro Plan',
+          prices: [{ id: 'price_1', unitAmount: 1000 }],
+        },
+      }),
+    } as unknown as FlowgladServerAdmin
+
+    const handler = requestHandler({
+      getCustomerExternalId: async () => 'user_1',
+      flowglad: () => mockFlowgladServer,
+      flowgladAdmin: () => mockAdmin,
+    })
+
+    const response = await handler(
+      {
+        path: ['pricing-models', 'default'],
+        method: HTTPMethod.GET,
+      },
+      {}
+    )
+
+    expect(response.status).toBe(200)
+    expect((response.data as any).pricingModel.id).toBe('pm_123')
+    expect((response.data as any).pricingModel.name).toBe('Pro Plan')
+  })
+
+  it('calls getCustomerExternalId for non-public routes', async () => {
+    const getCustomerExternalId = vi
+      .fn()
+      .mockResolvedValue('user_123')
+    const flowglad = vi.fn().mockReturnValue({
+      getBilling: vi.fn().mockResolvedValue({
+        subscription: { id: 'sub_1' },
+      }),
+    })
+
+    const handler = requestHandler({
+      getCustomerExternalId,
+      flowglad,
+    })
+
+    await handler(
+      {
+        path: ['customers', 'billing'],
+        method: HTTPMethod.POST,
+        body: { externalId: 'ext_123' },
+      },
+      {}
+    )
+
+    expect(getCustomerExternalId).toHaveBeenCalled()
+    expect(flowglad).toHaveBeenCalledWith('user_123')
+  })
+
+  it('returns 404 for invalid paths', async () => {
+    const handler = requestHandler({
+      getCustomerExternalId: async () => 'user_1',
+      flowglad: () => mockFlowgladServer,
+    })
+
+    const response = await handler(
+      {
+        path: ['invalid', 'path'],
+        method: HTTPMethod.GET,
+      },
+      {}
+    )
+
+    expect(response.status).toBe(404)
+    expect((response.error as any).message).toContain(
+      'is not a valid Flowglad API path'
+    )
+  })
+
+  it('calls beforeRequest and afterRequest hooks', async () => {
+    const beforeRequest = vi.fn()
+    const afterRequest = vi.fn()
+    const mockAdmin = {
+      getDefaultPricingModel: async () => ({
+        pricingModel: { id: 'pm_1' },
+      }),
+    } as unknown as FlowgladServerAdmin
+
+    const handler = requestHandler({
+      getCustomerExternalId: async () => 'user_1',
+      flowglad: () => mockFlowgladServer,
+      flowgladAdmin: () => mockAdmin,
+      beforeRequest,
+      afterRequest,
+    })
+
+    await handler(
+      {
+        path: ['pricing-models', 'default'],
+        method: HTTPMethod.GET,
+      },
+      {}
+    )
+
+    expect(beforeRequest).toHaveBeenCalled()
+    expect(afterRequest).toHaveBeenCalled()
+  })
+
+  it('calls onError when an error occurs', async () => {
+    const onError = vi.fn()
+    const handler = requestHandler({
+      getCustomerExternalId: async () => {
+        throw new Error('Auth failed')
+      },
+      flowglad: () => mockFlowgladServer,
+      onError,
+    })
+
+    await handler(
+      {
+        path: ['customers', 'billing'],
+        method: HTTPMethod.POST,
+        body: { externalId: 'ext_123' },
+      },
+      {}
+    )
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error))
+  })
+})

--- a/packages/server/src/subrouteHandlers/index.ts
+++ b/packages/server/src/subrouteHandlers/index.ts
@@ -9,6 +9,7 @@ import {
   getCustomerBilling,
   updateCustomer,
 } from './customerHandlers'
+import { getDefaultPricingModel } from './pricingHandlers'
 import {
   adjustSubscription,
   cancelSubscription,
@@ -18,7 +19,10 @@ import type { SubRouteHandler } from './types'
 import { createUsageEvent } from './usageEventHandlers'
 
 export const routeToHandlerMap: {
-  [K in FlowgladActionKey]: SubRouteHandler<K>
+  [K in Exclude<
+    FlowgladActionKey,
+    FlowgladActionKey.GetDefaultPricingModel
+  >]: SubRouteHandler<K>
 } = {
   [FlowgladActionKey.GetCustomerBilling]: getCustomerBilling,
   [FlowgladActionKey.FindOrCreateCustomer]: findOrCreateCustomer,
@@ -42,4 +46,12 @@ export const routeToHandlerMap: {
     }
   },
   [FlowgladActionKey.CreateUsageEvent]: createUsageEvent,
+}
+
+/**
+ * Map of public route handlers that do not require authentication.
+ * These handlers use FlowgladServerAdmin instead of FlowgladServer.
+ */
+export const publicRouteToHandlerMap = {
+  [FlowgladActionKey.GetDefaultPricingModel]: getDefaultPricingModel,
 }

--- a/packages/server/src/subrouteHandlers/pricingHandlers.test.ts
+++ b/packages/server/src/subrouteHandlers/pricingHandlers.test.ts
@@ -1,0 +1,81 @@
+import { HTTPMethod } from '@flowglad/shared'
+import { describe, expect, it } from 'vitest'
+import type { FlowgladServerAdmin } from '../FlowgladServerAdmin'
+import { getDefaultPricingModel } from './pricingHandlers'
+
+describe('getDefaultPricingModel handler', () => {
+  it('returns status 200 with pricingModel containing id, name, and prices array when admin.getDefaultPricingModel() resolves successfully', async () => {
+    const mockAdmin = {
+      getDefaultPricingModel: async () => ({
+        pricingModel: {
+          id: 'pm_123',
+          name: 'Pro Plan',
+          prices: [{ id: 'price_1', unitAmount: 1000 }],
+        },
+      }),
+    } as unknown as FlowgladServerAdmin
+
+    const result = await getDefaultPricingModel(
+      { method: HTTPMethod.GET, data: {} },
+      mockAdmin
+    )
+
+    expect(result.status).toBe(200)
+    expect((result.data as any).pricingModel.id).toBe('pm_123')
+    expect((result.data as any).pricingModel.name).toBe('Pro Plan')
+    expect((result.data as any).pricingModel.prices).toHaveLength(1)
+    expect(result.error).toBeUndefined()
+  })
+
+  it('returns status 500 with error.message containing original error text when admin.getDefaultPricingModel() throws an Error', async () => {
+    const mockAdmin = {
+      getDefaultPricingModel: async () => {
+        throw new Error('Database connection failed')
+      },
+    } as unknown as FlowgladServerAdmin
+
+    const result = await getDefaultPricingModel(
+      { method: HTTPMethod.GET, data: {} },
+      mockAdmin
+    )
+
+    expect(result.status).toBe(500)
+    expect(result.data).toEqual({})
+    expect(result.error?.message).toBe('Database connection failed')
+  })
+
+  it('returns status 500 with generic error message when admin.getDefaultPricingModel() throws non-Error value', async () => {
+    const mockAdmin = {
+      getDefaultPricingModel: async () => {
+        throw 'string error'
+      },
+    } as unknown as FlowgladServerAdmin
+
+    const result = await getDefaultPricingModel(
+      { method: HTTPMethod.GET, data: {} },
+      mockAdmin
+    )
+
+    expect(result.status).toBe(500)
+    expect(result.error?.message).toBe(
+      'Failed to fetch default pricing model'
+    )
+  })
+
+  it('returns status 405 when method is not GET', async () => {
+    const mockAdmin = {
+      getDefaultPricingModel: async () => ({
+        pricingModel: { id: 'pm_123' },
+      }),
+    } as unknown as FlowgladServerAdmin
+
+    // Type assertion needed because we're testing invalid method handling
+    const result = await getDefaultPricingModel(
+      { method: HTTPMethod.POST as HTTPMethod.GET, data: {} },
+      mockAdmin
+    )
+
+    expect(result.status).toBe(405)
+    expect(result.error?.message).toBe('Method not allowed')
+  })
+})

--- a/packages/server/src/subrouteHandlers/pricingHandlers.ts
+++ b/packages/server/src/subrouteHandlers/pricingHandlers.ts
@@ -1,0 +1,60 @@
+import { type FlowgladActionKey, HTTPMethod } from '@flowglad/shared'
+import type { FlowgladServerAdmin } from '../FlowgladServerAdmin'
+import type { InferRouteHandlerParams } from './types'
+
+/**
+ * Response type for the getDefaultPricingModel handler.
+ */
+export interface GetDefaultPricingModelResponse {
+  data: object
+  status: number
+  error?: { message: string }
+}
+
+/**
+ * Handler for fetching the default pricing model.
+ * This is a public route that does not require authentication.
+ *
+ * @param params - The request parameters containing method and data
+ * @param admin - The FlowgladServerAdmin instance
+ * @returns The default pricing model or an error response
+ */
+export const getDefaultPricingModel = async (
+  params: InferRouteHandlerParams<FlowgladActionKey.GetDefaultPricingModel>,
+  admin: FlowgladServerAdmin
+): Promise<GetDefaultPricingModelResponse> => {
+  if (params.method !== HTTPMethod.GET) {
+    return {
+      data: {},
+      status: 405,
+      error: {
+        message: 'Method not allowed',
+      },
+    }
+  }
+
+  try {
+    const response = await admin.getDefaultPricingModel()
+    return {
+      data: response,
+      status: 200,
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      return {
+        data: {},
+        status: 500,
+        error: {
+          message: error.message,
+        },
+      }
+    }
+    return {
+      data: {},
+      status: 500,
+      error: {
+        message: 'Failed to fetch default pricing model',
+      },
+    }
+  }
+}

--- a/packages/server/src/supabase/supabaseEdgeHandler.test.ts
+++ b/packages/server/src/supabase/supabaseEdgeHandler.test.ts
@@ -364,7 +364,7 @@ describe('supabaseEdgeHandler', () => {
       })
 
       const req = createMockRequest(
-        'https://project.supabase.co/functions/v1/api-flowglad/billing'
+        'https://project.supabase.co/functions/v1/api-flowglad/customers/billing'
       )
 
       const response = await handler(req)
@@ -381,7 +381,7 @@ describe('supabaseEdgeHandler', () => {
       })
 
       const req = createMockRequest(
-        'https://project.supabase.co/functions/v1/api-flowglad/billing'
+        'https://project.supabase.co/functions/v1/api-flowglad/customers/billing'
       )
 
       const response = await handler(req)
@@ -400,7 +400,7 @@ describe('supabaseEdgeHandler', () => {
       })
 
       const req = createMockRequest(
-        'https://project.supabase.co/functions/v1/api-flowglad/billing'
+        'https://project.supabase.co/functions/v1/api-flowglad/customers/billing'
       )
 
       const response = await handler(req)
@@ -526,7 +526,7 @@ describe('supabaseEdgeHandler', () => {
       )
 
       const req = createMockRequest(
-        'https://project.supabase.co/functions/v1/api-flowglad/billing',
+        'https://project.supabase.co/functions/v1/api-flowglad/customers/billing',
         {
           headers: {
             Authorization: 'Bearer token123',
@@ -562,7 +562,7 @@ describe('supabaseEdgeHandler', () => {
       )
 
       const req = createMockRequest(
-        'https://project.supabase.co/functions/v1/api-flowglad/billing'
+        'https://project.supabase.co/functions/v1/api-flowglad/customers/billing'
       )
 
       await handler(req)

--- a/packages/shared/src/actions.test.ts
+++ b/packages/shared/src/actions.test.ts
@@ -10,6 +10,8 @@ import {
   createSubscriptionSchema,
   createUsageEventSchema,
   flowgladActionValidators,
+  isPublicActionKey,
+  publicActionKeys,
   subscriptionAdjustmentTiming,
   terseSubscriptionItemSchema,
   updateCustomerInputSchema,
@@ -962,6 +964,7 @@ describe('flowgladActionValidators', () => {
       FlowgladActionKey.CreateSubscription,
       FlowgladActionKey.UpdateCustomer,
       FlowgladActionKey.CreateUsageEvent,
+      FlowgladActionKey.GetDefaultPricingModel,
     ]
 
     for (const key of expectedKeys) {
@@ -977,14 +980,29 @@ describe('flowgladActionValidators', () => {
     }
   })
 
-  it('all validators use POST method', () => {
+  it('most validators use POST method, GetDefaultPricingModel uses GET', () => {
     for (const key of Object.keys(
       flowgladActionValidators
     ) as FlowgladActionKey[]) {
-      expect(flowgladActionValidators[key].method).toBe(
-        HTTPMethod.POST
-      )
+      if (key === FlowgladActionKey.GetDefaultPricingModel) {
+        expect(flowgladActionValidators[key].method).toBe(
+          HTTPMethod.GET
+        )
+      } else {
+        expect(flowgladActionValidators[key].method).toBe(
+          HTTPMethod.POST
+        )
+      }
     }
+  })
+
+  it('GetDefaultPricingModel validator accepts empty object', () => {
+    const validator =
+      flowgladActionValidators[
+        FlowgladActionKey.GetDefaultPricingModel
+      ].inputValidator
+    const result = validator.safeParse({})
+    expect(result.success).toBe(true)
   })
 
   it('GetCustomerBilling validator accepts externalId', () => {
@@ -1048,5 +1066,55 @@ describe('flowgladActionValidators', () => {
       timing: 'immediately',
     })
     expect(result.success).toBe(true)
+  })
+})
+
+describe('isPublicActionKey type guard', () => {
+  it('returns true for GetDefaultPricingModel', () => {
+    const key: FlowgladActionKey =
+      FlowgladActionKey.GetDefaultPricingModel
+    expect(isPublicActionKey(key)).toBe(true)
+  })
+
+  it('returns false for GetCustomerBilling action key', () => {
+    expect(
+      isPublicActionKey(FlowgladActionKey.GetCustomerBilling)
+    ).toBe(false)
+  })
+
+  it('returns false for FindOrCreateCustomer action key', () => {
+    expect(
+      isPublicActionKey(FlowgladActionKey.FindOrCreateCustomer)
+    ).toBe(false)
+  })
+
+  it('returns false for CreateCheckoutSession action key', () => {
+    expect(
+      isPublicActionKey(FlowgladActionKey.CreateCheckoutSession)
+    ).toBe(false)
+  })
+
+  it('returns false for CancelSubscription action key', () => {
+    expect(
+      isPublicActionKey(FlowgladActionKey.CancelSubscription)
+    ).toBe(false)
+  })
+})
+
+describe('publicActionKeys', () => {
+  it('contains GetDefaultPricingModel', () => {
+    expect(
+      publicActionKeys.has(FlowgladActionKey.GetDefaultPricingModel)
+    ).toBe(true)
+  })
+
+  it('does not contain GetCustomerBilling', () => {
+    expect(
+      publicActionKeys.has(FlowgladActionKey.GetCustomerBilling)
+    ).toBe(false)
+  })
+
+  it('has exactly 1 entry', () => {
+    expect(publicActionKeys.size).toBe(1)
   })
 })

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -465,4 +465,24 @@ export const flowgladActionValidators = {
     method: HTTPMethod.POST,
     inputValidator: clientCreateUsageEventSchema,
   },
+  [FlowgladActionKey.GetDefaultPricingModel]: {
+    method: HTTPMethod.GET,
+    inputValidator: z.object({}),
+  },
 } as const satisfies FlowgladActionValidatorMap
+
+/**
+ * Set of action keys that do not require authentication.
+ * These routes can be accessed without a customer ID.
+ */
+export const publicActionKeys: Set<FlowgladActionKey> = new Set([
+  FlowgladActionKey.GetDefaultPricingModel,
+])
+
+/**
+ * Type guard to check if an action key is a public action.
+ * @param key - The action key to check
+ * @returns True if the action key is a public action
+ */
+export const isPublicActionKey = (key: FlowgladActionKey): boolean =>
+  publicActionKeys.has(key)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,6 +23,8 @@ export {
   createSubscriptionSchema,
   createUsageEventSchema,
   flowgladActionValidators,
+  isPublicActionKey,
+  publicActionKeys,
   subscriptionAdjustmentTiming,
   terseSubscriptionItemSchema,
   uncancelSubscriptionSchema,

--- a/packages/shared/src/types/sdk.ts
+++ b/packages/shared/src/types/sdk.ts
@@ -13,6 +13,7 @@ export enum FlowgladActionKey {
   CreateSubscription = 'subscriptions/create',
   UpdateCustomer = 'customers/update',
   CreateUsageEvent = 'usage-events/create',
+  GetDefaultPricingModel = 'pricing-models/default',
 }
 
 export enum HTTPMethod {


### PR DESCRIPTION
Introduce `FlowgladHookData` for standardized hook returns and implement public route infrastructure to allow unauthenticated access to public data.

---
<a href="https://cursor.com/background-agent?bcId=bc-6aee853d-ec9c-451f-ab61-df21242e2c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6aee853d-ec9c-451f-ab61-df21242e2c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a standardized FlowgladHookData hook return type and adds public route support to serve pricing data without auth. Enables GET /pricing-models/default via a new flowgladAdmin pathway.

- New Features
  - React: added FlowgladHookData<TData, TRefetchParams> and FlowgladError; exported from @flowglad/react.
  - Shared: added FlowgladActionKey.GetDefaultPricingModel, publicActionKeys, and isPublicActionKey; validator uses GET with empty input.
  - Server: requestHandler supports public routes via flowgladAdmin and publicRouteToHandlerMap.
  - Server: added pricing handler getDefaultPricingModel for GET /pricing-models/default.
  - Next.js: nextRouteHandler accepts and forwards flowgladAdmin.
  - Tests: added coverage for public routing and pricing handler; fixed Supabase tests to use customers/billing path.

- Migration
  - Pass flowgladAdmin to requestHandler/nextRouteHandler to enable public pricing routes.
  - Call GET /pricing-models/default for unauthenticated pricing data.
  - Optionally adopt FlowgladHookData and FlowgladError in hooks.

<sup>Written for commit 19f583a776caa0601cc1091253b7e0b23db45449. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

