### PR TITLE
[transaction-effects-migration] Patch 5: Migrate payment processing functions to TransactionEffectsContext

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@flowglad/javascript",

--- a/platform/flowglad-next/src/app/purchase/post-payment/route.tsx
+++ b/platform/flowglad-next/src/app/purchase/post-payment/route.tsx
@@ -52,16 +52,12 @@ const processPaymentIntent = async ({
     throw new Error(`Payment intent not found: ${paymentIntentId}`)
   }
   const { payment, purchase, invoice, checkoutSession } =
-    await comprehensiveAdminTransaction(async ({ transaction }) => {
-      const paymentResult = await processPaymentIntentStatusUpdated(
+    await comprehensiveAdminTransaction(async (ctx) => {
+      const { transaction } = ctx
+      const { payment } = await processPaymentIntentStatusUpdated(
         paymentIntent,
-        transaction
+        ctx
       )
-      const {
-        result: { payment },
-        eventsToInsert,
-        ledgerCommand,
-      } = paymentResult
       if (!payment.purchaseId) {
         throw new Error(
           `No purchase id found for payment ${payment.id}`
@@ -101,8 +97,6 @@ const processPaymentIntent = async ({
       }
       return {
         result: { payment, purchase, checkoutSession, invoice },
-        eventsToInsert,
-        ledgerCommand,
       }
     })
   return {

--- a/platform/flowglad-next/src/server/mutations/confirmCheckoutSession.ts
+++ b/platform/flowglad-next/src/server/mutations/confirmCheckoutSession.ts
@@ -15,10 +15,11 @@ const confirmCheckoutSessionInputSchema = z.object({
 export const confirmCheckoutSession = publicProcedure
   .input(confirmCheckoutSessionInputSchema)
   .mutation(async ({ input }) => {
-    return comprehensiveAdminTransaction(async ({ transaction }) => {
-      return await confirmCheckoutSessionTransaction(
+    return comprehensiveAdminTransaction(async (ctx) => {
+      const result = await confirmCheckoutSessionTransaction(
         input,
-        transaction
+        ctx
       )
+      return { result }
     })
   })

--- a/platform/flowglad-next/src/subscriptions/createSubscription/payGo.flow.test.ts
+++ b/platform/flowglad-next/src/subscriptions/createSubscription/payGo.flow.test.ts
@@ -288,7 +288,8 @@ describe('Pay as You Go Workflow E2E', () => {
 
     // 2. Call @createCheckoutSessionTransaction to create an ActivateSubscription checkout session
     const checkoutSession = await comprehensiveAdminTransaction(
-      async ({ transaction }) => {
+      async (ctx) => {
+        const { transaction } = ctx
         const checkoutSessionInput: CreateCheckoutSessionInput['checkoutSession'] =
           {
             type: CheckoutSessionType.Product,
@@ -334,7 +335,7 @@ describe('Pay as You Go Workflow E2E', () => {
         // 3. Call @confirmCheckoutSession.ts to finalize it
         await confirmCheckoutSessionTransaction(
           { id: checkoutSession.id },
-          transaction
+          ctx
         )
 
         // expect a feeCalculation for the checkout session
@@ -347,7 +348,7 @@ describe('Pay as You Go Workflow E2E', () => {
       }
     )
 
-    await comprehensiveAdminTransaction(async ({ transaction }) => {
+    await comprehensiveAdminTransaction(async (ctx) => {
       // 4. Call @processSetupIntentSucceeded with a stubbed paymentIntent
       const paymentIntent: CoreStripePaymentIntent = {
         id: 'si_123',
@@ -359,10 +360,11 @@ describe('Pay as You Go Workflow E2E', () => {
         },
       }
 
-      return processPaymentIntentStatusUpdated(
+      const result = await processPaymentIntentStatusUpdated(
         paymentIntent,
-        transaction
+        ctx
       )
+      return { result }
     })
 
     await comprehensiveAdminTransaction(async ({ transaction }) => {

--- a/platform/flowglad-next/src/subscriptions/createSubscription/timeTrial.flow.test.ts
+++ b/platform/flowglad-next/src/subscriptions/createSubscription/timeTrial.flow.test.ts
@@ -168,7 +168,8 @@ describe('Subscription Activation Workflow E2E - Time Trial', () => {
     expect(ci2.price.id).toBe(price.id)
 
     const checkoutSession = await comprehensiveAdminTransaction(
-      async ({ transaction }) => {
+      async (ctx) => {
+        const { transaction } = ctx
         // 1. Create checkout session
         const checkoutSessionInput: CreateCheckoutSessionInput['checkoutSession'] =
           {
@@ -217,7 +218,7 @@ describe('Subscription Activation Workflow E2E - Time Trial', () => {
         // 3. Confirm checkout session
         await confirmCheckoutSessionTransaction(
           { id: checkoutSession.id },
-          transaction
+          ctx
         )
         // 4. Expect fee calculation exists
         const feeCalculations = await selectFeeCalculations(

--- a/platform/flowglad-next/src/subscriptions/processBillingRunPaymentIntents.ts
+++ b/platform/flowglad-next/src/subscriptions/processBillingRunPaymentIntents.ts
@@ -6,7 +6,6 @@ import type {
 } from '@/db/ledgerManager/ledgerManagerTypes'
 import type { BillingRun } from '@/db/schema/billingRuns'
 import type { Customer } from '@/db/schema/customers'
-import type { Event } from '@/db/schema/events'
 import type { InvoiceLineItem } from '@/db/schema/invoiceLineItems'
 import type { Invoice } from '@/db/schema/invoices'
 import type { Organization } from '@/db/schema/organizations'
@@ -321,10 +320,10 @@ export const processOutcomeForBillingRun = async (
       `Invoice for billing period ${billingRun.billingPeriodId} not found.`
     )
   }
-  const {
-    result: { payment },
-    eventsToInsert: childeventsToInsert,
-  } = await processPaymentIntentStatusUpdated(event, transaction)
+  const { payment } = await processPaymentIntentStatusUpdated(
+    event,
+    ctx
+  )
 
   if (billingRunStatus === BillingRunStatus.Succeeded) {
     await createStripeTaxTransactionIfNeededForPayment(
@@ -365,7 +364,6 @@ export const processOutcomeForBillingRun = async (
         payment,
       },
       ledgerCommands: [],
-      eventsToInsert: childeventsToInsert || [],
     }
   }
 
@@ -542,10 +540,6 @@ export const processOutcomeForBillingRun = async (
   const organizationMemberUsers = usersAndMemberships.map(
     (userAndMembership) => userAndMembership.user
   )
-  const eventsToInsert: Event.Insert[] = []
-  if (childeventsToInsert && childeventsToInsert.length > 0) {
-    eventsToInsert.push(...childeventsToInsert)
-  }
 
   // Track cache invalidations from subscription item adjustments and status changes
   const customerSubscriptionsCacheKey =
@@ -704,7 +698,6 @@ export const processOutcomeForBillingRun = async (
       payment,
     },
     ledgerCommands: ledgerCommands,
-    eventsToInsert,
     cacheInvalidations,
   }
 }

--- a/platform/flowglad-next/src/test/behaviorTest/behaviorTests/checkout.integration.behavior.test.ts
+++ b/platform/flowglad-next/src/test/behaviorTest/behaviorTests/checkout.integration.behavior.test.ts
@@ -23,7 +23,10 @@
 import type Stripe from 'stripe'
 import { expect } from 'vitest'
 import { teardownOrg } from '@/../seedDatabase'
-import { adminTransaction } from '@/db/adminTransaction'
+import {
+  adminTransaction,
+  comprehensiveAdminTransaction,
+} from '@/db/adminTransaction'
 import type { FeeCalculation } from '@/db/schema/feeCalculations'
 import type { Invoice } from '@/db/schema/invoices'
 import type { Payment } from '@/db/schema/payments'
@@ -136,7 +139,8 @@ const confirmCheckoutSessionBehavior = defineBehavior({
     )
 
     // Update checkout session with payment intent ID and confirm
-    await adminTransaction(async ({ transaction }) => {
+    await comprehensiveAdminTransaction(async (ctx) => {
+      const { transaction } = ctx
       const session = await selectCheckoutSessionById(
         prev.updatedCheckoutSession.id,
         transaction
@@ -154,10 +158,8 @@ const confirmCheckoutSessionBehavior = defineBehavior({
       )
 
       // Confirm the checkout session
-      await confirmCheckoutSessionTransaction(
-        { id: session.id },
-        transaction
-      )
+      await confirmCheckoutSessionTransaction({ id: session.id }, ctx)
+      return { result: null }
     })
 
     return {

--- a/platform/flowglad-next/src/utils/bookkeeping/confirmCheckoutSession.test.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/confirmCheckoutSession.test.ts
@@ -145,11 +145,13 @@ describe('confirmCheckoutSessionTransaction', () => {
       })
 
       await expect(
-        comprehensiveAdminTransaction(async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
+        comprehensiveAdminTransaction(async (ctx) => {
+          const { transaction } = ctx
+          const result = await confirmCheckoutSessionTransaction(
             { id: checkoutSession.id },
-            transaction
+            ctx
           )
+          return { result }
         })
       ).rejects.toThrow('Checkout session is not open')
       await comprehensiveAdminTransaction(async ({ transaction }) => {
@@ -164,11 +166,13 @@ describe('confirmCheckoutSessionTransaction', () => {
       })
 
       await expect(
-        comprehensiveAdminTransaction(async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
+        comprehensiveAdminTransaction(async (ctx) => {
+          const { transaction } = ctx
+          const result = await confirmCheckoutSessionTransaction(
             { id: checkoutSession.id },
-            transaction
+            ctx
           )
+          return { result }
         })
       ).rejects.toThrow('Checkout session is not open')
 
@@ -184,11 +188,13 @@ describe('confirmCheckoutSessionTransaction', () => {
       })
 
       await expect(
-        comprehensiveAdminTransaction(async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
+        comprehensiveAdminTransaction(async (ctx) => {
+          const { transaction } = ctx
+          const result = await confirmCheckoutSessionTransaction(
             { id: checkoutSession.id },
-            transaction
+            ctx
           )
+          return { result }
         })
       ).rejects.toThrow('Checkout session is not open')
     })
@@ -208,11 +214,12 @@ describe('confirmCheckoutSessionTransaction', () => {
         })
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
+        async (ctx) => {
+          const { transaction } = ctx
           const confirmResult =
             await confirmCheckoutSessionTransaction(
               { id: addPaymentMethodCheckoutSession.id },
-              transaction
+              ctx
             )
           const feeCalculations = await selectFeeCalculations(
             { checkoutSessionId: addPaymentMethodCheckoutSession.id },
@@ -224,26 +231,25 @@ describe('confirmCheckoutSessionTransaction', () => {
         }
       )
 
-      expect(result.confirmResult.result.customer).toMatchObject({})
+      expect(result.confirmResult.customer).toMatchObject({})
       // Verify that createFeeCalculationForCheckoutSession was not called
       expect(result.feeCalculations.length).toBe(0)
     })
 
     it('should use existing fee calculation when one is already present', async () => {
       const checkoutFeeCalculations =
-        await comprehensiveAdminTransaction(
-          async ({ transaction }) => {
-            await confirmCheckoutSessionTransaction(
-              { id: checkoutSession.id },
-              transaction
-            )
-            const feeCalculations = await selectFeeCalculations(
-              { checkoutSessionId: checkoutSession.id },
-              transaction
-            )
-            return { result: feeCalculations }
-          }
-        )
+        await comprehensiveAdminTransaction(async (ctx) => {
+          const { transaction } = ctx
+          await confirmCheckoutSessionTransaction(
+            { id: checkoutSession.id },
+            ctx
+          )
+          const feeCalculations = await selectFeeCalculations(
+            { checkoutSessionId: checkoutSession.id },
+            transaction
+          )
+          return { result: feeCalculations }
+        })
 
       expect(checkoutFeeCalculations.length).toBe(1)
     })
@@ -252,11 +258,14 @@ describe('confirmCheckoutSessionTransaction', () => {
   describe('Customer Handling', () => {
     it('should retrieve customer via customerId when set on the session', async () => {
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: checkoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: checkoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -279,11 +288,14 @@ describe('confirmCheckoutSessionTransaction', () => {
       })
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: checkoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: checkoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -315,11 +327,14 @@ describe('confirmCheckoutSessionTransaction', () => {
       )
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: checkoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: checkoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -370,11 +385,14 @@ describe('confirmCheckoutSessionTransaction', () => {
       )
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: checkoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: checkoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -459,11 +477,14 @@ describe('confirmCheckoutSessionTransaction', () => {
       )
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: checkoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: checkoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -552,11 +573,14 @@ describe('confirmCheckoutSessionTransaction', () => {
       )
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: checkoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: checkoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -616,11 +640,14 @@ describe('confirmCheckoutSessionTransaction', () => {
       )
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: checkoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: checkoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -649,18 +676,21 @@ describe('confirmCheckoutSessionTransaction', () => {
       })
 
       await expect(
-        comprehensiveAdminTransaction(async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
+        comprehensiveAdminTransaction(async (ctx) => {
+          const { transaction } = ctx
+          const result = await confirmCheckoutSessionTransaction(
             { id: checkoutSession.id },
-            transaction
+            ctx
           )
+          return { result }
         })
       ).rejects.toThrow('Checkout session has no customer email')
     })
 
     it('should skip Stripe customer creation when customer record has stripeCustomerId', async () => {
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
+        async (ctx) => {
+          const { transaction } = ctx
           const updatedCustomer = await updateCustomer(
             {
               ...customer,
@@ -675,7 +705,7 @@ describe('confirmCheckoutSessionTransaction', () => {
           const confirmResult =
             await confirmCheckoutSessionTransaction(
               { id: checkoutSession.id },
-              transaction
+              ctx
             )
           return {
             result: { confirmResult, updatedCustomer },
@@ -683,10 +713,10 @@ describe('confirmCheckoutSessionTransaction', () => {
         }
       )
 
-      expect(result.confirmResult.result.customer).toMatchObject({})
-      expect(
-        result.confirmResult.result.customer?.stripeCustomerId
-      ).toEqual(result.updatedCustomer.stripeCustomerId)
+      expect(result.confirmResult.customer).toMatchObject({})
+      expect(result.confirmResult.customer?.stripeCustomerId).toEqual(
+        result.updatedCustomer.stripeCustomerId
+      )
       // Verify that createStripeCustomer was not called
       expect(createStripeCustomer).not.toHaveBeenCalled()
     })
@@ -711,11 +741,14 @@ describe('confirmCheckoutSessionTransaction', () => {
       )
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: checkoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: checkoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -747,11 +780,13 @@ describe('confirmCheckoutSessionTransaction', () => {
       })
 
       await expect(
-        comprehensiveAdminTransaction(async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
+        comprehensiveAdminTransaction(async (ctx) => {
+          const { transaction } = ctx
+          const result = await confirmCheckoutSessionTransaction(
             { id: checkoutSession.id },
-            transaction
+            ctx
           )
+          return { result }
         })
       ).rejects.toThrow('Checkout session has no customer email')
     })
@@ -813,11 +848,14 @@ describe('confirmCheckoutSessionTransaction', () => {
       vi.mocked(getSetupIntent).mockResolvedValue(mockSetupIntent)
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: updatedCheckoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: updatedCheckoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -885,11 +923,14 @@ describe('confirmCheckoutSessionTransaction', () => {
       vi.mocked(getSetupIntent).mockResolvedValue(mockSetupIntent)
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: updatedCheckoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: updatedCheckoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -921,11 +962,14 @@ describe('confirmCheckoutSessionTransaction', () => {
       // Mock calculateTotalFeeAmount and calculateTotalDueAmount
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: updatedCheckoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: updatedCheckoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -964,11 +1008,14 @@ describe('confirmCheckoutSessionTransaction', () => {
       const mockTotalAmountDue = 0
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: updatedCheckoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: updatedCheckoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -1006,11 +1053,14 @@ describe('confirmCheckoutSessionTransaction', () => {
         )
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: checkoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: checkoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -1059,11 +1109,14 @@ describe('confirmCheckoutSessionTransaction', () => {
       })
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: updatedCheckoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: updatedCheckoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -1113,11 +1166,14 @@ describe('confirmCheckoutSessionTransaction', () => {
         )
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: updatedCheckoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: updatedCheckoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -1143,11 +1199,14 @@ describe('confirmCheckoutSessionTransaction', () => {
         )
 
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: updatedCheckoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: updatedCheckoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 
@@ -1161,11 +1220,14 @@ describe('confirmCheckoutSessionTransaction', () => {
   describe('Return Value', () => {
     it('should return the customer object with all expected properties', async () => {
       const result = await comprehensiveAdminTransaction(
-        async ({ transaction }) => {
-          return confirmCheckoutSessionTransaction(
-            { id: checkoutSession.id },
-            transaction
-          )
+        async (ctx) => {
+          const { transaction } = ctx
+          const confirmResult =
+            await confirmCheckoutSessionTransaction(
+              { id: checkoutSession.id },
+              ctx
+            )
+          return { result: confirmResult }
         }
       )
 

--- a/platform/flowglad-next/src/utils/bookkeeping/confirmCheckoutSession.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/confirmCheckoutSession.ts
@@ -1,7 +1,5 @@
-import type { LedgerCommand } from '@/db/ledgerManager/ledgerManagerTypes'
 import { feeReadyCheckoutSessionSelectSchema } from '@/db/schema/checkoutSessions'
 import type { Customer } from '@/db/schema/customers'
-import type { Event } from '@/db/schema/events'
 import type { FeeCalculation } from '@/db/schema/feeCalculations'
 import {
   selectCheckoutSessionById,
@@ -13,8 +11,7 @@ import {
 } from '@/db/tableMethods/customerMethods'
 import { selectLatestFeeCalculation } from '@/db/tableMethods/feeCalculationMethods'
 import { selectPurchaseAndCustomersByPurchaseWhere } from '@/db/tableMethods/purchaseMethods'
-import type { TransactionOutput } from '@/db/transactionEnhacementTypes'
-import type { DbTransaction } from '@/db/types'
+import type { TransactionEffectsContext } from '@/db/types'
 import { CheckoutSessionStatus, CheckoutSessionType } from '@/types'
 import { createCustomerBookkeeping } from '@/utils/bookkeeping'
 import { createFeeCalculationForCheckoutSession } from '@/utils/bookkeeping/fees/checkoutSession'
@@ -35,8 +32,9 @@ import {
 
 export const confirmCheckoutSessionTransaction = async (
   input: { id: string; savePaymentMethodForFuture?: boolean },
-  transaction: DbTransaction
-): Promise<TransactionOutput<{ customer: Customer.Record }>> => {
+  ctx: TransactionEffectsContext
+): Promise<{ customer: Customer.Record }> => {
+  const { transaction, emitEvent, enqueueLedgerCommand } = ctx
   try {
     // Find purchase session
     const checkoutSession = await selectCheckoutSessionById(
@@ -71,8 +69,6 @@ export const confirmCheckoutSessionTransaction = async (
     }
 
     let customer: Customer.Record | null = null
-    let customerEvents: Event.Insert[] = []
-    let customerLedgerCommand: LedgerCommand | undefined
 
     if (checkoutSession.customerId) {
       // Find customer
@@ -114,14 +110,21 @@ export const confirmCheckoutSessionTransaction = async (
           transaction,
           organizationId: checkoutSession.organizationId,
           livemode: checkoutSession.livemode,
+          emitEvent,
+          enqueueLedgerCommand,
         }
       )
 
       customer = customerResult.result.customer
 
-      // Store events/ledger from customer creation to bubble up
-      customerEvents = customerResult.eventsToInsert || []
-      customerLedgerCommand = customerResult.ledgerCommand
+      // Emit events from customer creation
+      if (customerResult.eventsToInsert?.length) {
+        emitEvent(...customerResult.eventsToInsert)
+      }
+      // Enqueue ledger command from customer creation
+      if (customerResult.ledgerCommand) {
+        enqueueLedgerCommand(customerResult.ledgerCommand)
+      }
     }
     /**
      * Set the customer id if the checkout session doesn't have one,
@@ -238,14 +241,7 @@ export const confirmCheckoutSessionTransaction = async (
         )
       }
     }
-    return {
-      result: {
-        customer,
-      },
-      eventsToInsert:
-        customerEvents.length > 0 ? customerEvents : undefined,
-      ledgerCommand: customerLedgerCommand,
-    }
+    return { customer }
   } catch (error) {
     core.error(error)
     throw error

--- a/platform/flowglad-next/src/utils/bookkeeping/processPaymentIntentStatusUpdated.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping/processPaymentIntentStatusUpdated.ts
@@ -1,9 +1,5 @@
 import type Stripe from 'stripe'
-import type {
-  CreditGrantRecognizedLedgerCommand,
-  LedgerCommand,
-} from '@/db/ledgerManager/ledgerManagerTypes'
-import type { Event } from '@/db/schema/events'
+import type { CreditGrantRecognizedLedgerCommand } from '@/db/ledgerManager/ledgerManagerTypes'
 import type { FeeCalculation } from '@/db/schema/feeCalculations'
 import type { Payment } from '@/db/schema/payments'
 import type { Purchase } from '@/db/schema/purchases'
@@ -26,8 +22,10 @@ import {
   selectSubscriptionById,
 } from '@/db/tableMethods/subscriptionMethods'
 import { bulkInsertOrDoNothingUsageCreditsByPaymentSubscriptionAndUsageMeter } from '@/db/tableMethods/usageCreditMethods'
-import type { TransactionOutput } from '@/db/transactionEnhacementTypes'
-import type { DbTransaction } from '@/db/types'
+import type {
+  DbTransaction,
+  TransactionEffectsContext,
+} from '@/db/types'
 import { sendCustomerPaymentFailedNotificationIdempotently } from '@/trigger/notifications/send-customer-payment-failed-notification'
 import { idempotentSendOrganizationPaymentFailedNotification } from '@/trigger/notifications/send-organization-payment-failed-notification'
 import {
@@ -108,11 +106,11 @@ export const upsertPaymentForStripeCharge = async (
     charge: Stripe.Charge
     paymentIntentMetadata: StripeIntentMetadata
   },
-  transaction: DbTransaction
+  ctx: TransactionEffectsContext
 ): Promise<{
   payment: Payment.Record
-  eventsToInsert: Event.Insert[]
 }> => {
+  const { transaction, emitEvent } = ctx
   const paymentIntentId = charge.payment_intent
     ? stripeIdFromObjectOrId(charge.payment_intent)
     : null
@@ -134,8 +132,6 @@ export const upsertPaymentForStripeCharge = async (
   let livemode: Nullish<boolean> = null
   let customerId: Nullish<string> = null
   let currency: Nullish<CurrencyCode> = null
-  let subscriptionId: Nullish<string> = null
-  let checkoutSessionEvents: Event.Insert[] = []
   let feeCalculation: FeeCalculation.Record | null = null
   if (paymentIntentMetadata.type === IntentMetadataType.BillingRun) {
     const billingRun = await selectBillingRunById(
@@ -163,7 +159,6 @@ export const upsertPaymentForStripeCharge = async (
     customerId = subscription.customerId
     organizationId = subscription.organizationId
     livemode = subscription.livemode
-    subscriptionId = subscription.id
     feeCalculation = await selectFeeCalculationForPaymentIntent(
       {
         type: IntentMetadataType.BillingRun,
@@ -191,7 +186,10 @@ export const upsertPaymentForStripeCharge = async (
       },
       transaction
     )
-    checkoutSessionEvents = eventsFromCheckoutSession
+    // Emit events from checkout session processing
+    if (eventsFromCheckoutSession.length > 0) {
+      emitEvent(...eventsFromCheckoutSession)
+    }
     invoiceId = invoice?.id ?? null
     currency = invoice?.currency ?? null
     if (!checkoutSession.organizationId) {
@@ -205,9 +203,6 @@ export const upsertPaymentForStripeCharge = async (
     purchaseId = purchase?.id ?? null
     livemode = checkoutSession.livemode
     customerId = purchase?.customerId || invoice?.customerId || null
-    // hard assumption
-    // checkoutSessionId payment intents are only for anonymous single payment purchases
-    subscriptionId = null
   } else {
     throw new Error(
       'No invoice, purchase, or subscription found for payment intent'
@@ -291,7 +286,6 @@ export const upsertPaymentForStripeCharge = async (
     )
   return {
     payment: latestPayment,
-    eventsToInsert: checkoutSessionEvents,
   }
 }
 
@@ -473,13 +467,14 @@ export const ledgerCommandForPaymentSucceeded = async (
  * If the payment has already been marked succeeded, return.
  * Otherwise, we need to create a payment record and mark it succeeded.
  * @param paymentIntent
- * @param transaction
+ * @param ctx
  * @returns
  */
 export const processPaymentIntentStatusUpdated = async (
   paymentIntent: CoreStripePaymentIntent,
-  transaction: DbTransaction
-): Promise<TransactionOutput<{ payment: Payment.Record }>> => {
+  ctx: TransactionEffectsContext
+): Promise<{ payment: Payment.Record }> => {
+  const { transaction, emitEvent, enqueueLedgerCommand } = ctx
   const metadata = stripeIntentMetadataSchema.parse(
     paymentIntent.metadata
   )
@@ -502,16 +497,15 @@ export const processPaymentIntentStatusUpdated = async (
       `No charge found for payment intent ${paymentIntent.id}`
     )
   }
-  const { payment, eventsToInsert: checkoutSessionEvents } =
-    await upsertPaymentForStripeCharge(
-      {
-        charge: latestCharge,
-        paymentIntentMetadata: stripeIntentMetadataSchema.parse(
-          paymentIntent.metadata
-        ),
-      },
-      transaction
-    )
+  const { payment } = await upsertPaymentForStripeCharge(
+    {
+      charge: latestCharge,
+      paymentIntentMetadata: stripeIntentMetadataSchema.parse(
+        paymentIntent.metadata
+      ),
+    },
+    ctx
+  )
   // Fetch customer data for event payload
   // Re-fetch purchase after update to get the latest status
   const purchase = payment.purchaseId
@@ -522,10 +516,8 @@ export const processPaymentIntentStatusUpdated = async (
     transaction
   )
   const timestamp = Date.now()
-  const eventInserts: Event.Insert[] = []
-  let ledgerCommand: LedgerCommand | undefined
   if (paymentIntent.status === 'succeeded') {
-    eventInserts.push({
+    emitEvent({
       type: FlowgladEventType.PaymentSucceeded,
       occurredAt: timestamp,
       organizationId: payment.organizationId,
@@ -549,17 +541,20 @@ export const processPaymentIntentStatusUpdated = async (
         transaction
       )
       if (checkoutSession.priceId) {
-        ledgerCommand = await ledgerCommandForPaymentSucceeded(
+        const ledgerCommand = await ledgerCommandForPaymentSucceeded(
           {
             priceId: checkoutSession.priceId,
             payment,
           },
           transaction
         )
+        if (ledgerCommand) {
+          enqueueLedgerCommand(ledgerCommand)
+        }
       }
     }
   } else if (paymentIntent.status === 'canceled') {
-    eventInserts.push({
+    emitEvent({
       type: FlowgladEventType.PaymentFailed,
       occurredAt: timestamp,
       organizationId: payment.organizationId,
@@ -590,7 +585,7 @@ export const processPaymentIntentStatusUpdated = async (
       )
     }
 
-    eventInserts.push({
+    emitEvent({
       type: FlowgladEventType.PurchaseCompleted,
       occurredAt: timestamp,
       organizationId: payment.organizationId,
@@ -609,9 +604,5 @@ export const processPaymentIntentStatusUpdated = async (
       processedAt: null,
     })
   }
-  return {
-    result: { payment },
-    eventsToInsert: [...checkoutSessionEvents, ...eventInserts],
-    ledgerCommand,
-  }
+  return { payment }
 }


### PR DESCRIPTION
## Summary

- Migrates `processPaymentIntentStatusUpdated` and `confirmCheckoutSessionTransaction` from the legacy `TransactionOutput<T>` return pattern to the callback-based `TransactionEffectsContext` pattern
- Updates all callers to use the new API signatures with proper context propagation
- Updates test files to use `comprehensiveAdminTransaction` with the new callback structure

## Key Changes

### Function Signatures

**Before:**
```typescript
const { result, eventsToInsert, ledgerCommand } = 
  await processPaymentIntentStatusUpdated(paymentIntent, transaction)
```

**After:**
```typescript
const { payment } = await processPaymentIntentStatusUpdated(paymentIntent, {
  transaction,
  emitEvent,
  enqueueLedgerCommand,
  invalidateCache,
})
```

### Files Modified

| File | Change |
|------|--------|
| `processPaymentIntentStatusUpdated.ts` | Core migration to TransactionEffectsContext |
| `confirmCheckoutSession.ts` | Core migration to TransactionEffectsContext |
| `payment-intent-succeeded.ts` | Updated Trigger task to use new API |
| `post-payment/route.tsx` | Updated app route handler |
| `confirmCheckoutSession.ts` (mutation) | Updated server mutation |
| `processBillingRunPaymentIntents.ts` | Updated billing run processor |
| `*.test.ts` | Updated test files to use new patterns |

## Test plan

- [x] `bun run check` passes (lint, format, typecheck)
- [ ] Verify payment processing flow works in staging
- [ ] Verify checkout session confirmation works in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates payment processing to the TransactionEffectsContext callback pattern, replacing the legacy TransactionOutput flow. Simplifies return types and centralizes event emission and ledger queuing, with updates across triggers, routes, mutations, billing runs, and tests.

- **Refactors**
  - processPaymentIntentStatusUpdated, confirmCheckoutSessionTransaction, and upsertPaymentForStripeCharge now accept ctx: TransactionEffectsContext.
  - Events emitted via ctx.emitEvent; ledger commands enqueued via ctx.enqueueLedgerCommand; cache invalidations via ctx.invalidateCache.
  - Return values simplified to primary results only (e.g., { payment }, { customer }).
  - Updated trigger (payment-intent-succeeded), post-payment route, confirmCheckoutSession mutation, billing run processing, and tests to use comprehensiveAdminTransaction and pass callbacks.

- **Migration**
  - Replace transaction arg with ctx in callers: { transaction, emitEvent, enqueueLedgerCommand, invalidateCache }.
  - Remove use of eventsToInsert and ledgerCommand from return values; rely on callbacks.
  - In tests, use comprehensiveAdminTransaction and pass no-op callbacks where needed (e.g., createNoopContext for helper calls).

<sup>Written for commit ffb87c7ea37377c9887833dda33d6e6fdc58acd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined payment and checkout processing to use a unified transaction context for more consistent handling.
  * Events are now emitted directly and ledger actions coordinated centrally, improving reliability of payment state updates and billing.
  * Simplified public interfaces and return shapes for payment-related operations for clearer, more predictable results.

* **Tests**
  * Updated tests to use the new context-driven flows and adjusted assertions to match simplified return shapes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->