### PR TITLE
fix: clear billing portal cookie when authenticated user navigates to…

### DIFF
--- a/platform/flowglad-next/src/middleware.ts
+++ b/platform/flowglad-next/src/middleware.ts
@@ -2,7 +2,10 @@ import { getSessionCookie } from 'better-auth/cookies'
 import { type NextRequest, NextResponse } from 'next/server'
 import { middlewareLogic } from './routing-logic/middlewareLogic'
 import { isPublicRoute } from './routing-logic/publicRoutes'
-import { getCustomerBillingPortalOrganizationId } from './utils/customerBillingPortalState'
+import {
+  clearCustomerBillingPortalOrganizationId,
+  getCustomerBillingPortalOrganizationId,
+} from './utils/customerBillingPortalState'
 
 export default async function middleware(req: NextRequest) {
   // Handle CORS for staging
@@ -41,6 +44,12 @@ export default async function middleware(req: NextRequest) {
     )
   }
 
+  // Clear billing portal cookie if user is navigating to management portal
+  // This fixes the issue where users get "stuck" in the billing portal
+  if (logicResult.clearBillingPortalCookie) {
+    await clearCustomerBillingPortalOrganizationId()
+  }
+
   // Add pathname to headers for layout detection
   const requestHeaders = new Headers(req.headers)
   requestHeaders.set('x-pathname', req.nextUrl.pathname)
@@ -65,3 +74,4 @@ export const config = {
     '/(api|trpc)(.*)',
   ],
 }
+

--- a/platform/flowglad-next/src/routing-logic/middlewareLogic.test.ts
+++ b/platform/flowglad-next/src/routing-logic/middlewareLogic.test.ts
@@ -134,7 +134,7 @@ describe('middlewareLogic', () => {
         expect(result.proceed).toBe(true)
       })
 
-      it('should redirect to billing portal when path does not match organization', () => {
+      it('should clear billing portal cookie when authenticated user navigates to management portal', () => {
         const result = middlewareLogic({
           sessionCookie: 'valid_session_cookie',
           isProtectedRoute: true,
@@ -143,10 +143,10 @@ describe('middlewareLogic', () => {
           req: { nextUrl: 'https://example.com/dashboard' },
         })
 
-        expect(result.proceed).toBe(false)
-        if (!result.proceed) {
-          expect(result.redirect.url).toBe('/billing-portal/org_456')
-          expect(result.redirect.status).toBe(307)
+        // New behavior: proceed with cookie clearing flag instead of redirect
+        expect(result.proceed).toBe(true)
+        if (result.proceed) {
+          expect(result.clearBillingPortalCookie).toBe(true)
         }
       })
 
@@ -169,7 +169,7 @@ describe('middlewareLogic', () => {
         }
       })
 
-      it('should redirect for regular API routes when customerBillingPortalOrganizationId is set', () => {
+      it('should clear billing portal cookie for regular API routes when authenticated', () => {
         const result = middlewareLogic({
           sessionCookie: 'valid_session_cookie',
           isProtectedRoute: true,
@@ -178,10 +178,10 @@ describe('middlewareLogic', () => {
           req: { nextUrl: 'https://example.com/api/trpc/users.list' },
         })
 
-        expect(result.proceed).toBe(false)
-        if (!result.proceed) {
-          expect(result.redirect.url).toBe('/billing-portal/org_456')
-          expect(result.redirect.status).toBe(307)
+        // New behavior: proceed with cookie clearing flag instead of redirect
+        expect(result.proceed).toBe(true)
+        if (result.proceed) {
+          expect(result.clearBillingPortalCookie).toBe(true)
         }
       })
 


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->
Fixes the issue where users get "stuck" in the customer billing portal after accessing it. Previously, the middleware would redirect all protected routes to the billing portal if the customer-billing-organization-id cookie existed (24-hour duration), forcing users to clear cookies manually. Now, when an authenticated user navigates to a non-billing-portal route, the middleware automatically clears the cookie and proceeds instead of redirecting, allowing seamless switching between portals.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes users getting stuck in the customer billing portal by clearing the billing portal cookie when an authenticated user navigates to non-billing routes. Authenticated users can now return to the management portal without manual cookie clearing; unauthenticated behavior is unchanged.

- **Bug Fixes**
  - Clear customer-billing-organization-id for authed users on protected non-billing routes via a new clearBillingPortalCookie flag; middleware calls clearCustomerBillingPortalOrganizationId.
  - Do not clear for /billing-portal/* or /api/trpc/customerBillingPortal.* paths.
  - Preserve redirect for unauthenticated users with the cookie; tests updated to reflect the new proceed-with-clear behavior.

<sup>Written for commit 315c1e140335fc31bba15d70920f03265a31a66e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where users could get stuck in the billing portal session when navigating to non-billing routes. The system now clears the billing portal cookie instead of redirecting, improving navigation flow between billing and regular application areas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->