### PR TITLE
packages: upgrade flowglad/node to 0.26.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
       "name": "@flowglad/nextjs",
       "version": "0.16.2",
       "dependencies": {
-        "@flowglad/node": "0.24.0",
+        "@flowglad/node": "0.26.0",
         "@flowglad/react": "workspace:*",
         "@flowglad/server": "workspace:*",
         "@flowglad/shared": "workspace:*",
@@ -52,7 +52,7 @@
       "name": "@flowglad/react",
       "version": "0.16.2",
       "dependencies": {
-        "@flowglad/node": "0.24.0",
+        "@flowglad/node": "0.26.0",
         "@flowglad/shared": "workspace:*",
         "@tanstack/react-query": "5.66.0",
         "clsx": "2.1.1",
@@ -77,7 +77,7 @@
       "name": "@flowglad/server",
       "version": "0.16.2",
       "dependencies": {
-        "@flowglad/node": "0.24.0",
+        "@flowglad/node": "0.26.0",
         "@flowglad/shared": "workspace:*",
         "nanoid": "^3.3.11",
         "zod": "4.1.5",
@@ -103,7 +103,7 @@
       "name": "@flowglad/shared",
       "version": "0.16.2",
       "dependencies": {
-        "@flowglad/node": "0.24.0",
+        "@flowglad/node": "0.26.0",
         "date-fns": "4.1.0",
         "zod": "4.1.5",
       },
@@ -117,7 +117,7 @@
       "version": "1.0.1",
       "dependencies": {
         "@flowglad/nextjs": "workspace:*",
-        "@flowglad/node": "0.24.0",
+        "@flowglad/node": "0.26.0",
         "@flowglad/react": "workspace:*",
         "@flowglad/server": "workspace:*",
         "@flowglad/shared": "workspace:*",
@@ -639,7 +639,7 @@
 
     "@flowglad/nextjs": ["@flowglad/nextjs@workspace:packages/nextjs"],
 
-    "@flowglad/node": ["@flowglad/node@0.24.0", "", {}, "sha512-P5UhUaYNAGuCT9hLTQC34o+az4hsfMSuSGpYzg9bPQIrRnTkWvJfmyOmE+cGSlaGZCdLNnEwxCwDQr+lVeOyRw=="],
+    "@flowglad/node": ["@flowglad/node@0.26.0", "", {}, "sha512-2LRB0QImn++AIXXK6t+FzRqsa3K/nXaJcgv6JlqA9o29R0lPBlVK9phZC+iOvoQEA3/2qBQW6PLS2SDCRlPt2A=="],
 
     "@flowglad/playground-express": ["@flowglad/playground-express@workspace:playground/express"],
 

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -21,7 +21,7 @@
     "@flowglad/shared": "workspace:*",
     "@flowglad/react": "workspace:*",
     "@flowglad/server": "workspace:*",
-    "@flowglad/node": "0.24.0",
+    "@flowglad/node": "0.26.0",
     "@vercel/mcp-adapter": "0.11.1",
     "zod": "4.1.5"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,7 +17,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@flowglad/node": "0.24.0",
+    "@flowglad/node": "0.26.0",
     "@flowglad/shared": "workspace:*",
     "@tanstack/react-query": "5.66.0",
     "clsx": "2.1.1",

--- a/packages/react/src/FlowgladContext.tsx
+++ b/packages/react/src/FlowgladContext.tsx
@@ -854,6 +854,8 @@ export const FlowgladContextProvider = (
                   updatedAt: now,
                 },
                 subscriptionItems: [],
+                isUpgrade: false,
+                resolvedTiming: 'immediately',
               },
             })
           },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@flowglad/shared": "workspace:*",
-    "@flowglad/node": "0.24.0",
+    "@flowglad/node": "0.26.0",
     "nanoid": "^3.3.11",
     "zod": "4.1.5"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "zod": "4.1.5",
     "date-fns": "4.1.0",
-    "@flowglad/node": "0.24.0"
+    "@flowglad/node": "0.26.0"
   },
   "devDependencies": {
     "typescript": "5.8.2",

--- a/playground/express/package.json
+++ b/playground/express/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@flowglad/nextjs": "workspace:*",
-    "@flowglad/node": "0.24.0",
+    "@flowglad/node": "0.26.0",
     "@flowglad/react": "workspace:*",
     "@flowglad/server": "workspace:*",
     "@flowglad/shared": "workspace:*",


### PR DESCRIPTION
## What Does this PR Do?
- upgrade packages and flowglad-next to use flowglad/node 0.26.0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded the workspace to @flowglad/node 0.26.0 and updated the React context to include new subscription fields (isUpgrade, resolvedTiming) for API compatibility. Keeps Next.js, React, Server, Shared, and the Express playground aligned with 0.26.0.

- **Dependencies**
  - Bumped @flowglad/node from 0.24.0 to 0.26.0 across nextjs, react, server, shared, and playground; updated bun.lock.

<sup>Written for commit 1e5f699506cd4185810f9decb853679dc4304bc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core framework dependency across all packages to the latest stable version, improving system compatibility and stability.
  * Enhanced development-mode subscription tracking with additional metadata fields for improved debugging and observability during development.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->