### PR TITLE
chore: restore resource UI as dev-only

### DIFF
--- a/platform/flowglad-next/src/app/finance/subscriptions/[id]/InnerSubscriptionPage.tsx
+++ b/platform/flowglad-next/src/app/finance/subscriptions/[id]/InnerSubscriptionPage.tsx
@@ -10,8 +10,7 @@ import CancelSubscriptionModal from '@/components/forms/CancelSubscriptionModal'
 import { ItemFeature } from '@/components/ItemFeature'
 import PageContainer from '@/components/PageContainer'
 import { ProductCard } from '@/components/ProductCard'
-// FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-// import { SubscriptionResourceUsage } from '@/components/subscriptions/SubscriptionResourceUsage'
+import { SubscriptionResourceUsage } from '@/components/subscriptions/SubscriptionResourceUsage'
 import { CopyableField } from '@/components/ui/copyable-field'
 import { PageHeaderNew } from '@/components/ui/page-header-new'
 import {
@@ -34,7 +33,7 @@ import {
   FeatureUsageGrantFrequency,
   SubscriptionStatus,
 } from '@/types'
-import core from '@/utils/core'
+import core, { IS_DEV } from '@/utils/core'
 import { formatBillingPeriod, getCurrencyParts } from '@/utils/stripe'
 import { AddSubscriptionFeatureModal } from './AddSubscriptionFeatureModal'
 import { BillingHistorySection } from './BillingHistorySection'
@@ -274,13 +273,17 @@ const InnerSubscriptionPage = ({
             )}
           </div>
         </ExpandSection>
-        {/* FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-        <ExpandSection title="Resource Usage" defaultExpanded={false}>
-          <SubscriptionResourceUsage
-            subscriptionId={subscription.id}
-          />
-        </ExpandSection>
-        */}
+        {/* FIXME: Resource UI is temporarily dev-only while resource features are gated behind devOnlyProcedure. Remove IS_DEV check when resources are ready for production. */}
+        {IS_DEV && (
+          <ExpandSection
+            title="Resource Usage"
+            defaultExpanded={false}
+          >
+            <SubscriptionResourceUsage
+              subscriptionId={subscription.id}
+            />
+          </ExpandSection>
+        )}
         <BillingHistorySection
           subscriptionId={subscription.id}
           customerId={subscription.customerId}

--- a/platform/flowglad-next/src/app/pricing-models/[id]/InnerPricingModelDetailsPage.tsx
+++ b/platform/flowglad-next/src/app/pricing-models/[id]/InnerPricingModelDetailsPage.tsx
@@ -11,14 +11,11 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 import { trpc } from '@/app/_trpc/client'
 import { CustomersDataTable } from '@/app/customers/data-table'
-// FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-// import { ResourcesDataTable } from '@/app/resources/data-table'
+import { ResourcesDataTable } from '@/app/resources/data-table'
 import { UsageMetersDataTable } from '@/app/usage-meters/data-table'
-// FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-// import CreateResourceModal from '@/components/components/CreateResourceModal'
+import CreateResourceModal from '@/components/components/CreateResourceModal'
 import CreateUsageMeterModal from '@/components/components/CreateUsageMeterModal'
-// FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-// import EditResourceModal from '@/components/components/EditResourceModal'
+import EditResourceModal from '@/components/components/EditResourceModal'
 import { ExpandSection } from '@/components/ExpandSection'
 import { FeaturesDataTable } from '@/components/features/data-table'
 import ClonePricingModelModal from '@/components/forms/ClonePricingModelModal'
@@ -42,8 +39,8 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover'
 import type { PricingModel } from '@/db/schema/pricingModels'
-// FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-// import type { Resource } from '@/db/schema/resources'
+import type { Resource } from '@/db/schema/resources'
+import { IS_DEV } from '@/utils/core'
 
 export type InnerPricingModelDetailsPageProps = {
   pricingModel: PricingModel.ClientRecord
@@ -71,13 +68,12 @@ function InnerPricingModelDetailsPage({
     isCreateUsageMeterModalOpen,
     setIsCreateUsageMeterModalOpen,
   ] = useState(false)
-  // FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-  // const [isCreateResourceModalOpen, setIsCreateResourceModalOpen] =
-  //   useState(false)
-  // const [isEditResourceModalOpen, setIsEditResourceModalOpen] =
-  //   useState(false)
-  // const [resourceToEdit, setResourceToEdit] =
-  //   useState<Resource.ClientRecord | null>(null)
+  const [isCreateResourceModalOpen, setIsCreateResourceModalOpen] =
+    useState(false)
+  const [isEditResourceModalOpen, setIsEditResourceModalOpen] =
+    useState(false)
+  const [resourceToEdit, setResourceToEdit] =
+    useState<Resource.ClientRecord | null>(null)
   const [activeProductFilter, setActiveProductFilter] =
     useState<string>('active')
   const [activeFeatureFilter, setActiveFeatureFilter] =
@@ -305,25 +301,26 @@ function InnerPricingModelDetailsPage({
             buttonVariant="secondary"
           />
         </ExpandSection>
-        {/* FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-        <ExpandSection
-          title="Resources"
-          defaultExpanded={false}
-          contentPadding={false}
-        >
-          <ResourcesDataTable
-            filters={{ pricingModelId: pricingModel.id }}
-            onCreateResource={() =>
-              setIsCreateResourceModalOpen(true)
-            }
-            onEditResource={(resource) => {
-              setResourceToEdit(resource)
-              setIsEditResourceModalOpen(true)
-            }}
-            buttonVariant="secondary"
-          />
-        </ExpandSection>
-        */}
+        {/* FIXME: Resource UI is temporarily dev-only while resource features are gated behind devOnlyProcedure. Remove IS_DEV check when resources are ready for production. */}
+        {IS_DEV && (
+          <ExpandSection
+            title="Resources"
+            defaultExpanded={false}
+            contentPadding={false}
+          >
+            <ResourcesDataTable
+              filters={{ pricingModelId: pricingModel.id }}
+              onCreateResource={() =>
+                setIsCreateResourceModalOpen(true)
+              }
+              onEditResource={(resource) => {
+                setResourceToEdit(resource)
+                setIsEditResourceModalOpen(true)
+              }}
+              buttonVariant="secondary"
+            />
+          </ExpandSection>
+        )}
         <ExpandSection
           title="Customers"
           defaultExpanded={false}
@@ -366,21 +363,24 @@ function InnerPricingModelDetailsPage({
         defaultPricingModelId={pricingModel.id}
         hidePricingModelSelect={true}
       />
-      {/* FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-      <CreateResourceModal
-        isOpen={isCreateResourceModalOpen}
-        setIsOpen={setIsCreateResourceModalOpen}
-        defaultPricingModelId={pricingModel.id}
-        hidePricingModelSelect={true}
-      />
-      {resourceToEdit && (
-        <EditResourceModal
-          isOpen={isEditResourceModalOpen}
-          setIsOpen={setIsEditResourceModalOpen}
-          resource={resourceToEdit}
-        />
+      {/* FIXME: Resource modals are temporarily dev-only while resource features are gated behind devOnlyProcedure. Remove IS_DEV check when resources are ready for production. */}
+      {IS_DEV && (
+        <>
+          <CreateResourceModal
+            isOpen={isCreateResourceModalOpen}
+            setIsOpen={setIsCreateResourceModalOpen}
+            defaultPricingModelId={pricingModel.id}
+            hidePricingModelSelect={true}
+          />
+          {resourceToEdit && (
+            <EditResourceModal
+              isOpen={isEditResourceModalOpen}
+              setIsOpen={setIsEditResourceModalOpen}
+              resource={resourceToEdit}
+            />
+          )}
+        </>
       )}
-      */}
       <PricingModelIntegrationGuideModal
         isOpen={isGetIntegrationGuideModalOpen}
         setIsOpen={setIsGetIntegrationGuideModalOpen}

--- a/platform/flowglad-next/src/components/forms/FeatureFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/FeatureFormFields.tsx
@@ -22,15 +22,13 @@ import {
 import { Switch } from '@/components/ui/switch'
 import {
   type CreateFeatureInput,
-  // FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-  // resourceFeatureDefaultColumns,
+  resourceFeatureDefaultColumns,
   toggleFeatureDefaultColumns,
   usageCreditGrantFeatureDefaultColumns,
 } from '@/db/schema/features'
 import { FeatureType, FeatureUsageGrantFrequency } from '@/types'
-import core, { titleCase } from '@/utils/core'
-// FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-// import ResourcesSelect from './ResourcesSelect'
+import core, { IS_DEV, titleCase } from '@/utils/core'
+import ResourcesSelect from './ResourcesSelect'
 import UsageMetersSelect from './UsageMetersSelect'
 
 const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
@@ -123,12 +121,12 @@ const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
                       usageCreditGrantFeatureDefaultColumns
                     ).forEach(assignFeatureValueFromTuple)
                   }
-                  // FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-                  // if (value === FeatureType.Resource) {
-                  //   Object.entries(
-                  //     resourceFeatureDefaultColumns
-                  //   ).forEach(assignFeatureValueFromTuple)
-                  // }
+                  // FIXME: Resource feature type is temporarily dev-only while resource features are gated behind devOnlyProcedure. Remove IS_DEV check when resources are ready for production.
+                  if (IS_DEV && value === FeatureType.Resource) {
+                    Object.entries(
+                      resourceFeatureDefaultColumns
+                    ).forEach(assignFeatureValueFromTuple)
+                  }
                 }}
               >
                 <SelectTrigger>
@@ -151,16 +149,17 @@ const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
                       </div>
                     </div>
                   </SelectItem>
-                  {/* FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-                  <SelectItem value={FeatureType.Resource}>
-                    <div>
-                      <div>Resource</div>
-                      <div className="text-xs text-muted-foreground">
-                        Claimable capacity (seats, API keys, etc.)
+                  {/* FIXME: Resource feature type is temporarily dev-only while resource features are gated behind devOnlyProcedure. Remove IS_DEV check when resources are ready for production. */}
+                  {IS_DEV && (
+                    <SelectItem value={FeatureType.Resource}>
+                      <div>
+                        <div>Resource</div>
+                        <div className="text-xs text-muted-foreground">
+                          Claimable capacity (seats, API keys, etc.)
+                        </div>
                       </div>
-                    </div>
-                  </SelectItem>
-                  */}
+                    </SelectItem>
+                  )}
                 </SelectContent>
               </Select>
             </FormControl>
@@ -238,8 +237,8 @@ const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
         </>
       )}
 
-      {/* FIXME: FEATURE - Resource UI is temporarily disabled while resource features are gated behind devOnlyProcedure
-      {featureType === FeatureType.Resource && (
+      {/* FIXME: Resource form fields are temporarily dev-only while resource features are gated behind devOnlyProcedure. Remove IS_DEV check when resources are ready for production. */}
+      {IS_DEV && featureType === FeatureType.Resource && (
         <>
           <FormField
             control={form.control}
@@ -282,7 +281,6 @@ const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
           />
         </>
       )}
-      */}
       <Controller
         control={form.control}
         name="feature.active"


### PR DESCRIPTION
## What Does this PR Do?

Restore all resource-related UI components that were previously disabled while the resource feature was gated behind devOnlyProcedure. This includes the Resource Usage section on subscription pages, the Resources section on pricing model details, and the Resource feature type in feature creation forms. All restored UI is gated behind IS_DEV checks and only displays in development mode. FIXME comments indicate these checks should be removed once resources are ready for production.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored the resource-related UI and gated it behind IS_DEV so it only appears in development. This lets us test resources without exposing them in production.

- **New Features**
  - Resources section and create/edit modals on pricing model details
  - Resource Usage section on subscription page
  - Resource feature type and related form fields in feature creation

<sup>Written for commit 715a9857495d09cc4d75a5e7e1a28ac64c7c9dea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Resource Usage monitoring is now available in subscriptions.
  * Resource management capabilities are now enabled in pricing model configurations, including create and edit functionality.
  * Resource selection options are now available when managing feature forms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->