### PR TITLE
chore: update worktreeinclude to use local claude settings

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -7,4 +7,4 @@
 .env.*
 
 # Claude Code settings
-.claude/settings.json
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Updates `.worktreeinclude` to reference `.claude/settings.local.json` instead of `.claude/settings.json`
- Ensures local Claude Code settings are properly included in worktrees

## Test plan
- [x] Verify the change is correct by reviewing the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update .worktreeinclude to reference .claude/settings.local.json instead of .claude/settings.json so local Claude Code settings are included in worktrees. This ensures each worktree picks up developer-specific settings without relying on the shared config.

<sup>Written for commit 2fb48d1aae3fd603e803b69ce927e6a1bcddb4cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->