### PR TITLE
[rm-load-billing-prop]  flowglad hook data public routes

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,3 +8,4 @@ export type {
 export { useBilling } from './FlowgladContext'
 export { FlowgladProvider } from './FlowgladProvider'
 export { humanReadableCurrencyAmount } from './lib/utils'
+export type { FlowgladError, FlowgladHookData } from './types'

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -2,6 +2,20 @@ import type Flowglad from '@flowglad/node'
 
 import type { Subscription } from '@flowglad/shared'
 
+export interface FlowgladError {
+  message: string
+  status?: number
+  code?: string
+}
+
+export interface FlowgladHookData<TData, TRefetchParams = void> {
+  data: TData | null
+  isPending: boolean
+  isRefetching: boolean
+  error: FlowgladError | null
+  refetch: (params?: TRefetchParams) => void
+}
+
 export type SubscriptionCardSubscription = Pick<
   Subscription,
   | 'id'

--- a/packages/server/src/requestHandler.test.ts
+++ b/packages/server/src/requestHandler.test.ts
@@ -1,0 +1,177 @@
+import { FlowgladActionKey, HTTPMethod } from '@flowglad/shared'
+import { describe, expect, it, vi } from 'vitest'
+import type { FlowgladServer } from './FlowgladServer'
+import type { FlowgladServerAdmin } from './FlowgladServerAdmin'
+import { requestHandler } from './requestHandler'
+
+describe('requestHandler public route handling', () => {
+  const createMockFlowgladServer = () =>
+    ({
+      getBilling: async () => ({}),
+    }) as unknown as FlowgladServer
+
+  it('returns status 501 with error message when pricing endpoint called without flowgladAdmin configured', async () => {
+    const handler = requestHandler({
+      getCustomerExternalId: async () => 'user_1',
+      flowglad: () => createMockFlowgladServer(),
+    })
+
+    const response = await handler(
+      {
+        path: ['pricing-models', 'default'],
+        method: HTTPMethod.GET,
+      },
+      {}
+    )
+
+    expect(response.status).toBe(501)
+    expect(response.error).toEqual({
+      message: 'Public routes require flowgladAdmin option',
+    })
+  })
+
+  it('does not call getCustomerExternalId when flowgladAdmin provided and public route requested', async () => {
+    const getCustomerExternalId = vi.fn()
+    const mockAdmin = {
+      getDefaultPricingModel: async () => ({
+        pricingModel: { id: 'pm_1' },
+      }),
+    } as unknown as FlowgladServerAdmin
+
+    const handler = requestHandler({
+      getCustomerExternalId,
+      flowglad: () => createMockFlowgladServer(),
+      flowgladAdmin: () => mockAdmin,
+    })
+
+    await handler(
+      {
+        path: ['pricing-models', 'default'],
+        method: HTTPMethod.GET,
+      },
+      {}
+    )
+
+    expect(getCustomerExternalId).not.toHaveBeenCalled()
+  })
+
+  it('returns pricing model data when flowgladAdmin is provided', async () => {
+    const mockPricingModel = {
+      pricingModel: {
+        id: 'pm_1',
+        name: 'Pro Plan',
+        prices: [{ id: 'price_1', unitAmount: 999 }],
+      },
+    }
+    const mockAdmin = {
+      getDefaultPricingModel: async () => mockPricingModel,
+    } as unknown as FlowgladServerAdmin
+
+    const handler = requestHandler({
+      getCustomerExternalId: async () => 'user_1',
+      flowglad: () => createMockFlowgladServer(),
+      flowgladAdmin: () => mockAdmin,
+    })
+
+    const response = await handler(
+      {
+        path: ['pricing-models', 'default'],
+        method: HTTPMethod.GET,
+      },
+      {}
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.data).toEqual(mockPricingModel)
+  })
+
+  it('calls getCustomerExternalId for non-public routes', async () => {
+    const getCustomerExternalId = vi.fn().mockResolvedValue('user_1')
+    const mockFlowglad = {
+      getBilling: async () => ({ billing: {} }),
+    } as unknown as FlowgladServer
+
+    const handler = requestHandler({
+      getCustomerExternalId,
+      flowglad: () => mockFlowglad,
+    })
+
+    await handler(
+      {
+        path: ['customers', 'billing'],
+        method: HTTPMethod.POST,
+      },
+      {}
+    )
+
+    expect(getCustomerExternalId).toHaveBeenCalled()
+  })
+
+  it('returns 404 for invalid action key', async () => {
+    const handler = requestHandler({
+      getCustomerExternalId: async () => 'user_1',
+      flowglad: () => createMockFlowgladServer(),
+    })
+
+    const response = await handler(
+      {
+        path: ['invalid', 'route'],
+        method: HTTPMethod.GET,
+      },
+      {}
+    )
+
+    expect(response.status).toBe(404)
+    expect(response.error).toEqual({
+      message: '"invalid/route" is not a valid Flowglad API path',
+    })
+  })
+
+  it('calls beforeRequest and afterRequest hooks for public routes', async () => {
+    const beforeRequest = vi.fn()
+    const afterRequest = vi.fn()
+    const mockAdmin = {
+      getDefaultPricingModel: async () => ({
+        pricingModel: { id: 'pm_1' },
+      }),
+    } as unknown as FlowgladServerAdmin
+
+    const handler = requestHandler({
+      getCustomerExternalId: async () => 'user_1',
+      flowglad: () => createMockFlowgladServer(),
+      flowgladAdmin: () => mockAdmin,
+      beforeRequest,
+      afterRequest,
+    })
+
+    await handler(
+      {
+        path: ['pricing-models', 'default'],
+        method: HTTPMethod.GET,
+      },
+      {}
+    )
+
+    expect(beforeRequest).toHaveBeenCalled()
+    expect(afterRequest).toHaveBeenCalled()
+  })
+
+  it('calls onError when error occurs', async () => {
+    const onError = vi.fn()
+    const handler = requestHandler({
+      getCustomerExternalId: async () => 'user_1',
+      flowglad: () => createMockFlowgladServer(),
+      onError,
+    })
+
+    await handler(
+      {
+        path: ['invalid', 'route'],
+        method: HTTPMethod.GET,
+      },
+      {}
+    )
+
+    expect(onError).toHaveBeenCalled()
+  })
+})

--- a/packages/server/src/requestHandler.ts
+++ b/packages/server/src/requestHandler.ts
@@ -1,6 +1,14 @@
-import { FlowgladActionKey, type HTTPMethod } from '@flowglad/shared'
+import {
+  FlowgladActionKey,
+  type HTTPMethod,
+  isPublicActionKey,
+} from '@flowglad/shared'
 import type { FlowgladServer } from './FlowgladServer'
-import { routeToHandlerMap } from './subrouteHandlers'
+import type { FlowgladServerAdmin } from './FlowgladServerAdmin'
+import {
+  publicRouteToHandlerMap,
+  routeToHandlerMap,
+} from './subrouteHandlers'
 import type { SubRouteHandler } from './subrouteHandlers/types'
 
 /**
@@ -64,6 +72,14 @@ export interface RequestHandlerOptions<TRequest> {
     customerExternalId: string
   ) => Promise<FlowgladServer> | FlowgladServer
   /**
+   * Optional function that creates a FlowgladServerAdmin instance.
+   * Required for public routes (e.g., pricing endpoints) that don't require authentication.
+   * If not provided, public routes will return 501 Not Implemented.
+   *
+   * @returns A FlowgladServerAdmin instance
+   */
+  flowgladAdmin?: () => FlowgladServerAdmin
+  /**
    * Function to run when an error occurs during request handling.
    */
   onError?: (error: unknown) => void
@@ -98,6 +114,7 @@ export const requestHandler = <TRequest = unknown>(
   const {
     getCustomerExternalId,
     flowglad,
+    flowgladAdmin,
     onError,
     beforeRequest,
     afterRequest,
@@ -112,9 +129,6 @@ export const requestHandler = <TRequest = unknown>(
         await beforeRequest()
       }
 
-      const customerExternalId = await getCustomerExternalId(request)
-      const flowgladServer = await flowglad(customerExternalId)
-
       const joinedPath = input.path.join('/') as FlowgladActionKey
 
       if (!Object.values(FlowgladActionKey).includes(joinedPath)) {
@@ -124,7 +138,44 @@ export const requestHandler = <TRequest = unknown>(
         )
       }
 
-      const handler = routeToHandlerMap[joinedPath]
+      // Handle public routes before auth check
+      if (isPublicActionKey(joinedPath)) {
+        if (!flowgladAdmin) {
+          throw new RequestHandlerError(
+            'Public routes require flowgladAdmin option',
+            501
+          )
+        }
+        const admin = flowgladAdmin()
+        const publicHandler =
+          publicRouteToHandlerMap[
+            joinedPath as keyof typeof publicRouteToHandlerMap
+          ]
+        const data = input.method === 'GET' ? input.query : input.body
+        const result = await publicHandler(
+          { method: input.method, data },
+          admin
+        )
+
+        if (afterRequest) {
+          await afterRequest()
+        }
+
+        return {
+          status: result.status,
+          data: result.data,
+          error: result.error,
+        }
+      }
+
+      // Authenticated routes
+      const customerExternalId = await getCustomerExternalId(request)
+      const flowgladServer = await flowglad(customerExternalId)
+
+      const handler =
+        routeToHandlerMap[
+          joinedPath as keyof typeof routeToHandlerMap
+        ]
       if (!handler) {
         throw new RequestHandlerError(
           `"${joinedPath}" is not a valid Flowglad API path`,
@@ -138,7 +189,12 @@ export const requestHandler = <TRequest = unknown>(
       // of joinedPath to a specific FlowgladActionKey at compile time, even though
       // we've validated it at runtime
       const result = await (
-        handler as SubRouteHandler<typeof joinedPath>
+        handler as SubRouteHandler<
+          Exclude<
+            FlowgladActionKey,
+            FlowgladActionKey.GetDefaultPricingModel
+          >
+        >
       )(
         {
           method: input.method as any,

--- a/packages/server/src/subrouteHandlers/index.ts
+++ b/packages/server/src/subrouteHandlers/index.ts
@@ -9,6 +9,7 @@ import {
   getCustomerBilling,
   updateCustomer,
 } from './customerHandlers'
+import { getDefaultPricingModel } from './pricingHandlers'
 import {
   adjustSubscription,
   cancelSubscription,
@@ -18,7 +19,10 @@ import type { SubRouteHandler } from './types'
 import { createUsageEvent } from './usageEventHandlers'
 
 export const routeToHandlerMap: {
-  [K in FlowgladActionKey]: SubRouteHandler<K>
+  [K in Exclude<
+    FlowgladActionKey,
+    FlowgladActionKey.GetDefaultPricingModel
+  >]: SubRouteHandler<K>
 } = {
   [FlowgladActionKey.GetCustomerBilling]: getCustomerBilling,
   [FlowgladActionKey.FindOrCreateCustomer]: findOrCreateCustomer,
@@ -42,4 +46,12 @@ export const routeToHandlerMap: {
     }
   },
   [FlowgladActionKey.CreateUsageEvent]: createUsageEvent,
+}
+
+/**
+ * Map of public routes to their handlers.
+ * These routes don't require authentication and use FlowgladServerAdmin.
+ */
+export const publicRouteToHandlerMap = {
+  [FlowgladActionKey.GetDefaultPricingModel]: getDefaultPricingModel,
 }

--- a/packages/server/src/subrouteHandlers/pricingHandlers.test.ts
+++ b/packages/server/src/subrouteHandlers/pricingHandlers.test.ts
@@ -1,0 +1,79 @@
+import { HTTPMethod } from '@flowglad/shared'
+import { describe, expect, it } from 'vitest'
+import type { FlowgladServerAdmin } from '../FlowgladServerAdmin'
+import { getDefaultPricingModel } from './pricingHandlers'
+
+describe('getDefaultPricingModel handler', () => {
+  it('returns status 200 with pricingModel when admin.getDefaultPricingModel() resolves successfully', async () => {
+    const mockPricingModelResponse = {
+      pricingModel: {
+        id: 'pm_123',
+        name: 'Pro Plan',
+        prices: [{ id: 'price_1', unitAmount: 1000 }],
+      },
+    }
+    const mockAdmin = {
+      getDefaultPricingModel: async () => mockPricingModelResponse,
+    } as unknown as FlowgladServerAdmin
+
+    const result = await getDefaultPricingModel(
+      { method: HTTPMethod.GET, data: {} },
+      mockAdmin
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.data).toEqual(mockPricingModelResponse)
+    expect(result.error).toBeUndefined()
+  })
+
+  it('returns status 405 when method is not GET', async () => {
+    const mockAdmin = {
+      getDefaultPricingModel: async () => ({ pricingModel: {} }),
+    } as unknown as FlowgladServerAdmin
+
+    const result = await getDefaultPricingModel(
+      { method: HTTPMethod.POST, data: {} },
+      mockAdmin
+    )
+
+    expect(result.status).toBe(405)
+    expect(result.data).toEqual({})
+    expect(result.error).toEqual({ message: 'Method not allowed' })
+  })
+
+  it('returns status 500 with error.message containing original error text when admin.getDefaultPricingModel() throws an Error', async () => {
+    const mockAdmin = {
+      getDefaultPricingModel: async () => {
+        throw new Error('Database connection failed')
+      },
+    } as unknown as FlowgladServerAdmin
+
+    const result = await getDefaultPricingModel(
+      { method: HTTPMethod.GET, data: {} },
+      mockAdmin
+    )
+
+    expect(result.status).toBe(500)
+    expect(result.data).toEqual({})
+    expect(result.error?.message).toBe('Database connection failed')
+  })
+
+  it('returns status 500 with generic error message when admin.getDefaultPricingModel() throws non-Error value', async () => {
+    const mockAdmin = {
+      getDefaultPricingModel: async () => {
+        throw 'string error'
+      },
+    } as unknown as FlowgladServerAdmin
+
+    const result = await getDefaultPricingModel(
+      { method: HTTPMethod.GET, data: {} },
+      mockAdmin
+    )
+
+    expect(result.status).toBe(500)
+    expect(result.data).toEqual({})
+    expect(result.error?.message).toBe(
+      'Failed to fetch default pricing model'
+    )
+  })
+})

--- a/packages/server/src/subrouteHandlers/pricingHandlers.ts
+++ b/packages/server/src/subrouteHandlers/pricingHandlers.ts
@@ -1,0 +1,62 @@
+import type { Flowglad as FlowgladNode } from '@flowglad/node'
+import { HTTPMethod } from '@flowglad/shared'
+import type { FlowgladServerAdmin } from '../FlowgladServerAdmin'
+
+type PricingModelRetrieveDefaultResponse =
+  FlowgladNode.PricingModels.PricingModelRetrieveDefaultResponse
+
+export interface PublicRouteHandlerParams {
+  method: HTTPMethod
+  data: unknown
+}
+
+export interface PublicRouteHandlerResult {
+  data: PricingModelRetrieveDefaultResponse | Record<string, never>
+  status: number
+  error?: {
+    message: string
+  }
+}
+
+/**
+ * Handler for fetching the default pricing model.
+ * This is a public route that doesn't require authentication.
+ *
+ * @param params - The request parameters containing method and data
+ * @param admin - The FlowgladServerAdmin instance
+ * @returns The pricing model response or error
+ */
+export const getDefaultPricingModel = async (
+  params: PublicRouteHandlerParams,
+  admin: FlowgladServerAdmin
+): Promise<PublicRouteHandlerResult> => {
+  if (params.method !== HTTPMethod.GET) {
+    return {
+      data: {},
+      status: 405,
+      error: {
+        message: 'Method not allowed',
+      },
+    }
+  }
+
+  try {
+    const pricingModel = await admin.getDefaultPricingModel()
+    return {
+      data: pricingModel,
+      status: 200,
+    }
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error
+        ? error.message
+        : 'Failed to fetch default pricing model'
+    return {
+      data: {},
+      status: 500,
+      error: {
+        message: errorMessage,
+      },
+    }
+  }
+}

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -465,4 +465,23 @@ export const flowgladActionValidators = {
     method: HTTPMethod.POST,
     inputValidator: clientCreateUsageEventSchema,
   },
+  [FlowgladActionKey.GetDefaultPricingModel]: {
+    method: HTTPMethod.GET,
+    inputValidator: z.object({}),
+  },
 } as const satisfies FlowgladActionValidatorMap
+
+/**
+ * Set of action keys that are public and don't require authentication.
+ */
+export const publicActionKeys: Set<FlowgladActionKey> = new Set([
+  FlowgladActionKey.GetDefaultPricingModel,
+])
+
+/**
+ * Type guard to check if an action key is a public route.
+ * @param key - The action key to check
+ * @returns True if the action key is a public route
+ */
+export const isPublicActionKey = (key: FlowgladActionKey): boolean =>
+  publicActionKeys.has(key)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,6 +23,8 @@ export {
   createSubscriptionSchema,
   createUsageEventSchema,
   flowgladActionValidators,
+  isPublicActionKey,
+  publicActionKeys,
   subscriptionAdjustmentTiming,
   terseSubscriptionItemSchema,
   uncancelSubscriptionSchema,

--- a/packages/shared/src/types/sdk.ts
+++ b/packages/shared/src/types/sdk.ts
@@ -13,6 +13,7 @@ export enum FlowgladActionKey {
   CreateSubscription = 'subscriptions/create',
   UpdateCustomer = 'customers/update',
   CreateUsageEvent = 'usage-events/create',
+  GetDefaultPricingModel = 'pricing-models/default',
 }
 
 export enum HTTPMethod {


### PR DESCRIPTION
## What Does this PR Do?
This PR introduces the `FlowgladHookData` type to standardize hook return signatures, improving developer experience. It also establishes server-side infrastructure for public routes, allowing unauthenticated access to specific endpoints like pricing models. This addresses the problem where all routes previously required authentication, even for public data.

---
<a href="https://cursor.com/background-agent?bcId=bc-913ea766-8a1e-4085-b3f1-af21d43484a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-913ea766-8a1e-4085-b3f1-af21d43484a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standard FlowgladHookData type for React hooks and introduces public route support, including a GET /pricing-models/default endpoint that works without auth when flowgladAdmin is configured. This enables public pricing pages and simplifies hook return types.

- New Features
  - React: export FlowgladHookData<TData, TRefetchParams> and FlowgladError.
  - Shared: add FlowgladActionKey.GetDefaultPricingModel (GET), publicActionKeys, and isPublicActionKey.
  - Server: requestHandler handles public routes before auth, adds flowgladAdmin option, and a publicRouteToHandlerMap with getDefaultPricingModel.

- Migration
  - To serve pricing publicly, pass flowgladAdmin to requestHandler; without it, the endpoint returns 501.
  - Use GET /pricing-models/default to fetch the default pricing model.
  - Import FlowgladHookData and FlowgladError from @flowglad/react.

<sup>Written for commit 40431a03444e4f6865a55c7050e0ff8088dfcd3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public endpoint for retrieving default pricing models without authentication.
  * Extended TypeScript type exports to include `FlowgladError` and `FlowgladHookData` for improved type safety in integrations.
  * Added support for per-request admin configuration to handle public routes.

* **Tests**
  * Added comprehensive test coverage for public route handling and pricing model retrieval scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->