### PR TITLE
feat(cache): Add cache stats logging and tracing for bulk operations

### DIFF
--- a/platform/flowglad-next/src/utils/cache.ts
+++ b/platform/flowglad-next/src/utils/cache.ts
@@ -1,4 +1,4 @@
-import { SpanKind, trace } from '@opentelemetry/api'
+import { SpanKind, SpanStatusCode, trace } from '@opentelemetry/api'
 import { z } from 'zod'
 import core from './core'
 import { logger } from './logger'
@@ -225,7 +225,9 @@ export function cached<TArgs extends unknown[], TResult>(
             })
             logger.info('cache_stats', {
               namespace: config.namespace,
-              hit: true,
+              hit_count: 1,
+              miss_count: 0,
+              total_count: 1,
               latency_ms: latencyMs,
             })
             return parsed.data
@@ -239,7 +241,9 @@ export function cached<TArgs extends unknown[], TResult>(
             })
             logger.info('cache_stats', {
               namespace: config.namespace,
-              hit: false,
+              hit_count: 0,
+              miss_count: 1,
+              total_count: 1,
               validation_failed: true,
               latency_ms: latencyMs,
             })
@@ -252,7 +256,9 @@ export function cached<TArgs extends unknown[], TResult>(
           })
           logger.info('cache_stats', {
             namespace: config.namespace,
-            hit: false,
+            hit_count: 0,
+            miss_count: 1,
+            total_count: 1,
             latency_ms: latencyMs,
           })
         }
@@ -268,7 +274,9 @@ export function cached<TArgs extends unknown[], TResult>(
         })
         logger.info('cache_stats', {
           namespace: config.namespace,
-          hit: false,
+          hit_count: 0,
+          miss_count: 1,
+          total_count: 1,
           error: true,
         })
       }
@@ -354,7 +362,48 @@ export async function cachedBulkLookup<TKey, TResult>(
     return new Map()
   }
 
-  const span = trace.getActiveSpan()
+  const tracer = trace.getTracer('cache')
+  return tracer.startActiveSpan(
+    `cache.bulk.${config.namespace}`,
+    { kind: SpanKind.CLIENT },
+    async (span) => {
+      span.setAttribute('cache.namespace', config.namespace)
+      span.setAttribute('cache.bulk', true)
+      span.setAttribute('cache.key_count', keys.length)
+
+      const startTime = Date.now()
+      try {
+        const result = await cachedBulkLookupImpl(
+          config,
+          keys,
+          bulkFetchFn,
+          groupByKey,
+          span
+        )
+        span.setStatus({ code: SpanStatusCode.OK })
+        return result
+      } catch (error) {
+        span.recordException(error as Error)
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: (error as Error).message,
+        })
+        throw error
+      } finally {
+        span.setAttribute('duration_ms', Date.now() - startTime)
+        span.end()
+      }
+    }
+  )
+}
+
+async function cachedBulkLookupImpl<TKey, TResult>(
+  config: BulkCacheConfig<TKey, TResult[]>,
+  keys: TKey[],
+  bulkFetchFn: (keys: TKey[]) => Promise<TResult[]>,
+  groupByKey: (item: TResult) => TKey,
+  span: ReturnType<ReturnType<typeof trace.getTracer>['startSpan']>
+): Promise<Map<TKey, TResult[]>> {
   const redisClient = redis()
   const ttl = getTtlForNamespace(config.namespace)
 
@@ -379,8 +428,8 @@ export async function cachedBulkLookup<TKey, TResult>(
     )) as (TResult[] | null)[]
     const latencyMs = Date.now() - startTime
 
-    span?.setAttribute('cache.bulk_lookup_count', keys.length)
-    span?.setAttribute('cache.bulk_latency_ms', latencyMs)
+    span.setAttribute('cache.bulk_lookup_count', keys.length)
+    span.setAttribute('cache.bulk_latency_ms', latencyMs)
 
     // Process cached values
     let hitCount = 0
@@ -425,8 +474,8 @@ export async function cachedBulkLookup<TKey, TResult>(
       }
     }
 
-    span?.setAttribute('cache.bulk_hit_count', hitCount)
-    span?.setAttribute('cache.bulk_miss_count', missedKeys.length)
+    span.setAttribute('cache.bulk_hit_count', hitCount)
+    span.setAttribute('cache.bulk_miss_count', missedKeys.length)
 
     logger.debug('Bulk cache lookup', {
       namespace: config.namespace,
@@ -435,14 +484,30 @@ export async function cachedBulkLookup<TKey, TResult>(
       misses: missedKeys.length,
       latency_ms: latencyMs,
     })
+    logger.info('cache_stats', {
+      namespace: config.namespace,
+      bulk: true,
+      hit_count: hitCount,
+      miss_count: missedKeys.length,
+      total_count: keys.length,
+      latency_ms: latencyMs,
+    })
   } catch (error) {
     // Fail open - all keys become misses
     const errorMessage =
       error instanceof Error ? error.message : String(error)
-    span?.setAttribute('cache.bulk_error', errorMessage)
+    span.setAttribute('cache.bulk_error', errorMessage)
     logger.error('Bulk cache read error', {
       namespace: config.namespace,
       error: errorMessage,
+    })
+    logger.info('cache_stats', {
+      namespace: config.namespace,
+      bulk: true,
+      hit_count: 0,
+      miss_count: keys.length,
+      total_count: keys.length,
+      error: true,
     })
     missedKeys.push(...keys)
   }


### PR DESCRIPTION
## What Does this PR Do?

Adds comprehensive observability to cache operations by implementing cache_stats logging for bulk cache lookups and updating the log format for consistency. The cache_stats logs now use hit_count/miss_count/total_count for easier aggregation in dashboards. 

Adds proper OpenTelemetry span instrumentation to cachedBulkLookup() so bulk cache operations create their own traced spans. This enables full visibility into cache performance across both single and bulk operations.

All cache statistics are now logged at info level for Better Stack integration, allowing dashboard queries to track cache hit rates, latencies, and error rates per namespace.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cache_stats logging and OpenTelemetry tracing to bulk cache lookups, and standardizes log format to hit_count/miss_count/total_count. This improves observability and enables Better Stack dashboards to track hit rates, latency, and errors across single and bulk operations.

- **New Features**
  - Emit cache_stats at info level for bulk operations with hit_count, miss_count, total_count, and latency_ms.
  - Instrument cachedBulkLookup() with a dedicated CLIENT span, attributes, duration, and error status.
  - Update single-operation logs to the new count-based schema.

- **Refactors**
  - Extract cachedBulkLookupImpl for cleaner span wrapping and separation of concerns.

<sup>Written for commit dd3020aa82191bef48bd25bbee1375f2567102aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cache operation monitoring and logging capabilities with improved telemetry for bulk lookups, including detailed metrics and error tracking to support better performance insights.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->