### PR TITLE
fix: remove account notification preferences from schema

### DIFF
--- a/platform/flowglad-next/src/db/schema/memberships.rls.test.ts
+++ b/platform/flowglad-next/src/db/schema/memberships.rls.test.ts
@@ -471,7 +471,7 @@ describe.sequential('memberships RLS - notificationPreferences', () => {
               id: org1Membership.id,
               notificationPreferences: {
                 testModeNotifications: true,
-                payoutsEnabled: false,
+                subscriptionCreated: false,
               },
             },
             transaction
@@ -496,9 +496,9 @@ describe.sequential('memberships RLS - notificationPreferences', () => {
         memberships[0]
       )
       expect(prefs.testModeNotifications).toBe(true)
-      expect(prefs.payoutsEnabled).toBe(false)
+      expect(prefs.subscriptionCreated).toBe(false)
       // Defaults should still apply for unset preferences
-      expect(prefs.subscriptionCreated).toBe(true)
+      expect(prefs.subscriptionAdjusted).toBe(true)
     })
   })
 })

--- a/platform/flowglad-next/src/db/schema/memberships.ts
+++ b/platform/flowglad-next/src/db/schema/memberships.ts
@@ -78,9 +78,9 @@ export const memberships = pgTable(
 
 /**
  * Zod schema for notification preferences stored in the JSONB column.
- * Contains 8 fields:
+ * Contains 6 fields:
  * - testModeNotifications: Controls whether test mode emails are sent (defaults to false)
- * - 7 notification type preferences: Each controls a specific notification type (all default to true)
+ * - 5 notification type preferences: Each controls a specific notification type (all default to true)
  */
 export const notificationPreferencesSchema = z.object({
   testModeNotifications: z.boolean().default(false),
@@ -89,8 +89,6 @@ export const notificationPreferencesSchema = z.object({
   subscriptionCanceled: z.boolean().default(true),
   subscriptionCancellationScheduled: z.boolean().default(true),
   paymentFailed: z.boolean().default(true),
-  onboardingCompleted: z.boolean().default(true),
-  payoutsEnabled: z.boolean().default(true),
 })
 
 export type NotificationPreferences = z.infer<

--- a/platform/flowglad-next/src/db/tableMethods/membershipMethods.notificationPreferences.test.ts
+++ b/platform/flowglad-next/src/db/tableMethods/membershipMethods.notificationPreferences.test.ts
@@ -37,14 +37,12 @@ describe('memberships notificationPreferences', () => {
           getMembershipNotificationPreferences(freshMembership)
         expect(prefs.testModeNotifications).toBe(false)
 
-        // getMembershipNotificationPreferences should return all 7 notification types as true
+        // getMembershipNotificationPreferences should return all 5 notification types as true
         expect(prefs.subscriptionCreated).toBe(true)
         expect(prefs.subscriptionAdjusted).toBe(true)
         expect(prefs.subscriptionCanceled).toBe(true)
         expect(prefs.subscriptionCancellationScheduled).toBe(true)
         expect(prefs.paymentFailed).toBe(true)
-        expect(prefs.onboardingCompleted).toBe(true)
-        expect(prefs.payoutsEnabled).toBe(true)
 
         // Verify the full shape matches defaults
         expect(prefs).toEqual(DEFAULT_NOTIFICATION_PREFERENCES)
@@ -83,13 +81,11 @@ describe('memberships notificationPreferences', () => {
         // subscriptionCreated should be false (from stored value)
         expect(prefs.subscriptionCreated).toBe(false)
 
-        // All other 6 notification type preferences should return true (from defaults)
+        // All other 4 notification type preferences should return true (from defaults)
         expect(prefs.subscriptionAdjusted).toBe(true)
         expect(prefs.subscriptionCanceled).toBe(true)
         expect(prefs.subscriptionCancellationScheduled).toBe(true)
         expect(prefs.paymentFailed).toBe(true)
-        expect(prefs.onboardingCompleted).toBe(true)
-        expect(prefs.payoutsEnabled).toBe(true)
       })
     })
 
@@ -106,14 +102,12 @@ describe('memberships notificationPreferences', () => {
         // testModeNotifications should be false (default)
         expect(prefs.testModeNotifications).toBe(false)
 
-        // All 7 notification type preferences should be true (defaults)
+        // All 5 notification type preferences should be true (defaults)
         expect(prefs.subscriptionCreated).toBe(true)
         expect(prefs.subscriptionAdjusted).toBe(true)
         expect(prefs.subscriptionCanceled).toBe(true)
         expect(prefs.subscriptionCancellationScheduled).toBe(true)
         expect(prefs.paymentFailed).toBe(true)
-        expect(prefs.onboardingCompleted).toBe(true)
-        expect(prefs.payoutsEnabled).toBe(true)
       })
     })
 
@@ -146,12 +140,10 @@ describe('memberships notificationPreferences', () => {
         expect(prefs.subscriptionCreated).toBe(false)
         expect(prefs.paymentFailed).toBe(false)
 
-        // All 5 other notification types should be true (defaults)
+        // All 3 other notification types should be true (defaults)
         expect(prefs.subscriptionAdjusted).toBe(true)
         expect(prefs.subscriptionCanceled).toBe(true)
         expect(prefs.subscriptionCancellationScheduled).toBe(true)
-        expect(prefs.onboardingCompleted).toBe(true)
-        expect(prefs.payoutsEnabled).toBe(true)
       })
     })
 
@@ -176,8 +168,6 @@ describe('memberships notificationPreferences', () => {
       expect(result.subscriptionCanceled).toBe(true)
       expect(result.subscriptionCancellationScheduled).toBe(true)
       expect(result.paymentFailed).toBe(true)
-      expect(result.onboardingCompleted).toBe(true)
-      expect(result.payoutsEnabled).toBe(true)
     })
 
     it('DEFAULT_NOTIFICATION_PREFERENCES equals notificationPreferencesSchema.parse({})', () => {

--- a/platform/flowglad-next/src/server/routers/organizationsRouter.notificationPreferences.test.ts
+++ b/platform/flowglad-next/src/server/routers/organizationsRouter.notificationPreferences.test.ts
@@ -104,8 +104,6 @@ describe('organizationsRouter notification preferences', () => {
       expect(result.subscriptionCanceled).toBe(true)
       expect(result.subscriptionCancellationScheduled).toBe(true)
       expect(result.paymentFailed).toBe(true)
-      expect(result.onboardingCompleted).toBe(true)
-      expect(result.payoutsEnabled).toBe(true)
     })
 
     it('returns stored preferences merged with defaults', async () => {
@@ -136,8 +134,6 @@ describe('organizationsRouter notification preferences', () => {
       expect(result.subscriptionCanceled).toBe(true)
       expect(result.subscriptionCancellationScheduled).toBe(true)
       expect(result.paymentFailed).toBe(true)
-      expect(result.onboardingCompleted).toBe(true)
-      expect(result.payoutsEnabled).toBe(true)
     })
   })
 
@@ -218,8 +214,6 @@ describe('organizationsRouter notification preferences', () => {
         subscriptionCanceled: false,
         subscriptionCancellationScheduled: false,
         paymentFailed: false,
-        onboardingCompleted: false,
-        payoutsEnabled: false,
       }
 
       const result = await caller.updateNotificationPreferences({
@@ -236,8 +230,6 @@ describe('organizationsRouter notification preferences', () => {
       expect(getResult.subscriptionCanceled).toBe(false)
       expect(getResult.subscriptionCancellationScheduled).toBe(false)
       expect(getResult.paymentFailed).toBe(false)
-      expect(getResult.onboardingCompleted).toBe(false)
-      expect(getResult.payoutsEnabled).toBe(false)
     })
 
     it('handles toggling preferences back and forth', async () => {

--- a/platform/flowglad-next/src/server/routers/organizationsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/organizationsRouter.ts
@@ -491,8 +491,6 @@ const updateNotificationPreferencesInputSchema = z.object({
       subscriptionCanceled: z.boolean().optional(),
       subscriptionCancellationScheduled: z.boolean().optional(),
       paymentFailed: z.boolean().optional(),
-      onboardingCompleted: z.boolean().optional(),
-      payoutsEnabled: z.boolean().optional(),
     })
     .partial(),
 })


### PR DESCRIPTION
## What Does this PR Do?

Removes `onboardingCompleted` and `payoutsEnabled` from the notification preferences schema. These are account-level setup notifications that should not be user-configurable. Updated the Zod schema, API input validation, and all related tests accordingly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed onboardingCompleted and payoutsEnabled from user notification preferences to prevent users from toggling account-level setup notifications. Simplifies the schema and keeps setup notifications managed at the account level.

- **Refactors**
  - Removed onboardingCompleted and payoutsEnabled from the Zod schema and API input validation.
  - Updated tests and defaults; remaining 5 notification types still default to true, testModeNotifications to false.
  - Adjusted RLS and table method tests to match the new preference shape.

- **Migration**
  - No data migration required; any stored values for these fields are ignored.
  - Update clients to stop sending onboardingCompleted and payoutsEnabled when updating notification preferences.

<sup>Written for commit 507aa6f440eb56721c96b11eec32b9dcb59d16c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified notification preferences structure by removing two unused preference fields. The notification settings system now focuses on core subscription and payment event notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->