### PR TITLE
Revert: open resource APIs to authenticated users

### DIFF
--- a/platform/flowglad-next/bun.lock
+++ b/platform/flowglad-next/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "flowglad-next",
@@ -203,10 +202,10 @@
     },
   },
   "overrides": {
+    "esbuild": "0.25.0",
+    "chromium-bidi": "2.1.2",
     "@modelcontextprotocol/sdk": "1.23.0-beta.0",
     "@react-email/render": "0.0.17",
-    "chromium-bidi": "2.1.2",
-    "esbuild": "0.25.0",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],

--- a/platform/flowglad-next/src/server/routers/resourceClaimsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/resourceClaimsRouter.ts
@@ -19,7 +19,7 @@ import {
   releaseResourceInputSchema,
   releaseResourceTransaction,
 } from '@/resources/resourceClaimHelpers'
-import { protectedProcedure, router } from '@/server/trpc'
+import { devOnlyProcedure, router } from '@/server/trpc'
 import { FeatureType } from '@/types'
 import { trpcToRest } from '@/utils/openapi'
 
@@ -152,7 +152,7 @@ async function validateSubscriptionOwnership(
   return { subscription, customerId: subscription.customerId }
 }
 
-const claimProcedure = protectedProcedure
+const claimProcedure = devOnlyProcedure
   .meta({
     openapi: {
       method: 'POST',
@@ -189,7 +189,7 @@ const claimProcedure = protectedProcedure
     )
   )
 
-const releaseProcedure = protectedProcedure
+const releaseProcedure = devOnlyProcedure
   .meta({
     openapi: {
       method: 'POST',
@@ -226,7 +226,7 @@ const releaseProcedure = protectedProcedure
     )
   )
 
-const getUsageProcedure = protectedProcedure
+const getUsageProcedure = devOnlyProcedure
   .meta({
     openapi: {
       method: 'GET',
@@ -376,7 +376,7 @@ const getUsageProcedure = protectedProcedure
     )
   )
 
-const listClaimsProcedure = protectedProcedure
+const listClaimsProcedure = devOnlyProcedure
   .meta({
     openapi: {
       method: 'GET',

--- a/platform/flowglad-next/src/server/routers/resourcesRouter.ts
+++ b/platform/flowglad-next/src/server/routers/resourcesRouter.ts
@@ -25,7 +25,7 @@ import {
   createPaginatedTableRowOutputSchema,
   idInputSchema,
 } from '@/db/tableUtils'
-import { protectedProcedure, router } from '@/server/trpc'
+import { devOnlyProcedure, router } from '@/server/trpc'
 import { generateOpenApiMetas, trpcToRest } from '@/utils/openapi'
 
 const { openApiMetas, routeConfigs } = generateOpenApiMetas({
@@ -42,7 +42,7 @@ const resourcesPaginatedListSchema = createPaginatedListQuerySchema(
   resourcesClientSelectSchema
 )
 
-const listProcedure = protectedProcedure
+const listProcedure = devOnlyProcedure
   .meta(openApiMetas.LIST)
   .input(z.object({ pricingModelId: z.string() }))
   .output(
@@ -64,7 +64,7 @@ const listProcedure = protectedProcedure
     )
   )
 
-const getProcedure = protectedProcedure
+const getProcedure = devOnlyProcedure
   .meta(openApiMetas.GET)
   .input(idInputSchema)
   .output(z.object({ resource: resourcesClientSelectSchema }))
@@ -80,7 +80,7 @@ const getProcedure = protectedProcedure
     )
   )
 
-const createProcedure = protectedProcedure
+const createProcedure = devOnlyProcedure
   .meta(openApiMetas.POST)
   .input(createResourceSchema)
   .output(z.object({ resource: resourcesClientSelectSchema }))
@@ -108,7 +108,7 @@ const createProcedure = protectedProcedure
     )
   )
 
-const updateProcedure = protectedProcedure
+const updateProcedure = devOnlyProcedure
   .meta(openApiMetas.PUT)
   .input(editResourceSchema)
   .output(z.object({ resource: resourcesClientSelectSchema }))
@@ -127,7 +127,7 @@ const updateProcedure = protectedProcedure
     )
   )
 
-const listPaginatedProcedure = protectedProcedure
+const listPaginatedProcedure = devOnlyProcedure
   .input(resourcesPaginatedSelectSchema)
   .output(resourcesPaginatedListSchema)
   .query(async ({ input, ctx }) => {
@@ -141,7 +141,7 @@ const listPaginatedProcedure = protectedProcedure
     )
   })
 
-const getTableRowsProcedure = protectedProcedure
+const getTableRowsProcedure = devOnlyProcedure
   .input(
     createPaginatedTableRowInputSchema(
       z.object({


### PR DESCRIPTION
## What Does this PR Do?

Reverts PR #1411 which opened resource APIs to authenticated users. This restores the resource APIs to being dev-only procedures, gating them behind devOnlyProcedure while features remain gated behind devOnlyProcedure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts #1411 to restore dev-only access for resource and resource-claims APIs. Endpoints are no longer available to authenticated non-dev users and remain gated behind devOnlyProcedure.

- **Refactors**
  - Resource Claims: claim, release, usage, list → devOnlyProcedure.
  - Resources: list, get, create, update, paginated list, table rows → devOnlyProcedure.

<sup>Written for commit 5731539f46074459186df03ba67490ec703a96df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated access control for resource and claim management API endpoints to restrict usage to development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->