### PR TITLE
Fix pricing.yaml schema format

### DIFF
--- a/platform/flowglad-next/bun.lock
+++ b/platform/flowglad-next/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "flowglad-next",
@@ -204,10 +203,10 @@
     },
   },
   "overrides": {
+    "esbuild": "0.25.0",
+    "chromium-bidi": "2.1.2",
     "@modelcontextprotocol/sdk": "1.23.0-beta.0",
     "@react-email/render": "0.0.17",
-    "chromium-bidi": "2.1.2",
-    "esbuild": "0.25.0",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],

--- a/playground/generation-based-subscription/pricing.yaml
+++ b/playground/generation-based-subscription/pricing.yaml
@@ -110,17 +110,17 @@ products:
       active: true
       default: false
       slug: "basic_monthly"
-    prices:
-      - intervalUnit: "month"
-        name: "Basic Plan (Monthly)"
-        intervalCount: 1
-        type: "subscription"
-        isDefault: true
-        unitPrice: 1000
-        usageEventsPerUnit: null
-        active: true
-        slug: "basic_monthly"
-        usageMeterId: null
+    price:
+      intervalUnit: "month"
+      name: "Basic Plan (Monthly)"
+      intervalCount: 1
+      type: "subscription"
+      isDefault: true
+      unitPrice: 1000
+      usageEventsPerUnit: null
+      active: true
+      slug: "basic_monthly"
+      usageMeterId: null
     features:
       - "basic_fast_generations"
       - "general_commercial_terms"
@@ -132,18 +132,18 @@ products:
       active: true
       default: false
       slug: "fast_generation_top_ups"
-    prices:
-      - intervalUnit: null
-        name: "Fast Generation Top-Up"
-        intervalCount: null
-        type: "single_payment"
-        trialPeriodDays: null
-        isDefault: true
-        unitPrice: 400
-        usageEventsPerUnit: null
-        active: true
-        slug: "fast_generation_top_up"
-        usageMeterId: null
+    price:
+      intervalUnit: null
+      name: "Fast Generation Top-Up"
+      intervalCount: null
+      type: "single_payment"
+      trialPeriodDays: null
+      isDefault: true
+      unitPrice: 400
+      usageEventsPerUnit: null
+      active: true
+      slug: "fast_generation_top_up"
+      usageMeterId: null
     features:
       - "fast_generation_top_up_credit"
   - product:
@@ -152,35 +152,35 @@ products:
       active: true
       default: false
       slug: "fast_generation_usage_price"
-    prices:
-      - intervalUnit: "month"
-        name: "Fast Generation Usage"
-        intervalCount: 1
-        type: "usage"
-        trialPeriodDays: null
-        isDefault: true
-        unitPrice: 5
-        usageEventsPerUnit: 1
-        active: true
-        slug: "fast_generation_usage"
-        usageMeterSlug: "fast_generations"
+    price:
+      intervalUnit: "month"
+      name: "Fast Generation Usage"
+      intervalCount: 1
+      type: "usage"
+      trialPeriodDays: null
+      isDefault: true
+      unitPrice: 5
+      usageEventsPerUnit: 1
+      active: true
+      slug: "fast_generation_usage"
+      usageMeterSlug: "fast_generations"
     features: []
   - product:
       name: "Free Plan"
       active: true
       default: true
       slug: "free"
-    prices:
-      - intervalUnit: "month"
-        name: "Free Plan"
-        intervalCount: 1
-        type: "subscription"
-        isDefault: true
-        unitPrice: 0
-        usageEventsPerUnit: null
-        active: true
-        slug: "free"
-        usageMeterId: null
+    price:
+      intervalUnit: "month"
+      name: "Free Plan"
+      intervalCount: 1
+      type: "subscription"
+      isDefault: true
+      unitPrice: 0
+      usageEventsPerUnit: null
+      active: true
+      slug: "free"
+      usageMeterId: null
     features: []
   - product:
       name: "HD Video Minute Top-Ups"
@@ -188,18 +188,18 @@ products:
       active: true
       default: false
       slug: "hd_video_minute_top_ups"
-    prices:
-      - intervalUnit: null
-        name: "HD Video Minute Top-Up"
-        intervalCount: null
-        type: "single_payment"
-        trialPeriodDays: null
-        isDefault: true
-        unitPrice: 1000
-        usageEventsPerUnit: null
-        active: true
-        slug: "hd_video_minute_top_up"
-        usageMeterId: null
+    price:
+      intervalUnit: null
+      name: "HD Video Minute Top-Up"
+      intervalCount: null
+      type: "single_payment"
+      trialPeriodDays: null
+      isDefault: true
+      unitPrice: 1000
+      usageEventsPerUnit: null
+      active: true
+      slug: "hd_video_minute_top_up"
+      usageMeterId: null
     features:
       - "hd_video_minute_top_up_credit"
   - product:
@@ -208,18 +208,18 @@ products:
       active: true
       default: false
       slug: "hd_video_minute_usage_price"
-    prices:
-      - intervalUnit: "month"
-        name: "HD Video Minute Usage"
-        intervalCount: 1
-        type: "usage"
-        trialPeriodDays: null
-        isDefault: true
-        unitPrice: 100
-        usageEventsPerUnit: 1
-        active: true
-        slug: "hd_video_minute_usage"
-        usageMeterSlug: "hd_video_minutes"
+    price:
+      intervalUnit: "month"
+      name: "HD Video Minute Usage"
+      intervalCount: 1
+      type: "usage"
+      trialPeriodDays: null
+      isDefault: true
+      unitPrice: 100
+      usageEventsPerUnit: 1
+      active: true
+      slug: "hd_video_minute_usage"
+      usageMeterSlug: "hd_video_minutes"
     features: []
   - product:
       name: "Mega"
@@ -227,17 +227,17 @@ products:
       active: true
       default: false
       slug: "mega_monthly"
-    prices:
-      - intervalUnit: "month"
-        name: "Mega Plan (Monthly)"
-        intervalCount: 1
-        type: "subscription"
-        isDefault: true
-        unitPrice: 12000
-        usageEventsPerUnit: null
-        active: true
-        slug: "mega_monthly"
-        usageMeterId: null
+    price:
+      intervalUnit: "month"
+      name: "Mega Plan (Monthly)"
+      intervalCount: 1
+      type: "subscription"
+      isDefault: true
+      unitPrice: 12000
+      usageEventsPerUnit: null
+      active: true
+      slug: "mega_monthly"
+      usageMeterId: null
     features:
       - "mega_fast_generations"
       - "mega_hd_video_minutes"
@@ -253,17 +253,17 @@ products:
       active: true
       default: false
       slug: "pro_monthly"
-    prices:
-      - intervalUnit: "month"
-        name: "Pro Plan (Monthly)"
-        intervalCount: 1
-        type: "subscription"
-        isDefault: true
-        unitPrice: 6000
-        usageEventsPerUnit: null
-        active: true
-        slug: "pro_monthly"
-        usageMeterId: null
+    price:
+      intervalUnit: "month"
+      name: "Pro Plan (Monthly)"
+      intervalCount: 1
+      type: "subscription"
+      isDefault: true
+      unitPrice: 6000
+      usageEventsPerUnit: null
+      active: true
+      slug: "pro_monthly"
+      usageMeterId: null
     features:
       - "pro_fast_generations"
       - "pro_hd_video_minutes"
@@ -279,17 +279,17 @@ products:
       active: true
       default: false
       slug: "standard_monthly"
-    prices:
-      - intervalUnit: "month"
-        name: "Standard Plan (Monthly)"
-        intervalCount: 1
-        type: "subscription"
-        isDefault: true
-        unitPrice: 3000
-        usageEventsPerUnit: null
-        active: true
-        slug: "standard_monthly"
-        usageMeterId: null
+    price:
+      intervalUnit: "month"
+      name: "Standard Plan (Monthly)"
+      intervalCount: 1
+      type: "subscription"
+      isDefault: true
+      unitPrice: 3000
+      usageEventsPerUnit: null
+      active: true
+      slug: "standard_monthly"
+      usageMeterId: null
     features:
       - "standard_fast_generations"
       - "standard_hd_video_minutes"


### PR DESCRIPTION
## What Does this PR Do?

Fixes the pricing model validation by converting the pricing.yaml file from using a `prices:` array to a singular `price:` object for each product. The validation schema expects a single price per product, not an array.

Changes applied to all 9 products in the generation-based-subscription pricing model.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align pricing.yaml with the validation schema by converting each product’s prices array into a single price object. This fixes schema validation and ensures pricing loads correctly for all 9 products in the generation-based-subscription model.

- **Bug Fixes**
  - Updated playground/generation-based-subscription/pricing.yaml to use price (not prices) for all 9 products, matching setupSchemas.ts expectations and preserving all fields.

<sup>Written for commit e375a1940f110285a37df6fe2c5fde74e8b56f7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified pricing configuration structure from multiple prices per product to a single price per product. The same pricing fields (interval unit, count, name, type, default status, unit price, usage metrics, and slug) are preserved in the updated format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->