### PR TITLE
fix: Add missing EditResourceModal to pricing model details page

### DIFF
--- a/platform/flowglad-next/src/app/pricing-models/[id]/InnerPricingModelDetailsPage.tsx
+++ b/platform/flowglad-next/src/app/pricing-models/[id]/InnerPricingModelDetailsPage.tsx
@@ -15,6 +15,7 @@ import { ResourcesDataTable } from '@/app/resources/data-table'
 import { UsageMetersDataTable } from '@/app/usage-meters/data-table'
 import CreateResourceModal from '@/components/components/CreateResourceModal'
 import CreateUsageMeterModal from '@/components/components/CreateUsageMeterModal'
+import EditResourceModal from '@/components/components/EditResourceModal'
 import { ExpandSection } from '@/components/ExpandSection'
 import { FeaturesDataTable } from '@/components/features/data-table'
 import ClonePricingModelModal from '@/components/forms/ClonePricingModelModal'
@@ -38,6 +39,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover'
 import type { PricingModel } from '@/db/schema/pricingModels'
+import type { Resource } from '@/db/schema/resources'
 
 export type InnerPricingModelDetailsPageProps = {
   pricingModel: PricingModel.ClientRecord
@@ -67,6 +69,10 @@ function InnerPricingModelDetailsPage({
   ] = useState(false)
   const [isCreateResourceModalOpen, setIsCreateResourceModalOpen] =
     useState(false)
+  const [isEditResourceModalOpen, setIsEditResourceModalOpen] =
+    useState(false)
+  const [resourceToEdit, setResourceToEdit] =
+    useState<Resource.ClientRecord | null>(null)
   const [activeProductFilter, setActiveProductFilter] =
     useState<string>('active')
   const [activeFeatureFilter, setActiveFeatureFilter] =
@@ -304,6 +310,10 @@ function InnerPricingModelDetailsPage({
             onCreateResource={() =>
               setIsCreateResourceModalOpen(true)
             }
+            onEditResource={(resource) => {
+              setResourceToEdit(resource)
+              setIsEditResourceModalOpen(true)
+            }}
             buttonVariant="secondary"
           />
         </ExpandSection>
@@ -355,6 +365,13 @@ function InnerPricingModelDetailsPage({
         defaultPricingModelId={pricingModel.id}
         hidePricingModelSelect={true}
       />
+      {resourceToEdit && (
+        <EditResourceModal
+          isOpen={isEditResourceModalOpen}
+          setIsOpen={setIsEditResourceModalOpen}
+          resource={resourceToEdit}
+        />
+      )}
       <PricingModelIntegrationGuideModal
         isOpen={isGetIntegrationGuideModalOpen}
         setIsOpen={setIsGetIntegrationGuideModalOpen}


### PR DESCRIPTION
## What Does this PR Do?

Fixes the non-functional edit button for resources in the pricing model details page. The EditResourceModal component was missing from the page, and the edit handler wasn't wired up to the ResourcesDataTable. Now users can successfully edit resources.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken Edit button for resources on the pricing model details page by adding the EditResourceModal and wiring up the edit handler. Users can now open the modal and edit a resource.

- **Bug Fixes**
  - Rendered EditResourceModal and toggled it with isEditResourceModalOpen.
  - Tracked selected resource with resourceToEdit and connected onEditResource in ResourcesDataTable.

<sup>Written for commit 4959a46168bc19845537c4f6ec223223142533cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource editing now available - users can select and edit resource details through a dedicated modal interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->