### PR TITLE
fix: Combine MSW mock servers into single instance

### DIFF
--- a/platform/flowglad-next/mocks/server.ts
+++ b/platform/flowglad-next/mocks/server.ts
@@ -1,0 +1,19 @@
+/**
+ * Combined MSW server with all handlers
+ *
+ * MSW recommends using a single server instance with all handlers combined.
+ * Having multiple separate servers can cause conflicts where only one server's
+ * handlers are active at a time.
+ */
+import { setupServer } from 'msw/node'
+import { stripeHandlers } from './stripeServer'
+import { svixHandlers } from './svixServer'
+import { triggerHandlers } from './triggerServer'
+import { unkeyHandlers } from './unkeyServer'
+
+export const server = setupServer(
+  ...stripeHandlers,
+  ...svixHandlers,
+  ...triggerHandlers,
+  ...unkeyHandlers
+)

--- a/platform/flowglad-next/vitest.setup.ts
+++ b/platform/flowglad-next/vitest.setup.ts
@@ -3,10 +3,7 @@ import '@testing-library/jest-dom/vitest'
 import { webcrypto } from 'node:crypto'
 import { cleanup } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, vi } from 'vitest'
-import { stripeServer } from './mocks/stripeServer'
-import { svixServer } from './mocks/svixServer'
-import { triggerServer } from './mocks/triggerServer'
-import { unkeyServer } from './mocks/unkeyServer'
+import { server } from './mocks/server'
 import { seedDatabase } from './seedDatabase'
 
 // Ensure Unkey env vars are set for tests (MSW mocks the actual API calls)
@@ -42,27 +39,18 @@ vi.mock('@trigger.dev/core', async () => {
 
 // Start the mock server before all tests
 beforeAll(async () => {
-  stripeServer.listen()
-  triggerServer.listen()
-  svixServer.listen()
-  unkeyServer.listen()
+  server.listen({ onUnhandledRequest: 'warn' })
   await seedDatabase()
 })
 
 // Reset handlers after each test (optional, but recommended)
 afterEach(() => {
-  stripeServer.resetHandlers()
-  triggerServer.resetHandlers()
-  svixServer.resetHandlers()
-  unkeyServer.resetHandlers()
+  server.resetHandlers()
   cleanup()
 })
 
 // Stop the mock server after all tests
 afterAll(async () => {
-  stripeServer.close()
-  triggerServer.close()
-  svixServer.close()
-  unkeyServer.close()
+  server.close()
   //   await dropDatabase()
 })


### PR DESCRIPTION
## Summary
- Creates a combined MSW server in `mocks/server.ts` with all handlers (Stripe, Svix, Trigger, Unkey)
- Updates `vitest.setup.ts` to use the single combined server
- Adds `onUnhandledRequest: 'warn'` to catch unhandled requests

## Why
MSW recommends using a single server instance with all handlers combined. Having multiple separate servers calling `.listen()` can cause conflicts where handlers don't properly match requests.

This eliminates "intercepted a request without a matching request handler" warnings that were appearing in tests.

## Test plan
- [x] `bun run check` passes
- [x] Existing tests continue to work with combined server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Combined all MSW mock handlers into a single server to prevent handler conflicts and warn on unhandled requests. Updated the Vitest setup to use the unified server, reducing “intercepted a request without a matching request handler” warnings in tests.

- **Refactors**
  - Added mocks/server.ts that sets up one server with Stripe, Svix, Trigger, and Unkey handlers.
  - Replaced multiple listen/reset/close calls in vitest.setup.ts with server.listen({ onUnhandledRequest: 'warn' }), server.resetHandlers(), and server.close().

<sup>Written for commit bad20c4267af1f76065becabdfd4101b560ece54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified mock server infrastructure by consolidating multiple service mocks into a single centralized server instance, improving test management and configuration efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->