### PR TITLE
docs: instruct coding agents to open draft PR immediately

### DIFF
--- a/platform/flowglad-next/llm-prompts/fan-gameplan.md
+++ b/platform/flowglad-next/llm-prompts/fan-gameplan.md
@@ -60,10 +60,21 @@ This structure is required for compatibility with `fan-patches.sh`, which spins 
 - Branch from: `{base branch determined in step 5 for this patch}`
 - Branch name: `{project-name}/patch-{N}-{descriptive-slug}`
 - PR base: `{base branch determined in step 5 for this patch}`
-- After completing, run `bun run check` to verify lint/typecheck passes.
+
+**IMPORTANT: Open a draft PR immediately after your first commit.** Do not wait until implementation is complete. This ensures the PR title format is correct from the start.
+
+After your first commit, run:
+```bash
+gh pr create --draft --title "[{project-name}] Patch {N}: {Title}" --body "Work in progress" --base {base branch}
+```
+
+Then continue implementing. When finished:
+1. Run `bun run check` to verify lint/typecheck passes
+2. Update the PR description with a proper summary
+3. Mark the PR as ready for review when complete
 
 ## PR Title (CRITICAL)
-**You MUST use this EXACT title format when creating the PR:**
+**You MUST use this EXACT title format:**
 
 `[{project-name}] Patch {N}: {Title}`
 


### PR DESCRIPTION
## Summary
- Updates `fan-gameplan.md` template to instruct coding agents to open a draft PR immediately after their first commit
- Provides the exact `gh pr create --draft` command with the correct title format baked in
- Adds follow-up workflow: continue implementing, run checks, update PR description, mark ready

## Motivation
This change makes it more likely that the PR naming instructions will be followed, since the agent creates the PR with the correct title format right at the start rather than at the end when the format might be forgotten.

## Test plan
- [ ] Verify the template renders correctly when used by fan-gameplan

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update fan-gameplan.md to instruct coding agents to open a draft PR right after their first commit, using gh pr create --draft with the required title format. Adds a follow-up flow: keep implementing, run bun run check, update the PR description, then mark ready for review.

<sup>Written for commit 42e116710e7c61f2249f811870bbb22ad756b146. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

