### PR TITLE
fix: Add missing cache invalidations for subscription status changes

### DIFF
--- a/platform/flowglad-next/src/subscriptions/billingPeriodHelpers.ts
+++ b/platform/flowglad-next/src/subscriptions/billingPeriodHelpers.ts
@@ -33,6 +33,7 @@ import {
   LedgerTransactionType,
   SubscriptionStatus,
 } from '@/types'
+import { CacheDependency } from '@/utils/cache'
 import { core } from '@/utils/core'
 import { sumNetTotalSettledPaymentsForBillingPeriod } from '@/utils/paymentHelpers'
 import { tracedTrigger } from '@/utils/triggerTracing'
@@ -273,6 +274,11 @@ export const attemptToTransitionSubscriptionBillingPeriod = async (
         updatedBillingPeriod,
       },
       eventsToInsert: [],
+      cacheInvalidations: [
+        CacheDependency.customerSubscriptions(
+          subscription.customerId
+        ),
+      ],
     }
   }
 
@@ -312,6 +318,11 @@ export const attemptToTransitionSubscriptionBillingPeriod = async (
         updatedBillingPeriod,
       },
       eventsToInsert: [],
+      cacheInvalidations: [
+        CacheDependency.customerSubscriptions(
+          subscription.customerId
+        ),
+      ],
     }
   }
   const newBillingPeriod = result.billingPeriod
@@ -430,6 +441,9 @@ export const attemptToTransitionSubscriptionBillingPeriod = async (
       subscriptionId: subscription.id,
       payload: ledgerCommandPayload,
     },
+    cacheInvalidations: [
+      CacheDependency.customerSubscriptions(subscription.customerId),
+    ],
   }
 }
 

--- a/platform/flowglad-next/src/subscriptions/processBillingRunPaymentIntents.ts
+++ b/platform/flowglad-next/src/subscriptions/processBillingRunPaymentIntents.ts
@@ -55,7 +55,10 @@ import {
 } from '@/types'
 import { processPaymentIntentStatusUpdated } from '@/utils/bookkeeping/processPaymentIntentStatusUpdated'
 import { createStripeTaxTransactionIfNeededForPayment } from '@/utils/bookkeeping/stripeTaxTransactions'
-import type { CacheDependencyKey } from '@/utils/cache'
+import {
+  CacheDependency,
+  type CacheDependencyKey,
+} from '@/utils/cache'
 import { fetchDiscountInfoForInvoice } from '@/utils/discountHelpers'
 import {
   sendAwaitingPaymentConfirmationEmail,
@@ -540,9 +543,12 @@ export const processOutcomeForBillingRun = async (
     eventsToInsert.push(...childeventsToInsert)
   }
 
-  // Track cache invalidations from subscription item adjustments
-  const cacheInvalidations: CacheDependencyKey[] =
-    subscriptionItemAdjustmentResult?.cacheInvalidations ?? []
+  // Track cache invalidations from subscription item adjustments and status changes
+  const cacheInvalidations: CacheDependencyKey[] = [
+    // Always invalidate customerSubscriptions since status may change
+    CacheDependency.customerSubscriptions(subscription.customerId),
+    ...(subscriptionItemAdjustmentResult?.cacheInvalidations ?? []),
+  ]
 
   const notificationParams: BillingRunNotificationParams = {
     invoice,

--- a/platform/flowglad-next/src/utils/bookkeeping/processSetupIntent.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/processSetupIntent.ts
@@ -46,6 +46,7 @@ import {
   PurchaseStatus,
   SubscriptionStatus,
 } from '@/types'
+import { CacheDependency } from '@/utils/cache'
 import {
   IntentMetadataType,
   StripeIntentMetadata,
@@ -819,6 +820,9 @@ export const processSetupIntentSucceeded = async (
     return {
       result,
       eventsToInsert: [],
+      cacheInvalidations: [
+        CacheDependency.customerSubscriptions(result.customer.id),
+      ],
     }
   }
 


### PR DESCRIPTION
## What Does this PR Do?

Fixes three critical missing cache invalidations in subscription business logic paths that modify subscription status. These paths now properly invalidate the `customerSubscriptions` cache dependency when status changes, preventing stale cached data.

**Affected paths:**
- Billing period transitions (trial→active, scheduled cancellations, past due states)
- Payment outcome processing (success→active, failure→past due)
- Setup intent activation (incomplete→active)

Cache was previously invalidated during subscription creation and cancellation, but these status transitions in payment and billing workflows were missing invalidations, causing the cached subscription list to become stale.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the customerSubscriptions cache is invalidated whenever a subscription status changes, preventing stale subscription lists across billing and payment flows.

- **Bug Fixes**
  - Billing period transitions: invalidate on trial→active, scheduled cancellations, and past-due transitions.
  - Payment processing: always invalidate during billing run outcomes (success→active, failure→past due).
  - Setup intent: invalidate on activation (incomplete→active).

<sup>Written for commit 1dad7827f4be00aff20960891f0edb4e7701c6e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

