### PR TITLE
[resource-sdk-methods] FlowgladServerAdmin resources

### DIFF
--- a/packages/server/src/FlowgladServerAdmin.test.ts
+++ b/packages/server/src/FlowgladServerAdmin.test.ts
@@ -1,0 +1,540 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FlowgladServerAdmin } from './FlowgladServerAdmin'
+
+/**
+ * Unit tests for FlowgladServerAdmin resource methods.
+ *
+ * These tests verify:
+ * 1. getResources returns resources for any valid subscriptionId
+ * 2. claimResource and releaseResource work without customer authentication context
+ * 3. listResourceClaims returns claims for any subscription
+ *
+ * Note: These are unit tests that verify method signatures and call patterns.
+ * Integration tests would require a live API connection.
+ */
+
+// Mock FlowgladNode client
+vi.mock('@flowglad/node', () => {
+  const mockResourceClaims = {
+    usage: vi.fn(),
+    claim: vi.fn(),
+    release: vi.fn(),
+  }
+
+  const mockGet = vi.fn()
+
+  return {
+    Flowglad: vi.fn().mockImplementation(() => ({
+      resourceClaims: mockResourceClaims,
+      get: mockGet,
+    })),
+  }
+})
+
+describe('FlowgladServerAdmin resource methods', () => {
+  const createAdmin = () =>
+    new FlowgladServerAdmin({ apiKey: 'test-api-key' })
+
+  describe('getResources', () => {
+    it('returns resources for any subscriptionId without ownership validation', async () => {
+      const admin = createAdmin()
+
+      // Access the internal mock
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        resourceClaims: { usage: ReturnType<typeof vi.fn> }
+      }
+
+      mockFlowgladNode.resourceClaims.usage.mockResolvedValue({
+        usage: [
+          {
+            resourceSlug: 'seats',
+            resourceId: 'res_123',
+            capacity: 10,
+            claimed: 3,
+            available: 7,
+          },
+          {
+            resourceSlug: 'api_keys',
+            resourceId: 'res_456',
+            capacity: 5,
+            claimed: 2,
+            available: 3,
+          },
+        ],
+        claims: [],
+      })
+
+      const result = await admin.getResources('sub_any_subscription')
+
+      expect(
+        mockFlowgladNode.resourceClaims.usage
+      ).toHaveBeenCalledWith('sub_any_subscription')
+      expect(result).toHaveProperty('resources')
+      expect(result.resources).toHaveLength(2)
+      expect(result.resources[0].resourceSlug).toBe('seats')
+      expect(result.resources[0].capacity).toBe(10)
+      expect(result.resources[0].claimed).toBe(3)
+      expect(result.resources[0].available).toBe(7)
+    })
+
+    it('maps usage array from API response to resources in return value', async () => {
+      const admin = createAdmin()
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        resourceClaims: { usage: ReturnType<typeof vi.fn> }
+      }
+
+      const mockUsage = [
+        {
+          resourceSlug: 'test-resource',
+          resourceId: 'res_test',
+          capacity: 100,
+          claimed: 50,
+          available: 50,
+        },
+      ]
+
+      mockFlowgladNode.resourceClaims.usage.mockResolvedValue({
+        usage: mockUsage,
+        claims: [],
+      })
+
+      const result = await admin.getResources('sub_123')
+
+      // Verify the result.resources matches the usage from the API
+      expect(result.resources).toEqual(mockUsage)
+    })
+  })
+
+  describe('claimResource', () => {
+    it('creates claims for any subscription without ownership validation', async () => {
+      const admin = createAdmin()
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        resourceClaims: { claim: ReturnType<typeof vi.fn> }
+      }
+
+      const mockClaim = {
+        id: 'claim_123',
+        subscriptionItemFeatureId: 'sif_456',
+        resourceId: 'res_789',
+        subscriptionId: 'sub_abc',
+        pricingModelId: 'pm_def',
+        externalId: null,
+        claimedAt: Date.now(),
+        releasedAt: null,
+        releaseReason: null,
+        metadata: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }
+
+      mockFlowgladNode.resourceClaims.claim.mockResolvedValue({
+        claims: [mockClaim],
+        usage: {
+          resourceSlug: 'seats',
+          resourceId: 'res_789',
+          capacity: 10,
+          claimed: 1,
+          available: 9,
+        },
+      })
+
+      const result = await admin.claimResource('sub_abc', {
+        resourceSlug: 'seats',
+        quantity: 1,
+      })
+
+      expect(
+        mockFlowgladNode.resourceClaims.claim
+      ).toHaveBeenCalledWith('sub_abc', {
+        resourceSlug: 'seats',
+        quantity: 1,
+      })
+      expect(result.claims).toHaveLength(1)
+      expect(result.claims[0].id).toBe('claim_123')
+      expect(result.usage.claimed).toBe(1)
+    })
+
+    it('supports anonymous claims with quantity parameter', async () => {
+      const admin = createAdmin()
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        resourceClaims: { claim: ReturnType<typeof vi.fn> }
+      }
+
+      mockFlowgladNode.resourceClaims.claim.mockResolvedValue({
+        claims: [
+          { id: 'claim_1', externalId: null },
+          { id: 'claim_2', externalId: null },
+          { id: 'claim_3', externalId: null },
+        ],
+        usage: {
+          resourceSlug: 'seats',
+          resourceId: 'res_123',
+          capacity: 10,
+          claimed: 3,
+          available: 7,
+        },
+      })
+
+      const result = await admin.claimResource('sub_123', {
+        resourceSlug: 'seats',
+        quantity: 3,
+      })
+
+      expect(
+        mockFlowgladNode.resourceClaims.claim
+      ).toHaveBeenCalledWith('sub_123', {
+        resourceSlug: 'seats',
+        quantity: 3,
+      })
+      expect(result.claims).toHaveLength(3)
+    })
+
+    it('supports named claims with externalId parameter', async () => {
+      const admin = createAdmin()
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        resourceClaims: { claim: ReturnType<typeof vi.fn> }
+      }
+
+      mockFlowgladNode.resourceClaims.claim.mockResolvedValue({
+        claims: [{ id: 'claim_1', externalId: 'user_alice' }],
+        usage: {
+          resourceSlug: 'seats',
+          resourceId: 'res_123',
+          capacity: 10,
+          claimed: 1,
+          available: 9,
+        },
+      })
+
+      const result = await admin.claimResource('sub_123', {
+        resourceSlug: 'seats',
+        externalId: 'user_alice',
+        metadata: { assignedBy: 'admin' },
+      })
+
+      expect(
+        mockFlowgladNode.resourceClaims.claim
+      ).toHaveBeenCalledWith('sub_123', {
+        resourceSlug: 'seats',
+        externalId: 'user_alice',
+        metadata: { assignedBy: 'admin' },
+      })
+      expect(result.claims[0].externalId).toBe('user_alice')
+    })
+
+    it('supports named claims with externalIds parameter for bulk operations', async () => {
+      const admin = createAdmin()
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        resourceClaims: { claim: ReturnType<typeof vi.fn> }
+      }
+
+      mockFlowgladNode.resourceClaims.claim.mockResolvedValue({
+        claims: [
+          { id: 'claim_1', externalId: 'user_a' },
+          { id: 'claim_2', externalId: 'user_b' },
+        ],
+        usage: {
+          resourceSlug: 'seats',
+          resourceId: 'res_123',
+          capacity: 10,
+          claimed: 2,
+          available: 8,
+        },
+      })
+
+      const result = await admin.claimResource('sub_123', {
+        resourceSlug: 'seats',
+        externalIds: ['user_a', 'user_b'],
+      })
+
+      expect(
+        mockFlowgladNode.resourceClaims.claim
+      ).toHaveBeenCalledWith('sub_123', {
+        resourceSlug: 'seats',
+        externalIds: ['user_a', 'user_b'],
+      })
+      expect(result.claims).toHaveLength(2)
+    })
+  })
+
+  describe('releaseResource', () => {
+    it('releases claims for any subscription without customer authentication', async () => {
+      const admin = createAdmin()
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        resourceClaims: { release: ReturnType<typeof vi.fn> }
+      }
+
+      mockFlowgladNode.resourceClaims.release.mockResolvedValue({
+        releasedClaims: [
+          {
+            id: 'claim_123',
+            externalId: null,
+            releasedAt: Date.now(),
+          },
+        ],
+        usage: {
+          resourceSlug: 'seats',
+          resourceId: 'res_123',
+          capacity: 10,
+          claimed: 2,
+          available: 8,
+        },
+      })
+
+      const result = await admin.releaseResource('sub_123', {
+        resourceSlug: 'seats',
+        quantity: 1,
+      })
+
+      expect(
+        mockFlowgladNode.resourceClaims.release
+      ).toHaveBeenCalledWith('sub_123', {
+        resourceSlug: 'seats',
+        quantity: 1,
+      })
+      expect(result.releasedClaims).toHaveLength(1)
+      expect(result.usage.available).toBe(8)
+    })
+
+    it('supports releasing by externalId', async () => {
+      const admin = createAdmin()
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        resourceClaims: { release: ReturnType<typeof vi.fn> }
+      }
+
+      mockFlowgladNode.resourceClaims.release.mockResolvedValue({
+        releasedClaims: [
+          {
+            id: 'claim_123',
+            externalId: 'user_alice',
+            releasedAt: Date.now(),
+          },
+        ],
+        usage: {
+          resourceSlug: 'seats',
+          resourceId: 'res_123',
+          capacity: 10,
+          claimed: 0,
+          available: 10,
+        },
+      })
+
+      const result = await admin.releaseResource('sub_123', {
+        resourceSlug: 'seats',
+        externalId: 'user_alice',
+      })
+
+      expect(
+        mockFlowgladNode.resourceClaims.release
+      ).toHaveBeenCalledWith('sub_123', {
+        resourceSlug: 'seats',
+        externalId: 'user_alice',
+      })
+      expect(result.releasedClaims[0].externalId).toBe('user_alice')
+    })
+
+    it('supports releasing by externalIds for bulk operations', async () => {
+      const admin = createAdmin()
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        resourceClaims: { release: ReturnType<typeof vi.fn> }
+      }
+
+      mockFlowgladNode.resourceClaims.release.mockResolvedValue({
+        releasedClaims: [
+          { id: 'claim_1', externalId: 'user_a' },
+          { id: 'claim_2', externalId: 'user_b' },
+        ],
+        usage: {
+          resourceSlug: 'seats',
+          resourceId: 'res_123',
+          capacity: 10,
+          claimed: 3,
+          available: 7,
+        },
+      })
+
+      const result = await admin.releaseResource('sub_123', {
+        resourceSlug: 'seats',
+        externalIds: ['user_a', 'user_b'],
+      })
+
+      expect(
+        mockFlowgladNode.resourceClaims.release
+      ).toHaveBeenCalledWith('sub_123', {
+        resourceSlug: 'seats',
+        externalIds: ['user_a', 'user_b'],
+      })
+      expect(result.releasedClaims).toHaveLength(2)
+    })
+
+    it('supports releasing by claimIds', async () => {
+      const admin = createAdmin()
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        resourceClaims: { release: ReturnType<typeof vi.fn> }
+      }
+
+      mockFlowgladNode.resourceClaims.release.mockResolvedValue({
+        releasedClaims: [{ id: 'claim_abc' }, { id: 'claim_def' }],
+        usage: {
+          resourceSlug: 'seats',
+          resourceId: 'res_123',
+          capacity: 10,
+          claimed: 5,
+          available: 5,
+        },
+      })
+
+      const result = await admin.releaseResource('sub_123', {
+        resourceSlug: 'seats',
+        claimIds: ['claim_abc', 'claim_def'],
+      })
+
+      expect(
+        mockFlowgladNode.resourceClaims.release
+      ).toHaveBeenCalledWith('sub_123', {
+        resourceSlug: 'seats',
+        claimIds: ['claim_abc', 'claim_def'],
+      })
+      expect(result.releasedClaims).toHaveLength(2)
+    })
+  })
+
+  describe('listResourceClaims', () => {
+    it('returns claims for any subscription without ownership check', async () => {
+      const admin = createAdmin()
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        get: ReturnType<typeof vi.fn>
+      }
+
+      const mockClaims = [
+        {
+          id: 'claim_1',
+          subscriptionId: 'sub_123',
+          externalId: 'user_a',
+        },
+        {
+          id: 'claim_2',
+          subscriptionId: 'sub_123',
+          externalId: null,
+        },
+      ]
+
+      mockFlowgladNode.get.mockResolvedValue({ claims: mockClaims })
+
+      const result = await admin.listResourceClaims('sub_123')
+
+      expect(mockFlowgladNode.get).toHaveBeenCalledWith(
+        '/api/v1/resource-claims/sub_123/claims',
+        { query: undefined }
+      )
+      expect(result.claims).toHaveLength(2)
+      expect(result.claims[0].externalId).toBe('user_a')
+    })
+
+    it('supports filtering by resourceSlug', async () => {
+      const admin = createAdmin()
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        get: ReturnType<typeof vi.fn>
+      }
+
+      mockFlowgladNode.get.mockResolvedValue({
+        claims: [{ id: 'claim_1', externalId: 'user_a' }],
+      })
+
+      const result = await admin.listResourceClaims(
+        'sub_123',
+        'seats'
+      )
+
+      expect(mockFlowgladNode.get).toHaveBeenCalledWith(
+        '/api/v1/resource-claims/sub_123/claims',
+        { query: { resourceSlug: 'seats' } }
+      )
+      expect(result.claims).toHaveLength(1)
+    })
+
+    it('passes undefined query when resourceSlug is not provided', async () => {
+      const admin = createAdmin()
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        get: ReturnType<typeof vi.fn>
+      }
+
+      mockFlowgladNode.get.mockResolvedValue({ claims: [] })
+
+      await admin.listResourceClaims('sub_123')
+
+      expect(mockFlowgladNode.get).toHaveBeenCalledWith(
+        '/api/v1/resource-claims/sub_123/claims',
+        { query: undefined }
+      )
+    })
+
+    it('passes resourceSlug in query when provided', async () => {
+      const admin = createAdmin()
+      const mockFlowgladNode = (
+        admin as unknown as { flowgladNode: unknown }
+      ).flowgladNode as {
+        get: ReturnType<typeof vi.fn>
+      }
+
+      mockFlowgladNode.get.mockResolvedValue({ claims: [] })
+
+      await admin.listResourceClaims('sub_123', 'api_keys')
+
+      expect(mockFlowgladNode.get).toHaveBeenCalledWith(
+        '/api/v1/resource-claims/sub_123/claims',
+        { query: { resourceSlug: 'api_keys' } }
+      )
+    })
+  })
+
+  describe('method signatures', () => {
+    it('getResources requires subscriptionId parameter', () => {
+      const admin = createAdmin()
+      // TypeScript compilation would fail if subscriptionId is not required
+      expect(typeof admin.getResources).toBe('function')
+    })
+
+    it('claimResource requires subscriptionId and params without subscriptionId field', () => {
+      const admin = createAdmin()
+      // TypeScript compilation would fail if signature is wrong
+      expect(typeof admin.claimResource).toBe('function')
+    })
+
+    it('releaseResource requires subscriptionId and params without subscriptionId field', () => {
+      const admin = createAdmin()
+      expect(typeof admin.releaseResource).toBe('function')
+    })
+
+    it('listResourceClaims requires subscriptionId and optional resourceSlug', () => {
+      const admin = createAdmin()
+      expect(typeof admin.listResourceClaims).toBe('function')
+    })
+  })
+})

--- a/packages/server/src/FlowgladServerAdmin.ts
+++ b/packages/server/src/FlowgladServerAdmin.ts
@@ -5,6 +5,10 @@ import {
 import {
   type BulkCreateUsageEventsParams,
   bulkCreateUsageEventsSchema,
+  type ClaimResourceParams,
+  type ReleaseResourceParams,
+  type ResourceClaim,
+  type ResourceUsage,
 } from '@flowglad/shared'
 
 export class FlowgladServerAdmin {
@@ -111,5 +115,219 @@ export class FlowgladServerAdmin {
 
   public async getUsageEvent(id: string) {
     return this.flowgladNode.usageEvents.retrieve(id)
+  }
+
+  /**
+   * Get all resources and their usage for a subscription (admin operation).
+   *
+   * Returns capacity, claimed count, and available count for all resources
+   * in the subscription's pricing model. This operation bypasses customer
+   * authentication and ownership validation.
+   *
+   * @param subscriptionId - The subscription ID to get resources for (required)
+   * @returns Promise containing an array of resources with their usage data
+   *
+   * @example
+   * // Get all resources for a subscription
+   * const { resources } = await flowgladAdmin.getResources('sub_123')
+   * for (const resource of resources) {
+   *   console.log(`${resource.resourceSlug}: ${resource.claimed}/${resource.capacity} claimed`)
+   * }
+   *
+   * @example
+   * // Check if a subscription has available capacity for a specific resource
+   * const { resources } = await flowgladAdmin.getResources('sub_abc')
+   * const seats = resources.find(r => r.resourceSlug === 'seats')
+   * if (seats && seats.available > 0) {
+   *   console.log(`${seats.available} seats available`)
+   * }
+   */
+  public async getResources(
+    subscriptionId: string
+  ): Promise<{ resources: ResourceUsage[] }> {
+    const result =
+      await this.flowgladNode.resourceClaims.usage(subscriptionId)
+    return { resources: result.usage }
+  }
+
+  /**
+   * Claim resources on behalf of a customer (admin operation).
+   *
+   * This operation bypasses customer authentication and ownership validation,
+   * allowing merchants to claim resources for any subscription they manage.
+   *
+   * ## Claim Modes
+   *
+   * Choose ONE of the following modes per call:
+   *
+   * ### Anonymous Claims
+   * Use `quantity` to claim N resources without external identifiers.
+   * These claims are interchangeable and released in FIFO order when
+   * using quantity-based release.
+   *
+   * ### Named Claims
+   * Use `externalId` or `externalIds` to claim resources with identifiers.
+   * Named claims are idempotent - claiming the same externalId twice
+   * returns the existing claim without creating a duplicate.
+   *
+   * @param subscriptionId - The subscription ID to claim resources from (required)
+   * @param params - Claim parameters (resourceSlug and exactly one of quantity/externalId/externalIds)
+   * @param params.resourceSlug - The slug identifying the resource type (e.g., 'seats', 'api_keys')
+   * @param params.quantity - Anonymous mode: Number of resources to claim
+   * @param params.externalId - Named mode: Single identifier for a named resource
+   * @param params.externalIds - Named mode: Array of identifiers for multiple named resources
+   * @param params.metadata - Optional key-value data to attach to claims
+   * @returns Promise containing the created claims and updated usage
+   *
+   * @example
+   * // Claim 5 anonymous seats for a subscription
+   * const { claims, usage } = await flowgladAdmin.claimResource('sub_123', {
+   *   resourceSlug: 'seats',
+   *   quantity: 5
+   * })
+   * console.log(`Created ${claims.length} claims, ${usage.available} seats remaining`)
+   *
+   * @example
+   * // Claim named seats for specific users (idempotent)
+   * const { claims } = await flowgladAdmin.claimResource('sub_123', {
+   *   resourceSlug: 'seats',
+   *   externalIds: ['user_alice', 'user_bob', 'user_charlie'],
+   *   metadata: { assignedBy: 'admin' }
+   * })
+   *
+   * @example
+   * // Claim a single named API key
+   * const { claims } = await flowgladAdmin.claimResource('sub_456', {
+   *   resourceSlug: 'api_keys',
+   *   externalId: 'production-key',
+   *   metadata: { environment: 'production' }
+   * })
+   */
+  public async claimResource(
+    subscriptionId: string,
+    params: Omit<ClaimResourceParams, 'subscriptionId'>
+  ): Promise<{ claims: ResourceClaim[]; usage: ResourceUsage }> {
+    const result = await this.flowgladNode.resourceClaims.claim(
+      subscriptionId,
+      params
+    )
+    return {
+      claims: result.claims as ResourceClaim[],
+      usage: result.usage,
+    }
+  }
+
+  /**
+   * Release claimed resources on behalf of a customer (admin operation).
+   *
+   * This operation bypasses customer authentication and ownership validation,
+   * allowing merchants to release resources for any subscription they manage.
+   *
+   * ## Release Modes
+   *
+   * Choose ONE of the following modes per call:
+   *
+   * ### Anonymous Mode (FIFO)
+   * Use `quantity` to release N anonymous claims in FIFO order (oldest first).
+   * Only releases claims that have no external identifier.
+   *
+   * ### Named Mode by External ID
+   * Use `externalId` or `externalIds` to release specific named claims
+   * by their external identifiers.
+   *
+   * ### Direct Mode
+   * Use `claimIds` to release specific claims by their database IDs.
+   * Works for both anonymous and named claims.
+   *
+   * @param subscriptionId - The subscription ID to release resources from (required)
+   * @param params - Release parameters (resourceSlug and exactly one of quantity/externalId/externalIds/claimIds)
+   * @param params.resourceSlug - The slug identifying the resource type
+   * @param params.quantity - Anonymous mode: Number of claims to release (FIFO)
+   * @param params.externalId - Named mode: Single identifier to release
+   * @param params.externalIds - Named mode: Array of identifiers to release
+   * @param params.claimIds - Direct mode: Array of claim IDs to release
+   * @returns Promise containing the released claims and updated usage
+   *
+   * @example
+   * // Release 3 anonymous seats (FIFO order)
+   * const { releasedClaims, usage } = await flowgladAdmin.releaseResource('sub_123', {
+   *   resourceSlug: 'seats',
+   *   quantity: 3
+   * })
+   * console.log(`Released ${releasedClaims.length} claims, ${usage.available} seats now available`)
+   *
+   * @example
+   * // Release a specific user's seat
+   * const { releasedClaims } = await flowgladAdmin.releaseResource('sub_123', {
+   *   resourceSlug: 'seats',
+   *   externalId: 'user_alice'
+   * })
+   *
+   * @example
+   * // Release multiple named API keys
+   * const { releasedClaims } = await flowgladAdmin.releaseResource('sub_456', {
+   *   resourceSlug: 'api_keys',
+   *   externalIds: ['staging-key', 'dev-key']
+   * })
+   *
+   * @example
+   * // Release specific claims by their IDs
+   * const { releasedClaims } = await flowgladAdmin.releaseResource('sub_789', {
+   *   resourceSlug: 'seats',
+   *   claimIds: ['claim_abc', 'claim_def']
+   * })
+   */
+  public async releaseResource(
+    subscriptionId: string,
+    params: Omit<ReleaseResourceParams, 'subscriptionId'>
+  ): Promise<{
+    releasedClaims: ResourceClaim[]
+    usage: ResourceUsage
+  }> {
+    const result = await this.flowgladNode.resourceClaims.release(
+      subscriptionId,
+      params
+    )
+    return {
+      releasedClaims: result.releasedClaims as ResourceClaim[],
+      usage: result.usage,
+    }
+  }
+
+  /**
+   * List active resource claims for a subscription (admin operation).
+   *
+   * This operation bypasses customer authentication and ownership validation,
+   * allowing merchants to view claims for any subscription they manage.
+   *
+   * @param subscriptionId - The subscription ID to list claims for (required)
+   * @param resourceSlug - Optional filter to return only claims for a specific resource type
+   * @returns Promise containing an array of active claims
+   *
+   * @example
+   * // List all active claims for a subscription
+   * const { claims } = await flowgladAdmin.listResourceClaims('sub_123')
+   * console.log(`Found ${claims.length} active claims`)
+   *
+   * @example
+   * // List only seat claims
+   * const { claims } = await flowgladAdmin.listResourceClaims('sub_123', 'seats')
+   * const namedSeats = claims.filter(c => c.externalId !== null)
+   * console.log(`${namedSeats.length} named seats assigned`)
+   *
+   * @example
+   * // Find claims for a specific user across a subscription
+   * const { claims } = await flowgladAdmin.listResourceClaims('sub_123')
+   * const userClaims = claims.filter(c => c.externalId === 'user_alice')
+   */
+  public async listResourceClaims(
+    subscriptionId: string,
+    resourceSlug?: string
+  ): Promise<{ claims: ResourceClaim[] }> {
+    const query = resourceSlug ? { resourceSlug } : undefined
+    return this.flowgladNode.get<{ claims: ResourceClaim[] }>(
+      `/api/v1/resource-claims/${subscriptionId}/claims`,
+      { query }
+    )
   }
 }


### PR DESCRIPTION
## What Does this PR Do?
This PR adds administrative resource management methods (`getResources`, `claimResource`, `releaseResource`, `listResourceClaims`) to `FlowgladServerAdmin`. This enables merchants to perform resource operations on behalf of customers, requiring an explicit `subscriptionId` and bypassing customer ownership validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-0228942c-521b-4e63-84fc-d472c87f9d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0228942c-521b-4e63-84fc-d472c87f9d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds admin resource management APIs to FlowgladServerAdmin so merchants can view usage and claim/release resources for any subscription. These methods bypass customer ownership checks and require an explicit subscriptionId.

- **New Features**
  - getResources(subscriptionId): returns ResourceUsage[] with capacity, claimed, and available counts.
  - claimResource(subscriptionId, params): claim by quantity or externalId(s); returns claims and updated usage.
  - releaseResource(subscriptionId, params): release by quantity (FIFO), externalId(s), or claimIds; returns releasedClaims and updated usage.
  - listResourceClaims(subscriptionId, resourceSlug?): lists active claims with optional resource filter.

<sup>Written for commit 4313feaee09733e456f98ce84682aa551612fa2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

