### PR TITLE
fix: Fix MSW mock response for Unkey deleteKey endpoint

### DIFF
--- a/platform/flowglad-next/mocks/unkeyServer.ts
+++ b/platform/flowglad-next/mocks/unkeyServer.ts
@@ -39,6 +39,7 @@ export const unkeyHandlers = [
       meta: {
         requestId: `req_${core.nanoid()}`,
       },
+      data: {},
     })
   }),
 
@@ -94,6 +95,7 @@ export const unkeyHandlers = [
         meta: {
           requestId: `req_${core.nanoid()}`,
         },
+        data: {},
       })
     }
   ),


### PR DESCRIPTION
## Summary
- Added missing `data` field to MSW mock handlers for Unkey `deleteKey` endpoint (SDK v2.2.1 requires both `meta` and `data` fields)
- Added test-specific MSW handler in `apiKeyHelpers.test.ts` to properly simulate Unkey deletion failures

## Test plan
- [x] Run `bun run test src/utils/apiKeyHelpers.test.ts` - all tests pass
- [x] Verify the "should NOT delete the database record if Unkey deletion fails" test properly rejects when Unkey returns an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Unkey deleteKey MSW mocks to match the SDK v2.2.1 response shape, unblocking local tests. Adds an error simulation to confirm we keep the DB record when Unkey deletion fails.

- **Bug Fixes**
  - Add data: {} to deleteKey responses in mocks/unkeyServer to satisfy Unkey SDK v2.2.1 (requires meta and data).
  - Add a test-only MSW handler in apiKeyHelpers.test.ts that returns 404 for keys.deleteKey to exercise the failure path.

<sup>Written for commit 7781f9c5cb118f09ed8b45a690a6fc5842074a5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

