### PR TITLE
Patch 3: Add quantity selector to pricing page

### DIFF
--- a/playground/seat-based-billing/src/components/adjust-subscription-grid.tsx
+++ b/playground/seat-based-billing/src/components/adjust-subscription-grid.tsx
@@ -128,8 +128,11 @@ export function AdjustSubscriptionGrid({
         const plan: PricingPlan = {
           name: product.name,
           displayPrice: displayPrice,
+          unitPrice: price.unitPrice,
           slug: price.slug,
           features: featureNames,
+          singularQuantityLabel: product.singularQuantityLabel,
+          pluralQuantityLabel: product.pluralQuantityLabel,
         }
 
         if (product.description) {

--- a/playground/seat-based-billing/src/components/pricing-cards-grid.tsx
+++ b/playground/seat-based-billing/src/components/pricing-cards-grid.tsx
@@ -91,8 +91,11 @@ export function PricingCardsGrid() {
         const plan: PricingPlan = {
           name: product.name,
           displayPrice: displayPrice,
+          unitPrice: price.unitPrice,
           slug: price.slug,
           features: featureNames,
+          singularQuantityLabel: product.singularQuantityLabel,
+          pluralQuantityLabel: product.pluralQuantityLabel,
         }
 
         if (product.description) {

--- a/playground/seat-based-billing/src/components/ui/input.tsx
+++ b/playground/seat-based-billing/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const Input = React.forwardRef<
+  HTMLInputElement,
+  React.ComponentPropsWithoutRef<'input'>
+>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-10 w-full rounded border border-input bg-card px-3 py-2 text-base shadow-xs transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20 focus-visible:border-foreground disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Input.displayName = 'Input'
+
+export { Input }


### PR DESCRIPTION
## What Does This PR Do?

Implements Patch 3 from GP-75: adds a quantity selector UI to the pricing page for seat-based billing. Customers can now select the number of seats (1-100) when checking out the Pro plan, and the total price updates dynamically. The quantity selector only appears for plans with quantity labels and non-zero pricing.

**Key changes:**
- Added `unitPrice`, `singularQuantityLabel`, and `pluralQuantityLabel` to PricingPlan interface
- Implemented quantity state with +/- buttons and direct input field
- Dynamic price calculation based on quantity selection
- Quantity passed to checkout session for seat-based billing

The quantity selector intelligently shows singular vs. plural labels based on the selected quantity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a quantity selector to the pricing page for seat-based billing (GP-75). Users can pick 1–100 seats, and the total updates.

- **New Features**
  - Visible only on priced plans with quantity labels.
  - +/- and number input with 1–100 clamp; singular/plural labels shown.
  - Passes quantity to checkout; adds unitPrice and quantity labels to PricingPlan and grids; includes a small Input component.

- **Migration**
  - If you construct PricingPlan elsewhere, include unitPrice and (optional) quantity labels.

<sup>Written for commit a29bb52512a310d47f240997d023589b7493f10a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

