### PR TITLE
chore: remove deprecated Vitest deps.inline config

### DIFF
--- a/platform/flowglad-next/vitest.config.ts
+++ b/platform/flowglad-next/vitest.config.ts
@@ -63,9 +63,6 @@ export default defineConfig(({ mode }) => {
       environment: 'node',
       setupFiles: ['./vitest.setup.ts'],
       env: loadEnv(mode, process.cwd(), ''),
-      deps: {
-        inline: [/@stackframe\/stack-shared/], // Force inline this package
-      },
       server: {
         deps: {
           inline: [/@stackframe\/stack-shared/],

--- a/platform/flowglad-next/vitest.rls.config.ts
+++ b/platform/flowglad-next/vitest.rls.config.ts
@@ -39,9 +39,6 @@ export default defineConfig(({ mode }) => {
       environment: 'jsdom',
       setupFiles: ['./vitest.setup.ts'],
       env: loadEnv(mode, process.cwd(), ''),
-      deps: {
-        inline: [/@stackframe\/stack-shared/],
-      },
       server: {
         deps: {
           inline: [/@stackframe\/stack-shared/],


### PR DESCRIPTION
## Summary
- Removes the deprecated top-level `deps.inline` configuration from Vitest configs
- Both `vitest.config.ts` and `vitest.rls.config.ts` already had the correct `server.deps.inline` setting, so this just removes the redundant deprecated option
- Fixes the deprecation warning: `"deps.inline" is deprecated. If you rely on vite-node directly, use "server.deps.inline" instead.`

## Test plan
- [x] `bun run check` passes
- [ ] Tests still run without deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated Vitest test.deps.inline config and rely on server.deps.inline instead. This removes the deprecation warning when running tests.

- **Refactors**
  - Deleted test.deps.inline from vitest.config.ts and vitest.rls.config.ts; server.deps.inline remains to inline @stackframe/stack-shared.

<sup>Written for commit fb2ea4f04eeffc80fba9dac39cbf41a281b700c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted test configuration to refine how dependencies are managed during environment initialization and server operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->