### PR TITLE
[transaction-effects-migration] patch 2: migrate leaf functions to TransactionEffectsContext pattern

### DIFF
--- a/platform/flowglad-next/src/server/mutations/addFeatureToSubscription.ts
+++ b/platform/flowglad-next/src/server/mutations/addFeatureToSubscription.ts
@@ -8,25 +8,35 @@ export const addFeatureToSubscription = protectedProcedure
   .input(addFeatureToSubscriptionInputSchema)
   .mutation(
     authenticatedProcedureComprehensiveTransaction(
-      async ({ input, transaction }) => {
-        const { result, ledgerCommand } =
-          await addFeatureToSubscriptionItem(input, transaction)
+      async ({
+        input,
+        transaction,
+        emitEvent,
+        invalidateCache,
+        enqueueLedgerCommand,
+      }) => {
+        const { subscriptionItemFeature } =
+          await addFeatureToSubscriptionItem(input, {
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          })
 
         const [enrichedFeature] =
           await selectClientSubscriptionItemFeatureAndFeatureById(
-            result.subscriptionItemFeature.id,
+            subscriptionItemFeature.id,
             transaction
           )
 
         if (!enrichedFeature) {
           throw new Error(
-            `Failed to load subscription item feature ${result.subscriptionItemFeature.id} after creation.`
+            `Failed to load subscription item feature ${subscriptionItemFeature.id} after creation.`
           )
         }
 
         return {
           result: { subscriptionItemFeature: enrichedFeature },
-          ledgerCommand,
         }
       }
     )

--- a/platform/flowglad-next/src/server/routers/usageEventsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/usageEventsRouter.ts
@@ -53,16 +53,29 @@ export const createUsageEvent = protectedProcedure
   .output(z.object({ usageEvent: usageEventsClientSelectSchema }))
   .mutation(
     authenticatedProcedureComprehensiveTransaction(
-      async ({ input, ctx, transaction }) => {
+      async ({
+        input,
+        ctx,
+        transaction,
+        emitEvent,
+        invalidateCache,
+        enqueueLedgerCommand,
+      }) => {
         const resolvedInput = await resolveUsageEventInput(
           input,
           transaction
         )
 
-        return ingestAndProcessUsageEvent(
+        const result = await ingestAndProcessUsageEvent(
           { input: resolvedInput, livemode: ctx.livemode },
-          transaction
+          {
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }
         )
+        return { result }
       }
     )
   )

--- a/platform/flowglad-next/src/subscriptions/createSubscription/payGo.flow.test.ts
+++ b/platform/flowglad-next/src/subscriptions/createSubscription/payGo.flow.test.ts
@@ -202,8 +202,8 @@ describe('Pay as You Go Workflow E2E', () => {
 
     // 2. Create a usage event for the subscription
     const staticTransctionId = 'test-' + core.nanoid()
-    await comprehensiveAdminTransaction(async ({ transaction }) => {
-      return await ingestAndProcessUsageEvent(
+    await comprehensiveAdminTransaction(async (ctx) => {
+      const usageEvent = await ingestAndProcessUsageEvent(
         {
           input: {
             usageEvent: {
@@ -218,8 +218,9 @@ describe('Pay as You Go Workflow E2E', () => {
           },
           livemode: true,
         },
-        transaction
+        ctx
       )
+      return { result: usageEvent }
     })
 
     // 3. Call @customerBillingTransaction again and assert final state
@@ -241,8 +242,8 @@ describe('Pay as You Go Workflow E2E', () => {
     })
 
     // 4. Create a usage event for the subscription
-    await comprehensiveAdminTransaction(async ({ transaction }) => {
-      return await ingestAndProcessUsageEvent(
+    await comprehensiveAdminTransaction(async (ctx) => {
+      const usageEvent = await ingestAndProcessUsageEvent(
         {
           input: {
             usageEvent: {
@@ -257,8 +258,9 @@ describe('Pay as You Go Workflow E2E', () => {
           },
           livemode: true,
         },
-        transaction
+        ctx
       )
+      return { result: usageEvent }
     })
 
     // 5. Call @customerBillingTransaction again and assert final state
@@ -394,8 +396,8 @@ describe('Pay as You Go Workflow E2E', () => {
 
     // 6. Create a usage event after payment
     const newTransactionId = 'test2-' + core.nanoid()
-    await comprehensiveAdminTransaction(async ({ transaction }) => {
-      return await ingestAndProcessUsageEvent(
+    await comprehensiveAdminTransaction(async (ctx) => {
+      const usageEvent = await ingestAndProcessUsageEvent(
         {
           input: {
             usageEvent: {
@@ -410,8 +412,9 @@ describe('Pay as You Go Workflow E2E', () => {
           },
           livemode: true,
         },
-        transaction
+        ctx
       )
+      return { result: usageEvent }
     })
 
     // 7. Call @customerBillingTransaction again and assert final state after new usage

--- a/platform/flowglad-next/src/subscriptions/subscriptionItemFeatureHelpers.ts
+++ b/platform/flowglad-next/src/subscriptions/subscriptionItemFeatureHelpers.ts
@@ -1,6 +1,5 @@
 import { and, eq, isNull } from 'drizzle-orm'
 import * as R from 'ramda'
-import type { CreditGrantRecognizedLedgerCommand } from '@/db/ledgerManager/ledgerManagerTypes'
 import { Customer } from '@/db/schema/customers'
 import type { Feature } from '@/db/schema/features'
 import type { Price } from '@/db/schema/prices'
@@ -38,8 +37,10 @@ import {
   selectSubscriptionById,
 } from '@/db/tableMethods/subscriptionMethods'
 import { insertUsageCredit } from '@/db/tableMethods/usageCreditMethods'
-import type { TransactionOutput } from '@/db/transactionEnhacementTypes'
-import type { DbTransaction } from '@/db/types'
+import type {
+  DbTransaction,
+  TransactionEffectsContext,
+} from '@/db/types'
 import {
   FeatureType,
   LedgerTransactionType,
@@ -383,8 +384,9 @@ const grantImmediateUsageCredits = async (
     subscriptionItemFeature: SubscriptionItemFeature.Record
     grantAmount: number
   },
-  transaction: DbTransaction
-) => {
+  ctx: TransactionEffectsContext
+): Promise<void> => {
+  const { transaction, enqueueLedgerCommand } = ctx
   const usageMeterId = subscriptionItemFeature.usageMeterId
   if (!usageMeterId) {
     throw new Error(
@@ -467,7 +469,7 @@ const grantImmediateUsageCredits = async (
     transaction
   )
 
-  const ledgerCommand: CreditGrantRecognizedLedgerCommand = {
+  enqueueLedgerCommand({
     type: LedgerTransactionType.CreditGrantRecognized,
     organizationId: subscription.organizationId,
     livemode: subscription.livemode,
@@ -475,12 +477,7 @@ const grantImmediateUsageCredits = async (
     payload: {
       usageCredit,
     },
-  }
-
-  return {
-    usageCredit,
-    ledgerCommand,
-  }
+  })
 }
 
 const findOrCreateManualSubscriptionItem = async (
@@ -538,12 +535,11 @@ const findOrCreateManualSubscriptionItem = async (
 
 export const addFeatureToSubscriptionItem = async (
   input: AddFeatureToSubscriptionInput,
-  transaction: DbTransaction
-): Promise<
-  TransactionOutput<{
-    subscriptionItemFeature: SubscriptionItemFeature.Record
-  }>
-> => {
+  ctx: TransactionEffectsContext
+): Promise<{
+  subscriptionItemFeature: SubscriptionItemFeature.Record
+}> => {
+  const { transaction } = ctx
   const {
     subscriptionItemId,
     featureId,
@@ -700,8 +696,6 @@ export const addFeatureToSubscriptionItem = async (
       )
     }
   }
-  let ledgerCommand: CreditGrantRecognizedLedgerCommand | undefined
-
   if (
     feature.type === FeatureType.UsageCreditGrant &&
     grantCreditsImmediately
@@ -711,19 +705,15 @@ export const addFeatureToSubscriptionItem = async (
         'Missing usage feature insert data for immediate credit grant.'
       )
     }
-    const immediateGrant = await grantImmediateUsageCredits(
+    await grantImmediateUsageCredits(
       {
         subscription,
         subscriptionItemFeature,
         grantAmount: usageFeatureInsert.amount,
       },
-      transaction
+      ctx
     )
-    ledgerCommand = immediateGrant?.ledgerCommand
   }
 
-  return {
-    result: { subscriptionItemFeature },
-    ledgerCommand,
-  }
+  return { subscriptionItemFeature }
 }

--- a/platform/flowglad-next/src/utils/usage/usageEventHelpers.test.ts
+++ b/platform/flowglad-next/src/utils/usage/usageEventHelpers.test.ts
@@ -30,6 +30,7 @@ import type { CreateUsageEventInput } from '@/db/schema/usageEvents'
 import type { UsageMeter } from '@/db/schema/usageMeters'
 import { selectLedgerEntries } from '@/db/tableMethods/ledgerEntryMethods'
 import { selectLedgerTransactions } from '@/db/tableMethods/ledgerTransactionMethods'
+import { createNoopContext } from '@/test-utils/transactionCallbacks'
 import {
   CurrencyCode,
   IntervalUnit,
@@ -125,11 +126,23 @@ describe('usageEventHelpers', () => {
 
       const { usageEvent: createdUsageEvent } =
         await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            return ingestAndProcessUsageEvent(
-              { input, livemode: true },
-              transaction
-            )
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                { input, livemode: true },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
           }
         )
 
@@ -190,14 +203,26 @@ describe('usageEventHelpers', () => {
         }
       const { usageEvent: initialEvent } =
         await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            return ingestAndProcessUsageEvent(
-              {
-                input: { usageEvent: initialEventDetails },
-                livemode: true,
-              },
-              transaction
-            )
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                {
+                  input: { usageEvent: initialEventDetails },
+                  livemode: true,
+                },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
           }
         )
 
@@ -229,14 +254,26 @@ describe('usageEventHelpers', () => {
 
       const { usageEvent: resultEvent } =
         await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            return ingestAndProcessUsageEvent(
-              {
-                input: { usageEvent: initialEventDetails },
-                livemode: true,
-              },
-              transaction
-            )
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                {
+                  input: { usageEvent: initialEventDetails },
+                  livemode: true,
+                },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
           }
         )
 
@@ -309,7 +346,7 @@ describe('usageEventHelpers', () => {
             },
             livemode: true,
           },
-          transaction
+          createNoopContext(transaction)
         )
       })
 
@@ -329,7 +366,7 @@ describe('usageEventHelpers', () => {
         adminTransaction(async ({ transaction }) => {
           return ingestAndProcessUsageEvent(
             { input: inputMainSub, livemode: true },
-            transaction
+            createNoopContext(transaction)
           )
         })
       ).rejects.toThrow(
@@ -349,14 +386,26 @@ describe('usageEventHelpers', () => {
         }
       const { usageEvent: resultWithProps } =
         await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            return ingestAndProcessUsageEvent(
-              {
-                input: { usageEvent: propsPresentDetails },
-                livemode: true,
-              },
-              transaction
-            )
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                {
+                  input: { usageEvent: propsPresentDetails },
+                  livemode: true,
+                },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
           }
         )
       expect(resultWithProps.properties).toEqual({
@@ -373,14 +422,26 @@ describe('usageEventHelpers', () => {
         }
       const { usageEvent: resultWithoutProps } =
         await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            return ingestAndProcessUsageEvent(
-              {
-                input: { usageEvent: propsAbsentDetails },
-                livemode: true,
-              },
-              transaction
-            )
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                {
+                  input: { usageEvent: propsAbsentDetails },
+                  livemode: true,
+                },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
           }
         )
       expect(resultWithoutProps!.properties).toEqual({})
@@ -399,14 +460,26 @@ describe('usageEventHelpers', () => {
         }
       const { usageEvent: resultWithDate } =
         await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            return ingestAndProcessUsageEvent(
-              {
-                input: { usageEvent: datePresentDetails },
-                livemode: true,
-              },
-              transaction
-            )
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                {
+                  input: { usageEvent: datePresentDetails },
+                  livemode: true,
+                },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
           }
         )
       expect(resultWithDate.usageDate!).toBe(timestamp)
@@ -420,14 +493,26 @@ describe('usageEventHelpers', () => {
       }
       const { usageEvent: resultWithoutDate } =
         await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            return ingestAndProcessUsageEvent(
-              {
-                input: { usageEvent: dateAbsentDetails },
-                livemode: true,
-              },
-              transaction
-            )
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                {
+                  input: { usageEvent: dateAbsentDetails },
+                  livemode: true,
+                },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
           }
         )
       expect(typeof resultWithoutDate.usageDate).toBe('number')
@@ -443,14 +528,26 @@ describe('usageEventHelpers', () => {
       }
       const { usageEvent: resultLiveTrue } =
         await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            return ingestAndProcessUsageEvent(
-              {
-                input: { usageEvent: liveTrueDetails },
-                livemode: true,
-              },
-              transaction
-            )
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                {
+                  input: { usageEvent: liveTrueDetails },
+                  livemode: true,
+                },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
           }
         )
       expect(resultLiveTrue.livemode).toBe(true)
@@ -502,14 +599,26 @@ describe('usageEventHelpers', () => {
       }
       const { usageEvent: resultLiveFalse } =
         await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            return ingestAndProcessUsageEvent(
-              {
-                input: { usageEvent: liveFalseDetails },
-                livemode: false,
-              },
-              transaction
-            )
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                {
+                  input: { usageEvent: liveFalseDetails },
+                  livemode: false,
+                },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
           }
         )
       expect(resultLiveFalse.livemode).toBe(false)
@@ -604,14 +713,26 @@ describe('usageEventHelpers', () => {
       const beforeFirstEvent = Date.now()
       const { usageEvent: firstUsageEvent } =
         await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            return ingestAndProcessUsageEvent(
-              {
-                input: { usageEvent: firstEventDetails },
-                livemode: true,
-              },
-              transaction
-            )
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                {
+                  input: { usageEvent: firstEventDetails },
+                  livemode: true,
+                },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
           }
         )
 
@@ -656,14 +777,26 @@ describe('usageEventHelpers', () => {
       const beforeSecondEvent = Date.now()
       const { usageEvent: secondUsageEvent } =
         await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            return ingestAndProcessUsageEvent(
-              {
-                input: { usageEvent: secondEventDetails },
-                livemode: true,
-              },
-              transaction
-            )
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                {
+                  input: { usageEvent: secondEventDetails },
+                  livemode: true,
+                },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
           }
         )
 
@@ -710,14 +843,26 @@ describe('usageEventHelpers', () => {
       }
       const { usageEvent: thirdUsageEvent } =
         await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            return ingestAndProcessUsageEvent(
-              {
-                input: { usageEvent: thirdEventDetails },
-                livemode: true,
-              },
-              transaction
-            )
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                {
+                  input: { usageEvent: thirdEventDetails },
+                  livemode: true,
+                },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
           }
         )
       expect(thirdUsageEvent.properties).toEqual({
@@ -772,12 +917,26 @@ describe('usageEventHelpers', () => {
       }
 
       await expect(
-        comprehensiveAdminTransaction(async ({ transaction }) => {
-          return ingestAndProcessUsageEvent(
-            { input, livemode: true },
-            transaction
-          )
-        })
+        comprehensiveAdminTransaction(
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                { input, livemode: true },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
+          }
+        )
       ).rejects.toThrow(
         `Usage meter ${otherOrgUsageMeter.id} not found for this customer's pricing model`
       )
@@ -821,12 +980,26 @@ describe('usageEventHelpers', () => {
       }
 
       await expect(
-        comprehensiveAdminTransaction(async ({ transaction }) => {
-          return ingestAndProcessUsageEvent(
-            { input, livemode: true },
-            transaction
-          )
-        })
+        comprehensiveAdminTransaction(
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                { input, livemode: true },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
+          }
+        )
       ).rejects.toThrow(
         `Price ${otherOrgPrice.id} not found for this customer's pricing model`
       )
@@ -846,11 +1019,23 @@ describe('usageEventHelpers', () => {
 
       const { usageEvent: createdUsageEvent } =
         await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            return ingestAndProcessUsageEvent(
-              { input, livemode: true },
-              transaction
-            )
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                { input, livemode: true },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
           }
         )
 
@@ -896,12 +1081,26 @@ describe('usageEventHelpers', () => {
       }
 
       await expect(
-        comprehensiveAdminTransaction(async ({ transaction }) => {
-          return ingestAndProcessUsageEvent(
-            { input: undefinedPropsInput, livemode: true },
-            transaction
-          )
-        })
+        comprehensiveAdminTransaction(
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                { input: undefinedPropsInput, livemode: true },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
+          }
+        )
       ).rejects.toThrow('Properties are required')
 
       // Test with empty object properties
@@ -917,12 +1116,26 @@ describe('usageEventHelpers', () => {
       }
 
       await expect(
-        comprehensiveAdminTransaction(async ({ transaction }) => {
-          return ingestAndProcessUsageEvent(
-            { input: emptyPropsInput, livemode: true },
-            transaction
-          )
-        })
+        comprehensiveAdminTransaction(
+          async ({
+            transaction,
+            emitEvent,
+            invalidateCache,
+            enqueueLedgerCommand,
+          }) => {
+            return {
+              result: await ingestAndProcessUsageEvent(
+                { input: emptyPropsInput, livemode: true },
+                {
+                  transaction,
+                  emitEvent,
+                  invalidateCache,
+                  enqueueLedgerCommand,
+                }
+              ),
+            }
+          }
+        )
       ).rejects.toThrow('Properties are required')
     })
   })


### PR DESCRIPTION
## Summary
- Migrate `ingestAndProcessUsageEvent` from returning `TransactionOutput<T>` to using `TransactionEffectsContext` callback pattern
- Migrate `addFeatureToSubscriptionItem` to accept and pass through `TransactionEffectsContext`
- Migrate `grantImmediateUsageCredits` to use `enqueueLedgerCommand()` callback directly

This is patch-2 of the transaction effects migration, converting leaf functions from the return-based side effect pattern to the callback-based pattern introduced in #1392.

## Test plan
- [x] All existing tests updated to use new function signatures
- [x] `bun run check` passes with no TypeScript errors
- [ ] Run full test suite to verify behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated ingestAndProcessUsageEvent, addFeatureToSubscriptionItem, and grantImmediateUsageCredits to the TransactionEffectsContext callback pattern. This removes return-based side effects and routes ledger work via enqueueLedgerCommand, with server handlers and tests updated accordingly.

- **Refactors**
  - ingestAndProcessUsageEvent: now takes TransactionEffectsContext, enqueues UsageEventProcessed via enqueueLedgerCommand, and returns { usageEvent }.
  - addFeatureToSubscriptionItem: accepts TransactionEffectsContext, passes it through, and returns { subscriptionItemFeature }; immediate credit grants are emitted via ctx.
  - grantImmediateUsageCredits: uses enqueueLedgerCommand directly and returns void.
  - Updated usageEventsRouter and addFeatureToSubscription mutation to provide { transaction, emitEvent, invalidateCache, enqueueLedgerCommand }.

- **Migration**
  - Pass TransactionEffectsContext instead of a raw transaction.
  - Stop reading ledgerCommand from function returns; capture effects via the ctx.
  - Replace TransactionOutput usage with plain result objects; update tests to use createCapturingContext/createNoopContext.

<sup>Written for commit 05fd7d7608fed21a0317f83c120b4e5446b798a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

