### PR TITLE
Add successful payment notification preference

### DIFF
--- a/platform/flowglad-next/src/components/forms/EditNotificationPreferencesModal.test.tsx
+++ b/platform/flowglad-next/src/components/forms/EditNotificationPreferencesModal.test.tsx
@@ -111,6 +111,7 @@ describe('EditNotificationPreferencesModal', () => {
     subscriptionCanceled: true,
     subscriptionCancellationScheduled: true,
     paymentFailed: true,
+    paymentSuccessful: true,
   }
 
   const mockMutateAsync = vi.fn()
@@ -294,6 +295,7 @@ describe('EditNotificationPreferencesModal', () => {
         subscriptionCanceled: true,
         subscriptionCancellationScheduled: true,
         paymentFailed: true,
+        paymentSuccessful: true,
       }
 
       render(
@@ -318,6 +320,7 @@ describe('EditNotificationPreferencesModal', () => {
         subscriptionCanceled: false,
         subscriptionCancellationScheduled: false,
         paymentFailed: false,
+        paymentSuccessful: false,
       }
 
       render(
@@ -344,6 +347,7 @@ describe('EditNotificationPreferencesModal', () => {
         subscriptionCanceled: false,
         subscriptionCancellationScheduled: true,
         paymentFailed: false,
+        paymentSuccessful: true,
       }
 
       render(

--- a/platform/flowglad-next/src/components/forms/NotificationPreferencesFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/NotificationPreferencesFormFields.tsx
@@ -110,6 +110,12 @@ const NotificationPreferencesFormFields = () => {
           Payment Notifications
         </div>
         <NotificationToggle
+          id="payment-successful"
+          name="paymentSuccessful"
+          label="Payment Successful"
+          description="Notify when a payment is successful"
+        />
+        <NotificationToggle
           id="payment-failed"
           name="paymentFailed"
           label="Payment Failed"

--- a/platform/flowglad-next/src/db/schema/memberships.rls.test.ts
+++ b/platform/flowglad-next/src/db/schema/memberships.rls.test.ts
@@ -253,6 +253,7 @@ describe.sequential('memberships RLS - notificationPreferences', () => {
       expect(prefs.subscriptionAdjusted).toBe(true)
       expect(prefs.subscriptionCanceled).toBe(true)
       expect(prefs.paymentFailed).toBe(true)
+      expect(prefs.paymentSuccessful).toBe(true)
     })
 
     it('preserves existing preferences when updating partial preferences', async () => {

--- a/platform/flowglad-next/src/db/schema/memberships.ts
+++ b/platform/flowglad-next/src/db/schema/memberships.ts
@@ -78,9 +78,9 @@ export const memberships = pgTable(
 
 /**
  * Zod schema for notification preferences stored in the JSONB column.
- * Contains 6 fields:
+ * Contains 7 fields:
  * - testModeNotifications: Controls whether test mode emails are sent (defaults to true)
- * - 5 notification type preferences: Each controls a specific notification type (all default to true)
+ * - 6 notification type preferences: Each controls a specific notification type (all default to true)
  */
 export const notificationPreferencesSchema = z.object({
   testModeNotifications: z.boolean().default(true),
@@ -89,6 +89,7 @@ export const notificationPreferencesSchema = z.object({
   subscriptionCanceled: z.boolean().default(true),
   subscriptionCancellationScheduled: z.boolean().default(true),
   paymentFailed: z.boolean().default(true),
+  paymentSuccessful: z.boolean().default(true),
 })
 
 export type NotificationPreferences = z.infer<

--- a/platform/flowglad-next/src/db/tableMethods/membershipMethods.notificationPreferences.test.ts
+++ b/platform/flowglad-next/src/db/tableMethods/membershipMethods.notificationPreferences.test.ts
@@ -37,12 +37,13 @@ describe('memberships notificationPreferences', () => {
           getMembershipNotificationPreferences(freshMembership)
         expect(prefs.testModeNotifications).toBe(true)
 
-        // getMembershipNotificationPreferences should return all 5 notification types as true
+        // getMembershipNotificationPreferences should return all 6 notification types as true
         expect(prefs.subscriptionCreated).toBe(true)
         expect(prefs.subscriptionAdjusted).toBe(true)
         expect(prefs.subscriptionCanceled).toBe(true)
         expect(prefs.subscriptionCancellationScheduled).toBe(true)
         expect(prefs.paymentFailed).toBe(true)
+        expect(prefs.paymentSuccessful).toBe(true)
 
         // Verify the full shape matches defaults
         expect(prefs).toEqual(DEFAULT_NOTIFICATION_PREFERENCES)
@@ -81,11 +82,12 @@ describe('memberships notificationPreferences', () => {
         // subscriptionCreated should be false (from stored value)
         expect(prefs.subscriptionCreated).toBe(false)
 
-        // All other 4 notification type preferences should return true (from defaults)
+        // All other 5 notification type preferences should return true (from defaults)
         expect(prefs.subscriptionAdjusted).toBe(true)
         expect(prefs.subscriptionCanceled).toBe(true)
         expect(prefs.subscriptionCancellationScheduled).toBe(true)
         expect(prefs.paymentFailed).toBe(true)
+        expect(prefs.paymentSuccessful).toBe(true)
       })
     })
 
@@ -102,12 +104,13 @@ describe('memberships notificationPreferences', () => {
         // testModeNotifications should be true (default)
         expect(prefs.testModeNotifications).toBe(true)
 
-        // All 5 notification type preferences should be true (defaults)
+        // All 6 notification type preferences should be true (defaults)
         expect(prefs.subscriptionCreated).toBe(true)
         expect(prefs.subscriptionAdjusted).toBe(true)
         expect(prefs.subscriptionCanceled).toBe(true)
         expect(prefs.subscriptionCancellationScheduled).toBe(true)
         expect(prefs.paymentFailed).toBe(true)
+        expect(prefs.paymentSuccessful).toBe(true)
       })
     })
 
@@ -140,10 +143,11 @@ describe('memberships notificationPreferences', () => {
         expect(prefs.subscriptionCreated).toBe(false)
         expect(prefs.paymentFailed).toBe(false)
 
-        // All 3 other notification types should be true (defaults)
+        // All 4 other notification types should be true (defaults)
         expect(prefs.subscriptionAdjusted).toBe(true)
         expect(prefs.subscriptionCanceled).toBe(true)
         expect(prefs.subscriptionCancellationScheduled).toBe(true)
+        expect(prefs.paymentSuccessful).toBe(true)
       })
     })
 
@@ -168,6 +172,7 @@ describe('memberships notificationPreferences', () => {
       expect(result.subscriptionCanceled).toBe(true)
       expect(result.subscriptionCancellationScheduled).toBe(true)
       expect(result.paymentFailed).toBe(true)
+      expect(result.paymentSuccessful).toBe(true)
     })
 
     it('DEFAULT_NOTIFICATION_PREFERENCES equals notificationPreferencesSchema.parse({})', () => {

--- a/platform/flowglad-next/src/db/tableMethods/membershipMethods.test.ts
+++ b/platform/flowglad-next/src/db/tableMethods/membershipMethods.test.ts
@@ -36,6 +36,7 @@ describe('getMembershipNotificationPreferences', () => {
     expect(result.subscriptionCanceled).toBe(true)
     expect(result.subscriptionCancellationScheduled).toBe(true)
     expect(result.paymentFailed).toBe(true)
+    expect(result.paymentSuccessful).toBe(true)
   })
 
   it('returns all default preferences when membership has null notificationPreferences', () => {
@@ -67,6 +68,7 @@ describe('getMembershipNotificationPreferences', () => {
     expect(result.subscriptionCanceled).toBe(true)
     expect(result.subscriptionCancellationScheduled).toBe(true)
     expect(result.paymentFailed).toBe(true)
+    expect(result.paymentSuccessful).toBe(true)
   })
 
   it('returns stored preferences when all preferences are explicitly set', () => {
@@ -77,6 +79,7 @@ describe('getMembershipNotificationPreferences', () => {
       subscriptionCanceled: false,
       subscriptionCancellationScheduled: false,
       paymentFailed: false,
+      paymentSuccessful: false,
     }
     const membership: Membership.Record = {
       ...baseMembership,
@@ -106,5 +109,6 @@ describe('getMembershipNotificationPreferences', () => {
     expect(result.subscriptionCanceled).toBe(true)
     expect(result.subscriptionCancellationScheduled).toBe(true)
     expect(result.paymentFailed).toBe(true)
+    expect(result.paymentSuccessful).toBe(true)
   })
 })

--- a/platform/flowglad-next/src/server/routers/organizationsRouter.notificationPreferences.test.ts
+++ b/platform/flowglad-next/src/server/routers/organizationsRouter.notificationPreferences.test.ts
@@ -104,6 +104,7 @@ describe('organizationsRouter notification preferences', () => {
       expect(result.subscriptionCanceled).toBe(true)
       expect(result.subscriptionCancellationScheduled).toBe(true)
       expect(result.paymentFailed).toBe(true)
+      expect(result.paymentSuccessful).toBe(true)
     })
 
     it('returns stored preferences merged with defaults', async () => {
@@ -134,6 +135,7 @@ describe('organizationsRouter notification preferences', () => {
       expect(result.subscriptionCanceled).toBe(true)
       expect(result.subscriptionCancellationScheduled).toBe(true)
       expect(result.paymentFailed).toBe(true)
+      expect(result.paymentSuccessful).toBe(true)
     })
   })
 
@@ -214,6 +216,7 @@ describe('organizationsRouter notification preferences', () => {
         subscriptionCanceled: false,
         subscriptionCancellationScheduled: false,
         paymentFailed: false,
+        paymentSuccessful: false,
       }
 
       const result = await caller.updateNotificationPreferences({
@@ -230,6 +233,7 @@ describe('organizationsRouter notification preferences', () => {
       expect(getResult.subscriptionCanceled).toBe(false)
       expect(getResult.subscriptionCancellationScheduled).toBe(false)
       expect(getResult.paymentFailed).toBe(false)
+      expect(getResult.paymentSuccessful).toBe(false)
     })
 
     it('handles toggling preferences back and forth', async () => {

--- a/platform/flowglad-next/src/server/routers/organizationsRouter.test.ts
+++ b/platform/flowglad-next/src/server/routers/organizationsRouter.test.ts
@@ -97,6 +97,7 @@ describe('organizationsRouter - notification preferences', () => {
       expect(result.subscriptionCanceled).toBe(true)
       expect(result.subscriptionCancellationScheduled).toBe(true)
       expect(result.paymentFailed).toBe(true)
+      expect(result.paymentSuccessful).toBe(true)
     })
 
     it('returns stored notification preferences merged with defaults', async () => {
@@ -125,6 +126,7 @@ describe('organizationsRouter - notification preferences', () => {
       expect(result.subscriptionAdjusted).toBe(true)
       expect(result.subscriptionCanceled).toBe(true)
       expect(result.paymentFailed).toBe(true)
+      expect(result.paymentSuccessful).toBe(true)
     })
 
     it('throws BAD_REQUEST when organizationId is missing', async () => {
@@ -187,6 +189,7 @@ describe('organizationsRouter - notification preferences', () => {
       expect(result.preferences.subscriptionAdjusted).toBe(true)
       expect(result.preferences.subscriptionCanceled).toBe(true)
       expect(result.preferences.paymentFailed).toBe(true)
+      expect(result.preferences.paymentSuccessful).toBe(true)
 
       const getResult = await caller.getNotificationPreferences()
       expect(getResult).toEqual(result.preferences)
@@ -230,6 +233,7 @@ describe('organizationsRouter - notification preferences', () => {
         'subscriptionCanceled',
         'subscriptionCancellationScheduled',
         'paymentFailed',
+        'paymentSuccessful',
       ]
 
       for (const key of expectedKeys) {
@@ -295,6 +299,7 @@ describe('organizationsRouter - notification preferences', () => {
           subscriptionCanceled: false,
           subscriptionCancellationScheduled: false,
           paymentFailed: false,
+          paymentSuccessful: false,
         },
       })
 
@@ -314,6 +319,7 @@ describe('organizationsRouter - notification preferences', () => {
           subscriptionCanceled: true,
           subscriptionCancellationScheduled: true,
           paymentFailed: true,
+          paymentSuccessful: true,
         },
       })
 

--- a/platform/flowglad-next/src/server/routers/organizationsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/organizationsRouter.ts
@@ -497,6 +497,7 @@ const updateNotificationPreferencesInputSchema = z.object({
       subscriptionCanceled: z.boolean().optional(),
       subscriptionCancellationScheduled: z.boolean().optional(),
       paymentFailed: z.boolean().optional(),
+      paymentSuccessful: z.boolean().optional(),
     })
     .partial(),
 })


### PR DESCRIPTION
## What Does this PR Do?

Adds a new `paymentSuccessful` notification preference, allowing users to enable or disable notifications when payments succeed. This complements the existing `paymentFailed` preference and defaults to enabled for all new memberships.

The preference is integrated throughout the notification system: it's stored in the memberships JSONB column, exposed through the get/update notification preferences API endpoints, and included in the settings UI under the Payment Notifications section.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new paymentSuccessful notification preference so users can toggle successful payment emails. Defaults to enabled for new memberships and is wired through the API and settings UI.

- **New Features**
  - Add paymentSuccessful to memberships notificationPreferences (JSONB, default true).
  - Expose via organizationsRouter get/update endpoints and a toggle in Payment Notifications settings.
  - Update tests across schema, table methods, router, and form to cover defaults and partial updates.

<sup>Written for commit 3b56754ee8c7d00e065aad5ab857969befd87583. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Payment Successful" notification preference. Users can now control whether to receive notifications when payments are completed successfully; this preference is enabled by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->