### PR TITLE
Notification preferences components

### DIFF
--- a/platform/flowglad-next/src/app/settings/page.tsx
+++ b/platform/flowglad-next/src/app/settings/page.tsx
@@ -12,6 +12,7 @@ import { DetailLabel } from '@/components/DetailLabel'
 import { ExpandSection } from '@/components/ExpandSection'
 import CreateApiKeyModal from '@/components/forms/CreateApiKeyModal'
 import CreateWebhookModal from '@/components/forms/CreateWebhookModal'
+import EditNotificationPreferencesModal from '@/components/forms/EditNotificationPreferencesModal'
 import InviteUserToOrganizationModal from '@/components/forms/InviteUserToOrganizationModal'
 import OrganizationLogoInput from '@/components/OrganizationLogoInput'
 import PageContainer from '@/components/PageContainer'
@@ -21,6 +22,7 @@ import { PageHeaderNew } from '@/components/ui/page-header-new'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { useAuthenticatedContext } from '@/contexts/authContext'
+import { DEFAULT_NOTIFICATION_PREFERENCES } from '@/db/schema/memberships'
 import analyzeCodebasePrompt from '@/prompts/analyze-codebase.md'
 import { FlowgladApiKeyType } from '@/types'
 import { cursorDeepLink } from '@/utils/cursor'
@@ -32,6 +34,10 @@ const SettingsPage = () => {
     useState(false)
   const [isCreateWebhookModalOpen, setIsCreateWebhookModalOpen] =
     useState(false)
+  const [
+    isEditNotificationPreferencesModalOpen,
+    setIsEditNotificationPreferencesModalOpen,
+  ] = useState(false)
   const [codebaseMarkdownValue, setCodebaseMarkdownValue] =
     useState('')
   const hasInitializedRef = useRef(false)
@@ -59,6 +65,11 @@ const SettingsPage = () => {
 
   const { data: codebaseMarkdown, isLoading: isLoadingMarkdown } =
     trpc.organizations.getCodebaseMarkdown.useQuery()
+
+  const {
+    data: notificationPreferences,
+    isLoading: isLoadingNotificationPreferences,
+  } = trpc.organizations.getNotificationPreferences.useQuery()
 
   const updateCodebaseMarkdownMutation =
     trpc.organizations.updateCodebaseMarkdown.useMutation({
@@ -272,6 +283,37 @@ const SettingsPage = () => {
             </div>
           </ExpandSection>
 
+          {/* Notification Preferences Section */}
+          <ExpandSection
+            title="Notification Preferences"
+            defaultExpanded={false}
+          >
+            <div className="flex flex-col gap-3 w-full">
+              <div className="text-sm text-foreground">
+                Configure which email notifications you receive for
+                this organization
+              </div>
+              {isLoadingNotificationPreferences ? (
+                <div className="text-sm text-muted-foreground">
+                  Loading...
+                </div>
+              ) : (
+                <div>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={() =>
+                      setIsEditNotificationPreferencesModalOpen(true)
+                    }
+                  >
+                    Edit Preferences
+                  </Button>
+                </div>
+              )}
+            </div>
+          </ExpandSection>
+
           {/* API Section */}
           <ExpandSection
             title="API"
@@ -305,6 +347,13 @@ const SettingsPage = () => {
       <CreateWebhookModal
         isOpen={isCreateWebhookModalOpen}
         setIsOpen={setIsCreateWebhookModalOpen}
+      />
+      <EditNotificationPreferencesModal
+        isOpen={isEditNotificationPreferencesModalOpen}
+        setIsOpen={setIsEditNotificationPreferencesModalOpen}
+        currentPreferences={
+          notificationPreferences ?? DEFAULT_NOTIFICATION_PREFERENCES
+        }
       />
     </PageContainer>
   )

--- a/platform/flowglad-next/src/components/forms/EditNotificationPreferencesModal.tsx
+++ b/platform/flowglad-next/src/components/forms/EditNotificationPreferencesModal.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { z } from 'zod'
+import { trpc } from '@/app/_trpc/client'
+import FormModal from '@/components/forms/FormModal'
+import {
+  type NotificationPreferences,
+  notificationPreferencesSchema,
+} from '@/db/schema/memberships'
+import NotificationPreferencesFormFields from './NotificationPreferencesFormFields'
+
+const editNotificationPreferencesSchema = z.object({
+  preferences: notificationPreferencesSchema.partial(),
+})
+
+type EditNotificationPreferencesInput = z.infer<
+  typeof editNotificationPreferencesSchema
+>
+
+interface EditNotificationPreferencesModalProps {
+  isOpen: boolean
+  setIsOpen: (isOpen: boolean) => void
+  currentPreferences: NotificationPreferences
+}
+
+const EditNotificationPreferencesModal: React.FC<
+  EditNotificationPreferencesModalProps
+> = ({ isOpen, setIsOpen, currentPreferences }) => {
+  const utils = trpc.useUtils()
+  const updateNotificationPreferencesMutation =
+    trpc.organizations.updateNotificationPreferences.useMutation({
+      onSuccess: () => {
+        utils.organizations.getNotificationPreferences.invalidate()
+      },
+    })
+
+  const defaultValues: EditNotificationPreferencesInput = {
+    preferences: currentPreferences,
+  }
+
+  return (
+    <FormModal<EditNotificationPreferencesInput>
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      title="Edit Notification Preferences"
+      formSchema={editNotificationPreferencesSchema}
+      defaultValues={defaultValues}
+      onSubmit={async (data) => {
+        await updateNotificationPreferencesMutation.mutateAsync(data)
+      }}
+    >
+      <NotificationPreferencesFormFields />
+    </FormModal>
+  )
+}
+
+export default EditNotificationPreferencesModal

--- a/platform/flowglad-next/src/components/forms/NotificationPreferencesFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/NotificationPreferencesFormFields.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { Controller, useFormContext } from 'react-hook-form'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import type { NotificationPreferences } from '@/db/schema/memberships'
+
+interface NotificationToggleProps {
+  id: string
+  name: keyof NotificationPreferences
+  label: string
+  description?: string
+}
+
+/**
+ * Reusable toggle component for notification preferences
+ */
+const NotificationToggle = ({
+  id,
+  name,
+  label,
+  description,
+}: NotificationToggleProps) => {
+  const form = useFormContext<{
+    preferences: Partial<NotificationPreferences>
+  }>()
+
+  return (
+    <Controller
+      control={form.control}
+      name={`preferences.${name}`}
+      render={({ field }) => (
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label htmlFor={id}>{label}</Label>
+            {description && (
+              <div className="text-xs text-muted-foreground">
+                {description}
+              </div>
+            )}
+          </div>
+          <Switch
+            id={id}
+            checked={field.value ?? true}
+            onCheckedChange={field.onChange}
+          />
+        </div>
+      )}
+    />
+  )
+}
+
+/**
+ * Form fields for notification preferences.
+ * Uses react-hook-form context and renders grouped toggles for all notification types.
+ */
+const NotificationPreferencesFormFields = () => {
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Test Mode Section */}
+      <div className="flex flex-col gap-4">
+        <div className="text-sm font-medium text-foreground">
+          Test Mode
+        </div>
+        <NotificationToggle
+          id="test-mode-notifications"
+          name="testModeNotifications"
+          label="Receive Test Mode Notifications"
+          description="Enable to receive email notifications for test mode events"
+        />
+      </div>
+
+      {/* Border separator */}
+      <div className="border-t border-dashed border-border" />
+
+      {/* Subscription Notifications Group */}
+      <div className="flex flex-col gap-4">
+        <div className="text-sm font-medium text-foreground">
+          Subscription Notifications
+        </div>
+        <NotificationToggle
+          id="subscription-created"
+          name="subscriptionCreated"
+          label="Subscription Created"
+          description="Notify when a new subscription is created"
+        />
+        <NotificationToggle
+          id="subscription-adjusted"
+          name="subscriptionAdjusted"
+          label="Subscription Adjusted"
+          description="Notify when a subscription is upgraded or downgraded"
+        />
+        <NotificationToggle
+          id="subscription-canceled"
+          name="subscriptionCanceled"
+          label="Subscription Canceled"
+          description="Notify when a subscription is canceled"
+        />
+        <NotificationToggle
+          id="subscription-cancellation-scheduled"
+          name="subscriptionCancellationScheduled"
+          label="Cancellation Scheduled"
+          description="Notify when a cancellation is scheduled for the end of the billing period"
+        />
+      </div>
+
+      {/* Payment Notifications Group */}
+      <div className="flex flex-col gap-4">
+        <div className="text-sm font-medium text-foreground">
+          Payment Notifications
+        </div>
+        <NotificationToggle
+          id="payment-failed"
+          name="paymentFailed"
+          label="Payment Failed"
+          description="Notify when a payment fails"
+        />
+      </div>
+
+      {/* Account Notifications Group */}
+      <div className="flex flex-col gap-4">
+        <div className="text-sm font-medium text-foreground">
+          Account Notifications
+        </div>
+        <NotificationToggle
+          id="onboarding-completed"
+          name="onboardingCompleted"
+          label="Onboarding Completed"
+          description="Notify when Stripe Connect onboarding is completed"
+        />
+        <NotificationToggle
+          id="payouts-enabled"
+          name="payoutsEnabled"
+          label="Payouts Enabled"
+          description="Notify when payouts are enabled on your account"
+        />
+      </div>
+    </div>
+  )
+}
+
+export default NotificationPreferencesFormFields

--- a/platform/flowglad-next/src/db/schema/memberships.ts
+++ b/platform/flowglad-next/src/db/schema/memberships.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm'
-import { boolean, pgTable, text } from 'drizzle-orm/pg-core'
+import { boolean, jsonb, pgTable, text } from 'drizzle-orm/pg-core'
 import * as R from 'ramda'
 import { z } from 'zod'
 import { buildSchemas } from '@/db/createZodSchemas'
@@ -31,6 +31,9 @@ export const memberships = pgTable(
       organizations
     ),
     focused: boolean('focused').notNull().default(false),
+    notificationPreferences: jsonb(
+      'notification_preferences'
+    ).default({}),
   },
   (table) => {
     return [
@@ -99,6 +102,42 @@ export namespace Membership {
   >
   export type Where = SelectConditions<typeof memberships>
 }
+
+/**
+ * Schema for notification preferences stored in the membership's notificationPreferences JSONB column.
+ * Each preference controls whether a specific notification type is sent to the member.
+ */
+export const notificationPreferencesSchema = z.object({
+  testModeNotifications: z.boolean().default(false),
+  subscriptionCreated: z.boolean().default(true),
+  subscriptionAdjusted: z.boolean().default(true),
+  subscriptionCanceled: z.boolean().default(true),
+  subscriptionCancellationScheduled: z.boolean().default(true),
+  paymentFailed: z.boolean().default(true),
+  onboardingCompleted: z.boolean().default(true),
+  payoutsEnabled: z.boolean().default(true),
+})
+
+export type NotificationPreferences = z.infer<
+  typeof notificationPreferencesSchema
+>
+
+/**
+ * Default notification preferences for new memberships.
+ * Test mode notifications are disabled by default.
+ * All other notification types are enabled by default for backwards compatibility.
+ */
+export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences =
+  {
+    testModeNotifications: false,
+    subscriptionCreated: true,
+    subscriptionAdjusted: true,
+    subscriptionCanceled: true,
+    subscriptionCancellationScheduled: true,
+    paymentFailed: true,
+    onboardingCompleted: true,
+    payoutsEnabled: true,
+  }
 
 export const inviteUserToOrganizationSchema = z.object({
   email: z.email(),

--- a/platform/flowglad-next/src/db/tableMethods/membershipMethods.ts
+++ b/platform/flowglad-next/src/db/tableMethods/membershipMethods.ts
@@ -2,6 +2,7 @@ import { and, eq, sql } from 'drizzle-orm'
 import * as R from 'ramda'
 import { z } from 'zod'
 import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
   type Membership,
   memberships,
   membershipsClientSelectSchema,
@@ -9,6 +10,7 @@ import {
   membershipsSelectSchema,
   membershipsTableRowDataSchema,
   membershipsUpdateSchema,
+  type NotificationPreferences,
 } from '@/db/schema/memberships'
 import type { User } from '@/db/schema/users'
 import {
@@ -216,3 +218,17 @@ export const selectMembershipsTableRowData =
       }))
     }
   )
+
+/**
+ * Returns the notification preferences for a membership, merging stored preferences
+ * with defaults. This ensures that new preference fields are always populated.
+ */
+export const getMembershipNotificationPreferences = (
+  membership: Membership.Record
+): NotificationPreferences => {
+  return {
+    ...DEFAULT_NOTIFICATION_PREFERENCES,
+    ...((membership.notificationPreferences as Partial<NotificationPreferences>) ??
+      {}),
+  }
+}

--- a/platform/flowglad-next/src/server/routers/organizationsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/organizationsRouter.ts
@@ -8,6 +8,7 @@ import {
 import {
   membershipsClientSelectSchema,
   membershipsTableRowDataSchema,
+  notificationPreferencesSchema,
 } from '@/db/schema/memberships'
 import {
   createOrganizationSchema,
@@ -16,8 +17,10 @@ import {
 } from '@/db/schema/organizations'
 import { getRevenueDataInputSchema } from '@/db/schema/payments'
 import {
+  getMembershipNotificationPreferences,
   selectFocusedMembershipAndOrganization,
   selectMembershipAndOrganizationsByBetterAuthUserId,
+  selectMemberships,
   selectMembershipsAndOrganizationsByMembershipWhere,
   selectMembershipsAndUsersByMembershipWhere,
   selectMembershipsTableRowData,
@@ -440,6 +443,75 @@ const getMembersTableRowData = protectedProcedure
     })
   })
 
+const getNotificationPreferences = protectedProcedure
+  .output(notificationPreferencesSchema)
+  .query(
+    authenticatedProcedureTransaction(
+      async ({ transaction, userId, ctx }) => {
+        if (!ctx.organizationId) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'organizationId is required',
+          })
+        }
+        const [membership] = await selectMemberships(
+          { userId, organizationId: ctx.organizationId },
+          transaction
+        )
+        if (!membership) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Membership not found',
+          })
+        }
+        return getMembershipNotificationPreferences(membership)
+      }
+    )
+  )
+
+const updateNotificationPreferencesInputSchema = z.object({
+  preferences: notificationPreferencesSchema.partial(),
+})
+
+const updateNotificationPreferences = protectedProcedure
+  .input(updateNotificationPreferencesInputSchema)
+  .mutation(
+    authenticatedProcedureTransaction(
+      async ({ input, transaction, userId, ctx }) => {
+        if (!ctx.organizationId) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'organizationId is required',
+          })
+        }
+        const [membership] = await selectMemberships(
+          { userId, organizationId: ctx.organizationId },
+          transaction
+        )
+        if (!membership) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Membership not found',
+          })
+        }
+        const currentPrefs =
+          (membership.notificationPreferences as Record<
+            string,
+            boolean
+          >) ?? {}
+        const updatedPrefs = { ...currentPrefs, ...input.preferences }
+        await updateMembership(
+          {
+            id: membership.id,
+            notificationPreferences: updatedPrefs,
+          },
+          transaction
+        )
+        return { preferences: updatedPrefs }
+      }
+    )
+  )
+
 export const organizationsRouter = router({
   create: createOrganization,
   update: updateOrganization,
@@ -462,4 +534,7 @@ export const organizationsRouter = router({
   getActiveSubscribers: getActiveSubscribers,
   getSubscriberBreakdown: getSubscriberBreakdown,
   getCurrentSubscribers: getCurrentSubscribers,
+  // Notification preferences
+  getNotificationPreferences: getNotificationPreferences,
+  updateNotificationPreferences: updateNotificationPreferences,
 })


### PR DESCRIPTION
## What Does this PR Do?
This PR introduces the user interface for managing per-user notification preferences, addressing the lack of a UI for members to view or edit their settings.

Specifically, it:
- Creates `NotificationPreferencesFormFields` and `EditNotificationPreferencesModal` following the established `FormModal` pattern.
- Integrates a new "Notification Preferences" section into the settings page, allowing users to launch the modal and update their preferences.
- Includes the necessary backend API endpoints (`getNotificationPreferences`, `updateNotificationPreferences`) and schema definitions (`notificationPreferencesSchema` on `memberships` table) to support the UI, completing the prerequisites from Patch 1 and 2.

The goal is to provide a consistent way for users to control their email notifications, including a per-user test mode toggle and grouped notification type preferences.

---
<a href="https://cursor.com/background-agent?bcId=bc-670b617b-3cb5-488a-8234-2cc564f985a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-670b617b-3cb5-488a-8234-2cc564f985a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Notification Preferences UI and API so members can view and update their email settings per organization. Introduces a modal with grouped toggles and a new JSONB column to store per-user preferences.

- **New Features**
  - Settings page: new Notification Preferences section with an Edit Preferences modal (FormModal pattern).
  - Grouped toggles for test mode, subscription, payment, and account emails with sensible defaults.
  - TRPC endpoints: getNotificationPreferences and updateNotificationPreferences; helper merges stored values with defaults.

- **Migration**
  - Run the database migration to add the notification_preferences JSONB column on memberships (defaults applied: test mode off, others on).

<sup>Written for commit dd8fcf5cf203508cdacf6abf43a53d92a3452531. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

