### PR TITLE
chore(ui): disable resource UI while features are gated behind devOnlyProcedure

### DIFF
--- a/platform/flowglad-next/bun.lock
+++ b/platform/flowglad-next/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "flowglad-next",
@@ -202,10 +203,10 @@
     },
   },
   "overrides": {
-    "esbuild": "0.25.0",
-    "chromium-bidi": "2.1.2",
     "@modelcontextprotocol/sdk": "1.23.0-beta.0",
     "@react-email/render": "0.0.17",
+    "chromium-bidi": "2.1.2",
+    "esbuild": "0.25.0",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],

--- a/platform/flowglad-next/src/app/finance/subscriptions/[id]/InnerSubscriptionPage.tsx
+++ b/platform/flowglad-next/src/app/finance/subscriptions/[id]/InnerSubscriptionPage.tsx
@@ -10,7 +10,8 @@ import CancelSubscriptionModal from '@/components/forms/CancelSubscriptionModal'
 import { ItemFeature } from '@/components/ItemFeature'
 import PageContainer from '@/components/PageContainer'
 import { ProductCard } from '@/components/ProductCard'
-import { SubscriptionResourceUsage } from '@/components/subscriptions/SubscriptionResourceUsage'
+// FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
+// import { SubscriptionResourceUsage } from '@/components/subscriptions/SubscriptionResourceUsage'
 import { CopyableField } from '@/components/ui/copyable-field'
 import { PageHeaderNew } from '@/components/ui/page-header-new'
 import {
@@ -273,11 +274,13 @@ const InnerSubscriptionPage = ({
             )}
           </div>
         </ExpandSection>
+        {/* FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
         <ExpandSection title="Resource Usage" defaultExpanded={false}>
           <SubscriptionResourceUsage
             subscriptionId={subscription.id}
           />
         </ExpandSection>
+        */}
         <BillingHistorySection
           subscriptionId={subscription.id}
           customerId={subscription.customerId}

--- a/platform/flowglad-next/src/app/pricing-models/[id]/InnerPricingModelDetailsPage.tsx
+++ b/platform/flowglad-next/src/app/pricing-models/[id]/InnerPricingModelDetailsPage.tsx
@@ -11,11 +11,14 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 import { trpc } from '@/app/_trpc/client'
 import { CustomersDataTable } from '@/app/customers/data-table'
-import { ResourcesDataTable } from '@/app/resources/data-table'
+// FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
+// import { ResourcesDataTable } from '@/app/resources/data-table'
 import { UsageMetersDataTable } from '@/app/usage-meters/data-table'
-import CreateResourceModal from '@/components/components/CreateResourceModal'
+// FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
+// import CreateResourceModal from '@/components/components/CreateResourceModal'
 import CreateUsageMeterModal from '@/components/components/CreateUsageMeterModal'
-import EditResourceModal from '@/components/components/EditResourceModal'
+// FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
+// import EditResourceModal from '@/components/components/EditResourceModal'
 import { ExpandSection } from '@/components/ExpandSection'
 import { FeaturesDataTable } from '@/components/features/data-table'
 import ClonePricingModelModal from '@/components/forms/ClonePricingModelModal'
@@ -39,7 +42,8 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover'
 import type { PricingModel } from '@/db/schema/pricingModels'
-import type { Resource } from '@/db/schema/resources'
+// FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
+// import type { Resource } from '@/db/schema/resources'
 
 export type InnerPricingModelDetailsPageProps = {
   pricingModel: PricingModel.ClientRecord
@@ -67,12 +71,13 @@ function InnerPricingModelDetailsPage({
     isCreateUsageMeterModalOpen,
     setIsCreateUsageMeterModalOpen,
   ] = useState(false)
-  const [isCreateResourceModalOpen, setIsCreateResourceModalOpen] =
-    useState(false)
-  const [isEditResourceModalOpen, setIsEditResourceModalOpen] =
-    useState(false)
-  const [resourceToEdit, setResourceToEdit] =
-    useState<Resource.ClientRecord | null>(null)
+  // FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
+  // const [isCreateResourceModalOpen, setIsCreateResourceModalOpen] =
+  //   useState(false)
+  // const [isEditResourceModalOpen, setIsEditResourceModalOpen] =
+  //   useState(false)
+  // const [resourceToEdit, setResourceToEdit] =
+  //   useState<Resource.ClientRecord | null>(null)
   const [activeProductFilter, setActiveProductFilter] =
     useState<string>('active')
   const [activeFeatureFilter, setActiveFeatureFilter] =
@@ -300,6 +305,7 @@ function InnerPricingModelDetailsPage({
             buttonVariant="secondary"
           />
         </ExpandSection>
+        {/* FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
         <ExpandSection
           title="Resources"
           defaultExpanded={false}
@@ -317,6 +323,7 @@ function InnerPricingModelDetailsPage({
             buttonVariant="secondary"
           />
         </ExpandSection>
+        */}
         <ExpandSection
           title="Customers"
           defaultExpanded={false}
@@ -359,6 +366,7 @@ function InnerPricingModelDetailsPage({
         defaultPricingModelId={pricingModel.id}
         hidePricingModelSelect={true}
       />
+      {/* FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
       <CreateResourceModal
         isOpen={isCreateResourceModalOpen}
         setIsOpen={setIsCreateResourceModalOpen}
@@ -372,6 +380,7 @@ function InnerPricingModelDetailsPage({
           resource={resourceToEdit}
         />
       )}
+      */}
       <PricingModelIntegrationGuideModal
         isOpen={isGetIntegrationGuideModalOpen}
         setIsOpen={setIsGetIntegrationGuideModalOpen}

--- a/platform/flowglad-next/src/components/forms/FeatureFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/FeatureFormFields.tsx
@@ -22,13 +22,15 @@ import {
 import { Switch } from '@/components/ui/switch'
 import {
   type CreateFeatureInput,
-  resourceFeatureDefaultColumns,
+  // FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
+  // resourceFeatureDefaultColumns,
   toggleFeatureDefaultColumns,
   usageCreditGrantFeatureDefaultColumns,
 } from '@/db/schema/features'
 import { FeatureType, FeatureUsageGrantFrequency } from '@/types'
 import core, { titleCase } from '@/utils/core'
-import ResourcesSelect from './ResourcesSelect'
+// FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
+// import ResourcesSelect from './ResourcesSelect'
 import UsageMetersSelect from './UsageMetersSelect'
 
 const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
@@ -121,11 +123,12 @@ const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
                       usageCreditGrantFeatureDefaultColumns
                     ).forEach(assignFeatureValueFromTuple)
                   }
-                  if (value === FeatureType.Resource) {
-                    Object.entries(
-                      resourceFeatureDefaultColumns
-                    ).forEach(assignFeatureValueFromTuple)
-                  }
+                  // FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
+                  // if (value === FeatureType.Resource) {
+                  //   Object.entries(
+                  //     resourceFeatureDefaultColumns
+                  //   ).forEach(assignFeatureValueFromTuple)
+                  // }
                 }}
               >
                 <SelectTrigger>
@@ -148,6 +151,7 @@ const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
                       </div>
                     </div>
                   </SelectItem>
+                  {/* FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
                   <SelectItem value={FeatureType.Resource}>
                     <div>
                       <div>Resource</div>
@@ -156,6 +160,7 @@ const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
                       </div>
                     </div>
                   </SelectItem>
+                  */}
                 </SelectContent>
               </Select>
             </FormControl>
@@ -233,6 +238,7 @@ const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
         </>
       )}
 
+      {/* FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
       {featureType === FeatureType.Resource && (
         <>
           <FormField
@@ -276,6 +282,7 @@ const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
           />
         </>
       )}
+      */}
       <Controller
         control={form.control}
         name="feature.active"


### PR DESCRIPTION
## What Does this PR Do?

Temporarily disables resource-related UI components while the resource feature is gated behind devOnlyProcedure. This includes removing the Resources section from pricing model details, hiding resource usage from subscriptions, and removing the Resource feature type from the feature creation dropdown. All changes are clearly marked with FIXME comments explaining the temporary nature of the disabling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily disables all resource-related UI while the feature is gated behind devOnlyProcedure. Removes the Resources section on pricing model details, hides resource usage on subscription pages, and removes the Resource feature type from the feature form.

<sup>Written for commit 9748aa707c4e2fea55ab0421ea6a3fb1eb147c03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled Resource-related features across subscription management, pricing configuration, and feature creation interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->