### PR TITLE
feat(docs): Update YouTube footer link to demo video

### DIFF
--- a/platform/docs/docs.json
+++ b/platform/docs/docs.json
@@ -178,7 +178,7 @@
       "discord": "https://discord.com/servers/flowglad-1273695198639161364",
       "github": "https://github.com/flowglad",
       "linkedin": "https://www.linkedin.com/company/flowglad/",
-      "youtube": "https://www.youtube.com/@Flowglad"
+      "youtube": "https://www.youtube.com/watch?v=G6H0c1Cd2kU"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Updates the YouTube social link in the docs footer to point to the demo video instead of the general channel

Closes #1340

## Changes
- Changed `youtube` URL in `platform/docs/docs.json` from `https://www.youtube.com/@Flowglad` to `https://www.youtube.com/watch?v=G6H0c1Cd2kU`

## Test plan
- [ ] Verify the YouTube link in the docs footer now points to the demo video

🤖 Generated with [Claude Code](https://claude.ai/code) on [VERS](https://vers.sh)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the docs footer YouTube link to point to the demo video (https://www.youtube.com/watch?v=G6H0c1Cd2kU) instead of the channel, so visitors land on the demo immediately.

<sup>Written for commit 0f4c1d10214fb640f0e881e9621c5e9ea5f89304. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the YouTube social media link in the footer to reference a specific video.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->