### PR TITLE
Add worktree support for Claude Code settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ playground/react-native/prisma/database.sqlite
 # Git worktrees
 .conductor
 
+# Claude Code settings (shared via .worktreeinclude, not git)
+.claude/settings.json
+
 # openapi diffing
 temp-openapi**.json
 

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,10 @@
+# Files to copy to new git worktrees (used by Claude Code desktop app)
+# These files are gitignored but should be present in each worktree
+
+# Environment variables
+.env
+.env.local
+.env.*
+
+# Claude Code settings
+.claude/settings.json


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` to `.gitignore` so permissions aren't committed
- Create `.worktreeinclude` to automatically copy settings and env files to new worktrees

This allows Claude Code permissions to be shared across git worktrees without committing them to the repository. When new worktrees are created via the Claude Code desktop app, it will copy the settings file automatically.

## Test plan
- [ ] Verify `.claude/settings.json` is ignored by git
- [ ] Create a new worktree and confirm settings are copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds worktree support for Claude Code settings so permissions can be shared across worktrees without committing them. New worktrees created via the Claude Code desktop app will auto-copy settings and env files.

- **New Features**
  - Ignore .claude/settings.json in git.
  - Add .worktreeinclude to copy .env*, .env.local, and .claude/settings.json to new worktrees.

- **Migration**
  - Use the Claude Code desktop app to create worktrees so files are auto-copied.
  - For existing worktrees, manually copy .claude/settings.json and relevant .env files once.

<sup>Written for commit fa6eb326355f0e6b3401ddcc5d67ea9e4517e440. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development environment configuration files to improve consistency across local development setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->