### PR TITLE
chore: Raise cache invalidation logging to info level

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@flowglad/javascript",

--- a/platform/flowglad-next/src/utils/cache.ts
+++ b/platform/flowglad-next/src/utils/cache.ts
@@ -605,9 +605,10 @@ export async function invalidateDependencies(
       const cacheKeys = await client.smembers(registryKey)
 
       if (cacheKeys.length > 0) {
-        logger.debug('Invalidating cache keys for dependency', {
+        logger.info('cache_invalidation', {
           dependency: dep,
           cacheKeys,
+          invalidation_count: cacheKeys.length,
         })
         // Delete all the cache keys
         await client.del(...cacheKeys)


### PR DESCRIPTION
## What Does this PR Do?

Raises the log level for cache key invalidations from debug to info, improving observability of cache invalidation operations during production monitoring.

This makes it easier to track when dependencies are invalidated and which cache keys are affected without having to enable debug logging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised cache invalidation logs from debug to info and added a 'cache_invalidation' slug for easier dashboard queries. Added an invalidation_count field to support metric aggregation and make it easier to see which dependencies are invalidated and which cache keys are affected without enabling debug logs.

<sup>Written for commit 219821bf82a40fb47984a6cf45abf888cdd5ad4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved observability: standardized cache invalidation logging and increased its visibility (now logged at a higher severity) to make operational behavior easier to monitor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->