### PR TITLE
feat(cache): emit info-level logs for cache statistics

### DIFF
--- a/platform/flowglad-next/src/utils/cache.ts
+++ b/platform/flowglad-next/src/utils/cache.ts
@@ -223,6 +223,11 @@ export function cached<TArgs extends unknown[], TResult>(
               key: fullKey,
               latency_ms: latencyMs,
             })
+            logger.info('cache_stats', {
+              namespace: config.namespace,
+              hit: true,
+              latency_ms: latencyMs,
+            })
             return parsed.data
           } else {
             // Schema validation failed - treat as cache miss
@@ -232,11 +237,22 @@ export function cached<TArgs extends unknown[], TResult>(
               key: fullKey,
               error: parsed.error.message,
             })
+            logger.info('cache_stats', {
+              namespace: config.namespace,
+              hit: false,
+              validation_failed: true,
+              latency_ms: latencyMs,
+            })
           }
         } else {
           span?.setAttribute('cache.hit', false)
           logger.debug('Cache miss', {
             key: fullKey,
+            latency_ms: latencyMs,
+          })
+          logger.info('cache_stats', {
+            namespace: config.namespace,
+            hit: false,
             latency_ms: latencyMs,
           })
         }
@@ -249,6 +265,11 @@ export function cached<TArgs extends unknown[], TResult>(
         logger.error('Cache read error', {
           key: fullKey,
           error: errorMessage,
+        })
+        logger.info('cache_stats', {
+          namespace: config.namespace,
+          hit: false,
+          error: true,
         })
       }
 


### PR DESCRIPTION
## What Does this PR Do?

Adds info-level `cache_stats` logs to the cache combinator that emit on every cache operation. This enables aggregating cache hit rates per namespace in logging backends (Better Stack, Datadog, etc.) without relying on debug-level logs that are typically disabled in production. Each log includes the namespace, hit status, latency, and error information for comprehensive observability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit info-level cache_stats logs for every cache operation to track hit rate and latency by namespace. Improves production observability without enabling debug logs.

- **New Features**
  - Logs on hit, miss, validation failure, and error paths.
  - Fields: namespace, hit, latency_ms; plus validation_failed or error when relevant.
  - Enables aggregation in Better Stack, Datadog, and similar backends.

<sup>Written for commit 214a93364c17b93c44a41c00f0f83259a6810472. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

