### PR TITLE
Hooks data standardization

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,10 +1,12 @@
 export type {
+  CustomerBillingRouteResponse,
   ErrorFlowgladContextValues,
   FlowgladContextValues,
   LoadedFlowgladContextValues,
   NotAuthenticatedFlowgladContextValues,
   NotLoadedFlowgladContextValues,
 } from './FlowgladContext'
-export { useBilling } from './FlowgladContext'
+export { useBilling, usePricing } from './FlowgladContext'
 export { FlowgladProvider } from './FlowgladProvider'
 export { humanReadableCurrencyAmount } from './lib/utils'
+export type { FlowgladError, FlowgladHookData } from './types'

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -18,3 +18,32 @@ export type SubscriptionCardSubscriptionItem = Pick<
   Flowglad.StandardSubscriptionDetails.SubscriptionItem,
   'id' | 'unitPrice' | 'quantity' | 'price'
 >
+
+/**
+ * Standardized error type for Flowglad hooks.
+ */
+export interface FlowgladError {
+  message: string
+  status?: number
+  code?: string
+}
+
+/**
+ * Standardized return type for Flowglad hooks, inspired by Better Auth's useSession() pattern.
+ * Provides consistent API across all hooks.
+ *
+ * @template TData - The type of data returned by the hook
+ * @template TRefetchParams - The type of parameters accepted by the refetch function (defaults to void)
+ */
+export interface FlowgladHookData<TData, TRefetchParams = void> {
+  /** The fetched data or null if not yet loaded/error occurred */
+  data: TData | null
+  /** True during initial load when no data is available yet */
+  isPending: boolean
+  /** True when refetching with stale data available */
+  isRefetching: boolean
+  /** Standardized error object or null if no error */
+  error: FlowgladError | null
+  /** Function to manually trigger a refetch */
+  refetch: (params?: TRefetchParams) => void
+}


### PR DESCRIPTION
## What Does this PR Do?
This PR introduces the `usePricing()` hook for fetching public pricing data and standardizes the return types of `usePricing()` and `useBilling()` using the new `FlowgladHookData` and `FlowgladError` interfaces.

**Why these changes?**
*   **Standardized API**: To provide a consistent and improved developer experience across all data-fetching hooks with a unified return signature (`{ data, isPending, isRefetching, error, refetch }`).
*   **Public Pricing**: To enable fetching public pricing information without requiring user authentication.
*   **Cleanup**: To remove the deprecated `useCatalog` hook from the public API.

**Key Changes:**
*   Added `usePricing()` hook to `FlowgladContext.tsx` for eager client-side fetching of the default pricing model, including error handling and caching.
*   Introduced `FlowgladHookData<T>` and `FlowgladError` types in `packages/react/src/types.ts` for consistent hook responses.
*   Updated `useBilling()` in `FlowgladContext.tsx` to conform to the `FlowgladHookData<CustomerBillingDetails>` return type.
*   Removed `useCatalog` from `packages/react/src/index.ts` exports.

---
<a href="https://cursor.com/background-agent?bcId=bc-538eaee2-a658-49b4-bbcf-301ce6cf9f15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-538eaee2-a658-49b4-bbcf-301ce6cf9f15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new usePricing() hook to fetch public pricing without auth and standardizes hook responses with FlowgladHookData and FlowgladError. Updates useBilling to the new shape and removes useCatalog from public exports.

- **New Features**
  - usePricing(): fetches the default pricing model client-side with a 5-minute cache, SSR guard, refetch, and error handling.
  - Standardized hook API: both usePricing() and useBilling() return { data, isPending, isRefetching, error, refetch } via FlowgladHookData and FlowgladError.

- **Migration**
  - Replace useCatalog with useBilling(); access the catalog via billing.data?.catalog.

<sup>Written for commit 0bdd850baf52153eb9cbdbb50553da25718286aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `usePricing` hook to access pricing data without authentication.
  * Enhanced `useBilling` hook with improved data structure, loading states, and refetch capability.
  * Standardized error handling and hook return types for consistent API design.

* **Deprecations**
  * Marked `useCatalog` as deprecated; migrate to `useBilling` for catalog data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->