### PR TITLE
UseBilling lazy hook data

### DIFF
--- a/packages/react/src/FlowgladProvider.tsx
+++ b/packages/react/src/FlowgladProvider.tsx
@@ -13,12 +13,20 @@ import { validateUrl } from './utils'
 
 const queryClient = new QueryClient()
 
-export interface LoadedFlowgladProviderProps {
+export interface FlowgladProviderProps {
   children: React.ReactNode
   requestConfig?: RequestConfig
   baseURL?: string
-  loadBilling: boolean
+  /**
+   * @deprecated This prop is no longer used. Billing is now loaded lazily when useBilling() is called.
+   */
+  loadBilling?: boolean
 }
+
+/**
+ * @deprecated Use FlowgladProviderProps instead
+ */
+export type LoadedFlowgladProviderProps = FlowgladProviderProps
 
 interface DevModeFlowgladProviderProps {
   __devMode: true
@@ -26,11 +34,13 @@ interface DevModeFlowgladProviderProps {
   children: React.ReactNode
 }
 
-export type FlowgladProviderProps =
-  | LoadedFlowgladProviderProps
+export type FlowgladProviderPropsUnion =
+  | FlowgladProviderProps
   | DevModeFlowgladProviderProps
 
-export const FlowgladProvider = (props: FlowgladProviderProps) => {
+export const FlowgladProvider = (
+  props: FlowgladProviderPropsUnion
+) => {
   if ('__devMode' in props) {
     return (
       <QueryClientProvider client={queryClient}>
@@ -44,8 +54,8 @@ export const FlowgladProvider = (props: FlowgladProviderProps) => {
     )
   }
 
-  const { baseURL, loadBilling, requestConfig, children } =
-    props as LoadedFlowgladProviderProps
+  const { baseURL, requestConfig, children } =
+    props as FlowgladProviderProps
   if (baseURL) {
     validateUrl(baseURL, 'baseURL', true)
   }
@@ -53,7 +63,6 @@ export const FlowgladProvider = (props: FlowgladProviderProps) => {
     <QueryClientProvider client={queryClient}>
       <FlowgladContextProvider
         baseURL={baseURL}
-        loadBilling={loadBilling}
         requestConfig={requestConfig}
       >
         {children}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,5 @@
 export type {
+  CustomerBillingRouteResponse,
   ErrorFlowgladContextValues,
   FlowgladContextValues,
   LoadedFlowgladContextValues,
@@ -6,5 +7,10 @@ export type {
   NotLoadedFlowgladContextValues,
 } from './FlowgladContext'
 export { useBilling } from './FlowgladContext'
+export type {
+  FlowgladProviderProps,
+  LoadedFlowgladProviderProps,
+} from './FlowgladProvider'
 export { FlowgladProvider } from './FlowgladProvider'
 export { humanReadableCurrencyAmount } from './lib/utils'
+export type { FlowgladError, FlowgladHookData } from './types'

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -2,6 +2,20 @@ import type Flowglad from '@flowglad/node'
 
 import type { Subscription } from '@flowglad/shared'
 
+export interface FlowgladError {
+  message: string
+  status?: number
+  code?: string
+}
+
+export interface FlowgladHookData<TData, TRefetchParams = void> {
+  data: TData | null
+  isPending: boolean
+  isRefetching: boolean
+  error: FlowgladError | null
+  refetch: (params?: TRefetchParams) => void
+}
+
 export type SubscriptionCardSubscription = Pick<
   Subscription,
   | 'id'

--- a/playground/generation-based-subscription/src/components/providers.tsx
+++ b/playground/generation-based-subscription/src/components/providers.tsx
@@ -5,7 +5,6 @@ import {
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query'
-import { authClient } from '@/lib/auth-client'
 
 const createQueryClient = () =>
   new QueryClient({
@@ -43,16 +42,7 @@ export function ReactQueryProvider(props: {
 export function FlowgladProviderWrapper(props: {
   children: React.ReactNode
 }) {
-  // Use BetterAuth's useSession to watch for session changes reactively
-  const { data: session } = authClient.useSession()
-
-  // Derive loadBilling from session state reactively
-  // This ensures billing loads when session becomes available, even if layout didn't re-render
-  const loadBilling = !!session?.user
-
-  return (
-    <FlowgladProvider loadBilling={loadBilling}>
-      {props.children}
-    </FlowgladProvider>
-  )
+  // Billing now loads lazily when useBilling() is called
+  // No need to track session state - auth is handled by the route handler
+  return <FlowgladProvider>{props.children}</FlowgladProvider>
 }


### PR DESCRIPTION
Implement lazy loading for `useBilling()` and standardize its return type to `FlowgladHookData`.

This removes the `loadBilling` prop from `FlowgladProvider`, improving developer experience by fetching billing data only when `useBilling()` is called and providing a consistent API for data fetching.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a57d64f-eae9-4328-95f0-a10b9f3bfc8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a57d64f-eae9-4328-95f0-a10b9f3bfc8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-load billing and standardize useBilling() to return FlowgladHookData. Billing now fetches only when useBilling() is first called, giving a simple { data, isPending, isRefetching, error, refetch } API.

- New Features
  - useBilling() now lazy-loads billing and returns FlowgladHookData<CustomerBillingRouteResponse>.
  - Added FlowgladHookData and FlowgladError types; exported CustomerBillingRouteResponse and provider types.
  - Deprecated FlowgladProvider.loadBilling (ignored) and useCatalog (use billing.data?.data.catalog).
  - Playground updated to use <FlowgladProvider> without loadBilling.

- Migration
  - Remove loadBilling from <FlowgladProvider>.
  - Update consumers to read billing.data?.data and use isPending/isRefetching/error/refetch.
  - Replace useCatalog with useBilling().data?.data?.catalog.

<sup>Written for commit 2babe6191faae4fcfc4fa45af9025b9d04008a0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

