### PR TITLE
refactor: open resource APIs to authenticated users

### DIFF
--- a/platform/flowglad-next/bun.lock
+++ b/platform/flowglad-next/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "flowglad-next",
@@ -202,10 +203,10 @@
     },
   },
   "overrides": {
-    "esbuild": "0.25.0",
-    "chromium-bidi": "2.1.2",
     "@modelcontextprotocol/sdk": "1.23.0-beta.0",
     "@react-email/render": "0.0.17",
+    "chromium-bidi": "2.1.2",
+    "esbuild": "0.25.0",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],

--- a/platform/flowglad-next/src/server/routers/resourceClaimsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/resourceClaimsRouter.ts
@@ -19,7 +19,7 @@ import {
   releaseResourceInputSchema,
   releaseResourceTransaction,
 } from '@/resources/resourceClaimHelpers'
-import { devOnlyProcedure, router } from '@/server/trpc'
+import { protectedProcedure, router } from '@/server/trpc'
 import { FeatureType } from '@/types'
 import { trpcToRest } from '@/utils/openapi'
 
@@ -152,7 +152,7 @@ async function validateSubscriptionOwnership(
   return { subscription, customerId: subscription.customerId }
 }
 
-const claimProcedure = devOnlyProcedure
+const claimProcedure = protectedProcedure
   .meta({
     openapi: {
       method: 'POST',
@@ -189,7 +189,7 @@ const claimProcedure = devOnlyProcedure
     )
   )
 
-const releaseProcedure = devOnlyProcedure
+const releaseProcedure = protectedProcedure
   .meta({
     openapi: {
       method: 'POST',
@@ -226,7 +226,7 @@ const releaseProcedure = devOnlyProcedure
     )
   )
 
-const getUsageProcedure = devOnlyProcedure
+const getUsageProcedure = protectedProcedure
   .meta({
     openapi: {
       method: 'GET',
@@ -376,7 +376,7 @@ const getUsageProcedure = devOnlyProcedure
     )
   )
 
-const listClaimsProcedure = devOnlyProcedure
+const listClaimsProcedure = protectedProcedure
   .meta({
     openapi: {
       method: 'GET',

--- a/platform/flowglad-next/src/server/routers/resourcesRouter.ts
+++ b/platform/flowglad-next/src/server/routers/resourcesRouter.ts
@@ -25,7 +25,7 @@ import {
   createPaginatedTableRowOutputSchema,
   idInputSchema,
 } from '@/db/tableUtils'
-import { devOnlyProcedure, router } from '@/server/trpc'
+import { protectedProcedure, router } from '@/server/trpc'
 import { generateOpenApiMetas, trpcToRest } from '@/utils/openapi'
 
 const { openApiMetas, routeConfigs } = generateOpenApiMetas({
@@ -42,7 +42,7 @@ const resourcesPaginatedListSchema = createPaginatedListQuerySchema(
   resourcesClientSelectSchema
 )
 
-const listProcedure = devOnlyProcedure
+const listProcedure = protectedProcedure
   .meta(openApiMetas.LIST)
   .input(z.object({ pricingModelId: z.string() }))
   .output(
@@ -64,7 +64,7 @@ const listProcedure = devOnlyProcedure
     )
   )
 
-const getProcedure = devOnlyProcedure
+const getProcedure = protectedProcedure
   .meta(openApiMetas.GET)
   .input(idInputSchema)
   .output(z.object({ resource: resourcesClientSelectSchema }))
@@ -80,7 +80,7 @@ const getProcedure = devOnlyProcedure
     )
   )
 
-const createProcedure = devOnlyProcedure
+const createProcedure = protectedProcedure
   .meta(openApiMetas.POST)
   .input(createResourceSchema)
   .output(z.object({ resource: resourcesClientSelectSchema }))
@@ -108,7 +108,7 @@ const createProcedure = devOnlyProcedure
     )
   )
 
-const updateProcedure = devOnlyProcedure
+const updateProcedure = protectedProcedure
   .meta(openApiMetas.PUT)
   .input(editResourceSchema)
   .output(z.object({ resource: resourcesClientSelectSchema }))
@@ -127,7 +127,7 @@ const updateProcedure = devOnlyProcedure
     )
   )
 
-const listPaginatedProcedure = devOnlyProcedure
+const listPaginatedProcedure = protectedProcedure
   .input(resourcesPaginatedSelectSchema)
   .output(resourcesPaginatedListSchema)
   .query(async ({ input, ctx }) => {
@@ -141,7 +141,7 @@ const listPaginatedProcedure = devOnlyProcedure
     )
   })
 
-const getTableRowsProcedure = devOnlyProcedure
+const getTableRowsProcedure = protectedProcedure
   .input(
     createPaginatedTableRowInputSchema(
       z.object({


### PR DESCRIPTION
## What Does this PR Do?

Removes dev-only gating from resource and resource claims endpoints to allow authenticated users to create and manage resources in production. All resource endpoints have been changed from `devOnlyProcedure` to `protectedProcedure`, making the feature available to any authenticated organization member.

Affected endpoints:
- Resources: list, get, create, update, listPaginated, getTableRows
- Resource Claims: claim, release, getUsage, listClaims

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens resource and claim APIs to authenticated org members in production by switching routes from dev-only to protected. Users can now list, create, update, claim, and release resources in prod.

- New Features
  - Resources: list, get, create, update, listPaginated, getTableRows now require authentication (protectedProcedure).
  - Resource Claims: claim, release, getUsage, listClaims now require authentication (protectedProcedure).

<sup>Written for commit 7cee1b849883a83cf1cf669a7c3deb40850fd8cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication and authorization requirements for resource management operations to enforce proper access controls instead of development-only restrictions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->