### PR TITLE
Fix subscription adjustment timing enum mismatch

### DIFF
--- a/packages/react/src/FlowgladContext.tsx
+++ b/packages/react/src/FlowgladContext.tsx
@@ -108,7 +108,7 @@ export type LoadedFlowgladContextValues = BillingWithChecks & {
    * // With timing override
    * await adjustSubscription({
    *   priceSlug: 'pro-monthly',
-   *   timing: 'at_end_of_period'
+   *   timing: 'at_end_of_current_billing_period'
    * })
    *
    * // Explicit subscription ID (for multi-subscription customers)
@@ -133,7 +133,7 @@ export type LoadedFlowgladContextValues = BillingWithChecks & {
    * @param params.subscriptionItems - Array of items for multi-item adjustments
    * @param params.quantity - Number of units (default: 1)
    * @param params.subscriptionId - Subscription ID (auto-resolves if customer has exactly 1 subscription)
-   * @param params.timing - 'immediately' | 'at_end_of_period' | 'auto' (default: 'auto')
+   * @param params.timing - 'immediately' | 'at_end_of_current_billing_period' | 'auto' (default: 'auto')
    * @param params.prorate - Whether to prorate (default: true for immediate, false for end-of-period)
    */
   adjustSubscription: (params: AdjustSubscriptionParams) => Promise<{

--- a/packages/shared/src/actions.test.ts
+++ b/packages/shared/src/actions.test.ts
@@ -15,6 +15,7 @@ import {
   listResourceClaimsSchema,
   releaseResourceSchema,
   subscriptionAdjustmentTiming,
+  subscriptionAdjustmentTimingSchema,
   terseSubscriptionItemSchema,
   updateCustomerInputSchema,
   updateCustomerSchema,
@@ -1443,5 +1444,91 @@ describe('flowgladActionValidators', () => {
       timing: 'immediately',
     })
     expect(result.success).toBe(true)
+  })
+})
+
+describe('subscriptionAdjustmentTimingSchema', () => {
+  it('parses "immediately" as valid timing and returns the exact value', () => {
+    const result =
+      subscriptionAdjustmentTimingSchema.safeParse('immediately')
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toBe('immediately')
+    }
+  })
+
+  it('parses "at_end_of_current_billing_period" as valid timing and returns the exact value', () => {
+    const result = subscriptionAdjustmentTimingSchema.safeParse(
+      'at_end_of_current_billing_period'
+    )
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toBe('at_end_of_current_billing_period')
+    }
+  })
+
+  it('parses "auto" as valid timing and returns the exact value', () => {
+    const result =
+      subscriptionAdjustmentTimingSchema.safeParse('auto')
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toBe('auto')
+    }
+  })
+
+  it('rejects the old timing value "at_end_of_period" which was changed in a breaking update', () => {
+    const result = subscriptionAdjustmentTimingSchema.safeParse(
+      'at_end_of_period'
+    )
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects arbitrary invalid timing strings', () => {
+    const result =
+      subscriptionAdjustmentTimingSchema.safeParse('next_week')
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-string values', () => {
+    const resultNumber =
+      subscriptionAdjustmentTimingSchema.safeParse(123)
+    expect(resultNumber.success).toBe(false)
+
+    const resultNull =
+      subscriptionAdjustmentTimingSchema.safeParse(null)
+    expect(resultNull.success).toBe(false)
+
+    const resultObject = subscriptionAdjustmentTimingSchema.safeParse(
+      {
+        timing: 'immediately',
+      }
+    )
+    expect(resultObject.success).toBe(false)
+  })
+})
+
+describe('subscriptionAdjustmentTiming constant values', () => {
+  it('Immediately equals "immediately"', () => {
+    expect(subscriptionAdjustmentTiming.Immediately).toBe(
+      'immediately'
+    )
+  })
+
+  it('AtEndOfCurrentBillingPeriod equals "at_end_of_current_billing_period"', () => {
+    expect(
+      subscriptionAdjustmentTiming.AtEndOfCurrentBillingPeriod
+    ).toBe('at_end_of_current_billing_period')
+  })
+
+  it('Auto equals "auto"', () => {
+    expect(subscriptionAdjustmentTiming.Auto).toBe('auto')
+  })
+
+  it('contains exactly three timing options', () => {
+    const keys = Object.keys(subscriptionAdjustmentTiming)
+    expect(keys).toHaveLength(3)
+    expect(keys).toContain('Immediately')
+    expect(keys).toContain('AtEndOfCurrentBillingPeriod')
+    expect(keys).toContain('Auto')
   })
 })

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -91,19 +91,29 @@ export const uncancelSubscriptionSchema = z.object({
 })
 
 /**
- * Subscription adjustment timing options for the terse SDK API.
+ * Subscription adjustment timing options.
  * - 'immediately': Apply change now with proration
- * - 'at_end_of_period': Apply change at next billing period
+ * - 'at_end_of_current_billing_period': Apply change at next billing period
  * - 'auto': Upgrades happen immediately, downgrades at end of period
  */
 export const subscriptionAdjustmentTiming = {
   Immediately: 'immediately',
-  AtEndOfCurrentBillingPeriod: 'at_end_of_period',
+  AtEndOfCurrentBillingPeriod: 'at_end_of_current_billing_period',
   Auto: 'auto',
 } as const
 
 export type SubscriptionAdjustmentTiming =
   (typeof subscriptionAdjustmentTiming)[keyof typeof subscriptionAdjustmentTiming]
+
+/**
+ * Zod schema for subscription adjustment timing.
+ * Use this schema to validate timing values consistently across SDK and backend.
+ */
+export const subscriptionAdjustmentTimingSchema = z.enum([
+  subscriptionAdjustmentTiming.Immediately,
+  subscriptionAdjustmentTiming.AtEndOfCurrentBillingPeriod,
+  subscriptionAdjustmentTiming.Auto,
+])
 
 /**
  * Terse subscription item for multi-item adjustments.
@@ -135,12 +145,7 @@ export type TerseSubscriptionItem = z.input<
  */
 const adjustmentCommonOptions = {
   subscriptionId: z.string().optional(),
-  timing: z
-    .enum([
-      subscriptionAdjustmentTiming.Immediately,
-      subscriptionAdjustmentTiming.AtEndOfCurrentBillingPeriod,
-      subscriptionAdjustmentTiming.Auto,
-    ])
+  timing: subscriptionAdjustmentTimingSchema
     .optional()
     .default(subscriptionAdjustmentTiming.Auto),
   prorate: z.boolean().optional(),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,6 +13,7 @@ export type {
   GetResourcesParams,
   ListResourceClaimsParams,
   ReleaseResourceParams,
+  SubscriptionAdjustmentTiming,
   TerseSubscriptionItem,
   UncancelSubscriptionParams,
 } from './actions'
@@ -32,6 +33,7 @@ export {
   listResourceClaimsSchema,
   releaseResourceSchema,
   subscriptionAdjustmentTiming,
+  subscriptionAdjustmentTimingSchema,
   terseSubscriptionItemSchema,
   uncancelSubscriptionSchema,
   updateCustomerSchema,


### PR DESCRIPTION
## What Does this PR Do?

Fixes the enum value mismatch between the SDK and backend for subscription adjustment timing options.

**Changes:**
- Updated `subscriptionAdjustmentTiming.AtEndOfCurrentBillingPeriod` from `'at_end_of_period'` to `'at_end_of_current_billing_period'` (BREAKING)
- Created `subscriptionAdjustmentTimingSchema` Zod schema for consistent validation across SDK and backend
- Simplified `FlowgladServer.adjustSubscription` by removing now-unnecessary timing value mapping logic
- Updated JSDoc examples with correct timing values
- Added 10 comprehensive tests documenting the breaking change and verifying correct values

This resolves the inconsistency where the SDK used `'at_end_of_period'` while the backend expected `'at_end_of_current_billing_period'`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns subscription adjustment timing values between SDK and backend by replacing 'at_end_of_period' with 'at_end_of_current_billing_period' (breaking). Removes server-side mapping, adds a shared Zod schema, and updates docs and tests.

- **Migration**
  - Replace 'at_end_of_period' with 'at_end_of_current_billing_period' in all calls (e.g., adjustSubscription).
  - Use subscriptionAdjustmentTiming or subscriptionAdjustmentTimingSchema for safer typing/validation.
  - No behavior changes to 'auto' or 'immediately'; proration defaults unchanged.

<sup>Written for commit c3feb4f884daa44ac79452a6f78ac81ccd8e003d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated subscription adjustment timing value identifier to 'at_end_of_current_billing_period'

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->