### PR TITLE
Implement GP-75 seat management UI

### DIFF
--- a/playground/seat-based-billing/src/app/home-client.tsx
+++ b/playground/seat-based-billing/src/app/home-client.tsx
@@ -1,75 +1,102 @@
 'use client'
 
 import { useBilling } from '@flowglad/nextjs'
-import { CheckCircle2 } from 'lucide-react'
-import Image from 'next/image'
+import { Loader2, Trash2, UserPlus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { DashboardSkeleton } from '@/components/dashboard-skeleton'
 import { Button } from '@/components/ui/button'
 import {
   Card,
   CardContent,
+  CardDescription,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { Progress } from '@/components/ui/progress'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
 import { authClient } from '@/lib/auth-client'
-import { computeUsageTotal } from '@/lib/billing-helpers'
+import {
+  adjustSeatCount,
+  claimSeat,
+  getSeats,
+  listSeatClaims,
+  releaseSeat,
+} from '@/lib/seat-actions'
 
-// Mock images to cycle through
-const mockImages = [
-  '/images/flowglad.png',
-  '/images/unsplash-1.jpg',
-  '/images/unsplash-2.jpg',
-  '/images/unsplash-3.jpg',
-  '/images/unsplash-4.jpg',
-  '/images/unsplash-5.jpg',
-]
+interface ResourceUsage {
+  resourceSlug: string
+  resourceId: string
+  capacity: number
+  claimed: number
+  available: number
+}
 
-// Mock GIFs for video generation
-const mockVideoGif = [
-  'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExd252Y2NwNG5vdmQxMXl6cWxsMWNpYzV0ZnU3a3UwbGhtcHFkZTNoMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/a6OnFHzHgCU1O/giphy.gif',
-  'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNnNyOXhnNXp3cTJnaWw1OGZodXducHlzeThvbTBwdDc4cGw5OWFuZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/WI4A2fVnRBiYE/giphy.gif',
-  'https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3OWN6emx1M2JpM3lkczB4Y2Y2M3U5ejgyNzNmbnJnM2ZqMDlvb3B4ciZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/pa37AAGzKXoek/giphy.gif',
-]
+interface ResourceClaim {
+  id: string
+  externalId: string | null
+  claimedAt: number
+  metadata: Record<string, unknown> | null
+}
 
 export function HomeClient() {
   const router = useRouter()
   const { data: session, isPending: isSessionPending } =
     authClient.useSession()
   const billing = useBilling()
-  const [isGeneratingFastImage, setIsGeneratingFastImage] =
-    useState(false)
-  const [isGeneratingHDVideo, setIsGeneratingHDVideo] =
-    useState(false)
-  const [isGeneratingRelaxImage, setIsGeneratingRelaxImage] =
-    useState(false)
-  const [isGeneratingRelaxSDVideo, setIsGeneratingRelaxSDVideo] =
-    useState(false)
-  const [generateError, setGenerateError] = useState<string | null>(
+
+  // Seat management state
+  const [seatUsage, setSeatUsage] = useState<ResourceUsage | null>(
     null
   )
-  const [hdVideoError, setHdVideoError] = useState<string | null>(
-    null
-  )
-  const [topUpError, setTopUpError] = useState<string | null>(null)
-  const [displayedContent, setDisplayedContent] = useState<
+  const [claims, setClaims] = useState<ResourceClaim[]>([])
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [newQuantity, setNewQuantity] = useState(1)
+  const [isLoadingSeats, setIsLoadingSeats] = useState(true)
+  const [isClaimingOngoing, setIsClaimingOngoing] = useState(false)
+  const [isReleasingOngoing, setIsReleasingOngoing] = useState<
     string | null
   >(null)
-  const [currentImageIndex, setCurrentImageIndex] = useState(0)
-  const [currentVideoGifIndex, setCurrentVideoGifIndex] = useState(0)
+  const [isAdjusting, setIsAdjusting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
   const previousUserIdRef = useRef<string | undefined>(undefined)
 
-  // Refetch billing data when user ID changes to prevent showing previous user's data
+  // Fetch seat data
+  const refreshData = useCallback(async () => {
+    try {
+      setIsLoadingSeats(true)
+      setError(null)
+
+      const [seatsResult, claimsResult] = await Promise.all([
+        getSeats(),
+        listSeatClaims(),
+      ])
+
+      // Find the seats resource
+      const seatsResource = seatsResult.resources.find(
+        (r: ResourceUsage) => r.resourceSlug === 'seats'
+      )
+      setSeatUsage(seatsResource ?? null)
+      setClaims(claimsResult.claims)
+
+      // Set newQuantity to current capacity
+      if (seatsResource) {
+        setNewQuantity(seatsResource.capacity)
+      }
+    } catch (err) {
+      // If no subscription, seats will fail - that's expected for free plan
+      console.error('Error fetching seats:', err)
+      setSeatUsage(null)
+      setClaims([])
+    } finally {
+      setIsLoadingSeats(false)
+    }
+  }, [])
+
+  // Refetch billing data when user ID changes
   useEffect(() => {
     const currentUserId = session?.user?.id
-    // Only refetch if user ID actually changed and billing is loaded
     if (
       currentUserId &&
       currentUserId !== previousUserIdRef.current &&
@@ -79,7 +106,6 @@ export function HomeClient() {
       previousUserIdRef.current = currentUserId
       billing.reload()
     } else if (currentUserId) {
-      // Update ref even if we don't reload (e.g., on initial mount)
       previousUserIdRef.current = currentUserId
     }
   }, [session?.user?.id, billing])
@@ -90,14 +116,13 @@ export function HomeClient() {
       return
     }
 
-    // Check if user has at least one non-free plan subscription
-    // isFreePlan is true when the subscription's price has unitPrice === 0
     const hasNonFreePlan =
       billing.currentSubscriptions &&
       billing.currentSubscriptions.length > 0 &&
-      billing.currentSubscriptions.some((sub) => !sub.isFreePlan)
+      billing.currentSubscriptions.some(
+        (sub: { isFreePlan?: boolean }) => !sub.isFreePlan
+      )
 
-    // If user is on free plan (no non-free plan found), redirect to pricing
     if (!hasNonFreePlan) {
       router.push('/pricing')
     }
@@ -107,6 +132,96 @@ export function HomeClient() {
     billing.currentSubscriptions,
     router,
   ])
+
+  // Fetch seats when billing is loaded
+  useEffect(() => {
+    if (
+      billing.loaded &&
+      billing.currentSubscriptions?.some(
+        (s: { isFreePlan?: boolean }) => !s.isFreePlan
+      )
+    ) {
+      refreshData()
+    }
+  }, [billing.loaded, billing.currentSubscriptions, refreshData])
+
+  // Action handlers
+  const handleClaimSeat = async () => {
+    if (!inviteEmail.trim()) {
+      setError('Please enter an email address')
+      return
+    }
+
+    // Basic email validation
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!emailRegex.test(inviteEmail)) {
+      setError('Please enter a valid email address')
+      return
+    }
+
+    setIsClaimingOngoing(true)
+    setError(null)
+
+    try {
+      await claimSeat(inviteEmail.trim())
+      setInviteEmail('')
+      await refreshData()
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to claim seat'
+      )
+    } finally {
+      setIsClaimingOngoing(false)
+    }
+  }
+
+  const handleReleaseSeat = async (email: string) => {
+    setIsReleasingOngoing(email)
+    setError(null)
+
+    try {
+      await releaseSeat(email)
+      await refreshData()
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to release seat'
+      )
+    } finally {
+      setIsReleasingOngoing(null)
+    }
+  }
+
+  const handleAdjustSeats = async () => {
+    if (newQuantity < 1) {
+      setError('Seat count must be at least 1')
+      return
+    }
+
+    // Check if we're trying to reduce below claimed count
+    if (seatUsage && newQuantity < seatUsage.claimed) {
+      setError(
+        `Cannot reduce to ${newQuantity} seats. ${seatUsage.claimed} seats are currently claimed. Release some seats first.`
+      )
+      return
+    }
+
+    setIsAdjusting(true)
+    setError(null)
+
+    try {
+      await adjustSeatCount(newQuantity)
+      await billing.reload()
+      await refreshData()
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to adjust seat count'
+      )
+    } finally {
+      setIsAdjusting(false)
+    }
+  }
 
   if (isSessionPending || !billing.loaded) {
     return <DashboardSkeleton />
@@ -120,622 +235,253 @@ export function HomeClient() {
     return <DashboardSkeleton />
   }
 
-  // Get current subscription plan
-  // By default, each customer can only have one active subscription at a time,
-  // so accessing the first currentSubscriptions is sufficient.
-  // Multiple subscriptions per customer can be enabled in dashboard > settings
   const currentSubscription = billing.currentSubscriptions?.[0]
   const planName = currentSubscription?.name || 'Unknown Plan'
 
-  if (!billing.checkUsageBalance || !billing.checkFeatureAccess) {
-    return <DashboardSkeleton />
-  }
-
-  const fastGenerationsBalance = billing.checkUsageBalance(
-    'fast_generations'
-  )
-  const hdVideoMinutesBalance = billing.checkUsageBalance(
-    'hd_video_minutes'
-  )
-
-  // Check if user has access to usage meters (has balance object, even if balance is 0)
-  const hasFastGenerationsAccess = fastGenerationsBalance != null
-  const hasHDVideoMinutesAccess = hdVideoMinutesBalance != null
-
-  // Get feature access
-  const hasRelaxMode = !!billing.checkFeatureAccess(
-    'unlimited_relaxed_images'
-  )
-  const hasUnlimitedRelaxedSDVideo = !!billing.checkFeatureAccess(
-    'unlimited_relaxed_sd_video'
-  )
-  const hasOptionalTopUps = !!billing.checkFeatureAccess(
-    'optional_credit_top_ups'
-  )
-
-  // Check if customer has purchased top-up products by product slug
-  // This is a bit of a strange use case, but is just demonstrating how to use the hasPurchased function
-  const hasPurchasedFastGenTopUp = billing.hasPurchased(
-    'fast_generation_top_ups'
-  )
-  const hasPurchasedHDVideoTopUp = billing.hasPurchased(
-    'hd_video_minute_top_ups'
-  )
-
-  // Calculate progress for usage meters - get slug from price using priceId
-  const fastGenerationsRemaining =
-    fastGenerationsBalance?.availableBalance ?? 0
-
-  // Compute plan totals dynamically from current subscription's feature items
-  // This calculates how many usage credits (e.g., "360 fast generations")
-  // are included in the current subscription plan
-  const fastGenerationsPlanTotal = computeUsageTotal(
-    'fast_generations',
-    currentSubscription,
-    billing.pricingModel
-  )
-  // Use the higher of plan total or remaining balance as the display total
-  // This handles cases where top-ups increase balance beyond plan allocation
-  const fastGenerationsTotal = Math.max(
-    fastGenerationsPlanTotal,
-    fastGenerationsRemaining
-  )
-  const fastGenerationsProgress =
-    fastGenerationsTotal > 0
-      ? Math.min(
-          (fastGenerationsRemaining / fastGenerationsTotal) * 100,
-          100
-        )
-      : 0
-
-  const hdVideoMinutesRemaining =
-    hdVideoMinutesBalance?.availableBalance ?? 0
-  const hdVideoMinutesPlanTotal = computeUsageTotal(
-    'hd_video_minutes',
-    currentSubscription,
-    billing.pricingModel
-  )
-  // Use the higher of plan total or remaining balance as the display total
-  // This handles cases where top-ups increase balance beyond plan allocation
-  const hdVideoMinutesTotal = Math.max(
-    hdVideoMinutesPlanTotal,
-    hdVideoMinutesRemaining
-  )
-  const hdVideoMinutesProgress =
-    hdVideoMinutesTotal > 0
-      ? Math.min(
-          (hdVideoMinutesRemaining / hdVideoMinutesTotal) * 100,
-          100
-        )
-      : 0
-
-  // Action handlers
-  const handleGenerateFastImage = async () => {
-    if (!hasFastGenerationsAccess || fastGenerationsRemaining === 0) {
-      return
-    }
-
-    if (!billing.createUsageEvent) {
-      setGenerateError('createUsageEvent is not available')
-      return
-    }
-
-    setIsGeneratingFastImage(true)
-    setGenerateError(null)
-
-    try {
-      // Generate a unique transaction ID for idempotency
-      const transactionId = `fast_image_${Date.now()}_${Math.random().toString(36).substring(7)}`
-      // Random amount between 3-5
-      const amount = Math.floor(Math.random() * 3) + 3
-
-      const result = await billing.createUsageEvent({
-        usageMeterSlug: 'fast_generations',
-        amount,
-        transactionId,
-      })
-
-      if ('error' in result) {
-        throw new Error(
-          typeof result.error.json === 'object' &&
-            result.error.json !== null &&
-            'message' in result.error.json
-            ? String(result.error.json.message)
-            : 'Failed to create usage event'
-        )
-      }
-
-      // Cycle through mock images
-      const nextIndex = (currentImageIndex + 1) % mockImages.length
-      setCurrentImageIndex(nextIndex)
-      const nextImage = mockImages[nextIndex]
-      if (nextImage) {
-        setDisplayedContent(nextImage)
-      }
-
-      // Reload billing data to update usage balances
-      await billing.reload()
-    } catch (error) {
-      setGenerateError(
-        error instanceof Error
-          ? error.message
-          : 'Failed to generate image. Please try again.'
-      )
-    } finally {
-      setIsGeneratingFastImage(false)
-    }
-  }
-
-  const handleGenerateHDVideo = async () => {
-    if (!hasHDVideoMinutesAccess || hdVideoMinutesRemaining === 0) {
-      return
-    }
-
-    if (!billing.createUsageEvent) {
-      setHdVideoError('createUsageEvent is not available')
-      return
-    }
-
-    setIsGeneratingHDVideo(true)
-    setHdVideoError(null)
-
-    try {
-      // Generate a unique transaction ID for idempotency
-      const transactionId = `hd_video_${Date.now()}_${Math.random().toString(36).substring(7)}`
-      // Random amount between 1-3 minutes
-      const amount = Math.floor(Math.random() * 3) + 1
-
-      const result = await billing.createUsageEvent({
-        usageMeterSlug: 'hd_video_minutes',
-        amount,
-        transactionId,
-      })
-
-      if ('error' in result) {
-        throw new Error(
-          typeof result.error.json === 'object' &&
-            result.error.json !== null &&
-            'message' in result.error.json
-            ? String(result.error.json.message)
-            : 'Failed to create usage event'
-        )
-      }
-
-      // Cycle through mock video GIFs
-      const nextIndex =
-        (currentVideoGifIndex + 1) % mockVideoGif.length
-      setCurrentVideoGifIndex(nextIndex)
-      const nextGif = mockVideoGif[nextIndex]
-      if (nextGif) {
-        setDisplayedContent(nextGif)
-      }
-
-      // Reload billing data to update usage balances
-      await billing.reload()
-    } catch (error) {
-      setHdVideoError(
-        error instanceof Error
-          ? error.message
-          : 'Failed to generate HD video. Please try again.'
-      )
-    } finally {
-      setIsGeneratingHDVideo(false)
-    }
-  }
-
-  const handleGenerateRelaxImage = async () => {
-    if (!hasRelaxMode) {
-      return
-    }
-
-    setIsGeneratingRelaxImage(true)
-
-    try {
-      // Cycle through mock images for relax mode
-      const nextIndex = (currentImageIndex + 1) % mockImages.length
-      setCurrentImageIndex(nextIndex)
-      const nextImage = mockImages[nextIndex]
-      if (nextImage) {
-        setDisplayedContent(nextImage)
-      }
-    } finally {
-      setIsGeneratingRelaxImage(false)
-    }
-  }
-
-  const handleGenerateRelaxSDVideo = async () => {
-    if (!hasUnlimitedRelaxedSDVideo) {
-      return
-    }
-
-    setIsGeneratingRelaxSDVideo(true)
-
-    try {
-      // Cycle through mock video GIFs
-      const nextIndex =
-        (currentVideoGifIndex + 1) % mockVideoGif.length
-      setCurrentVideoGifIndex(nextIndex)
-      const nextGif = mockVideoGif[nextIndex]
-      if (nextGif) {
-        setDisplayedContent(nextGif)
-      }
-    } finally {
-      setIsGeneratingRelaxSDVideo(false)
-    }
-  }
-
-  const handlePurchaseFastGenerationTopUp = async () => {
-    if (!billing.createCheckoutSession || !billing.getPrice) {
-      return
-    }
-
-    setTopUpError(null)
-
-    const price = billing.getPrice('fast_generation_top_up')
-    if (!price) {
-      setTopUpError('Price not found. Please contact support.')
-      return
-    }
-
-    try {
-      await billing.createCheckoutSession({
-        priceId: price.id,
-        successUrl: window.location.href,
-        cancelUrl: window.location.href,
-        autoRedirect: true,
-      })
-    } catch (error) {
-      setTopUpError(
-        error instanceof Error
-          ? error.message
-          : 'Failed to start checkout. Please try again.'
-      )
-    }
-  }
-
-  const handlePurchaseHDVideoTopUp = async () => {
-    if (!billing.createCheckoutSession || !billing.getPrice) {
-      return
-    }
-
-    setTopUpError(null)
-
-    const price = billing.getPrice('hd_video_minute_top_up')
-    if (!price) {
-      setTopUpError('Price not found. Please contact support.')
-      return
-    }
-
-    try {
-      await billing.createCheckoutSession({
-        priceId: price.id,
-        successUrl: window.location.href,
-        cancelUrl: window.location.href,
-        autoRedirect: true,
-      })
-    } catch (error) {
-      setTopUpError(
-        error instanceof Error
-          ? error.message
-          : 'Failed to start checkout. Please try again.'
-      )
-    }
-  }
+  // Calculate progress
+  const capacity = seatUsage?.capacity ?? 0
+  const claimed = seatUsage?.claimed ?? 0
+  const available = seatUsage?.available ?? 0
+  const usageProgress = capacity > 0 ? (claimed / capacity) * 100 : 0
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
-      <main className="flex min-h-screen w-full max-w-7xl flex-col p-8">
-        <div className="w-full space-y-8">
-          {/* Image Display Area with Action Buttons */}
-          <Card className="max-w-2xl mx-auto">
+      <main className="flex min-h-screen w-full max-w-2xl flex-col p-8">
+        <div className="w-full space-y-6">
+          {/* Plan & Seat Usage Card */}
+          <Card>
             <CardHeader>
               <CardTitle>Current Plan: {planName}</CardTitle>
+              <CardDescription>
+                Manage your team seats
+              </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-6">
-              {/* Image Display Area - Standardized 16:9 aspect ratio */}
-              <div className="relative w-full aspect-video bg-muted rounded-lg border-2 border-dashed overflow-hidden">
-                {/* Loading spinner overlay */}
-                {isGeneratingFastImage ||
-                isGeneratingHDVideo ||
-                isGeneratingRelaxImage ||
-                isGeneratingRelaxSDVideo ? (
-                  <div className="absolute inset-0 flex items-center justify-center bg-muted/80 z-10">
-                    <div className="flex flex-col items-center gap-3">
-                      <div className="w-12 h-12 border-4 border-primary border-t-transparent rounded-full animate-spin" />
-                      <p className="text-sm text-muted-foreground">
-                        Generating...
-                      </p>
+            <CardContent className="space-y-4">
+              {isLoadingSeats ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                </div>
+              ) : seatUsage ? (
+                <>
+                  {/* Seat Usage Display */}
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium">
+                        Seats
+                      </span>
+                      <span className="text-sm text-muted-foreground">
+                        {claimed}/{capacity} used ({available}{' '}
+                        available)
+                      </span>
                     </div>
+                    <Progress value={usageProgress} className="h-3" />
                   </div>
-                ) : null}
-                {displayedContent ? (
-                  <Image
-                    src={displayedContent}
-                    alt="Generated content"
-                    fill
-                    className="object-cover"
-                  />
-                ) : (
-                  <div className="flex items-center justify-center h-full">
-                    <p className="text-muted-foreground">
-                      Generate an image or video to see it here!
-                    </p>
-                  </div>
-                )}
-              </div>
-
-              {/* Action Buttons */}
-              <div className="space-y-6">
-                {/* Primary Generation Actions */}
-                <div>
-                  <h3 className="text-sm font-medium text-muted-foreground mb-3">
-                    Primary Generation
-                  </h3>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    {/* Generate Fast Image */}
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="w-full">
-                          <Button
-                            onClick={handleGenerateFastImage}
-                            className="w-full transition-transform hover:-translate-y-px"
-                            size="lg"
-                            disabled={
-                              !hasFastGenerationsAccess ||
-                              fastGenerationsRemaining === 0 ||
-                              isGeneratingFastImage
-                            }
-                          >
-                            {isGeneratingFastImage
-                              ? 'Generating...'
-                              : 'Generate Fast Image'}
-                          </Button>
-                        </span>
-                      </TooltipTrigger>
-                      {(!hasFastGenerationsAccess ||
-                        fastGenerationsRemaining === 0) && (
-                        <TooltipContent>
-                          {!hasFastGenerationsAccess
-                            ? 'Not available in your plan'
-                            : 'No credits remaining'}
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
-                    {generateError && (
-                      <p className="text-sm text-destructive mt-2">
-                        {generateError}
-                      </p>
-                    )}
-
-                    {/* Generate HD Video */}
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="w-full">
-                          <Button
-                            onClick={handleGenerateHDVideo}
-                            className="w-full transition-transform hover:-translate-y-px"
-                            size="lg"
-                            disabled={
-                              !hasHDVideoMinutesAccess ||
-                              hdVideoMinutesRemaining === 0 ||
-                              isGeneratingHDVideo
-                            }
-                          >
-                            {isGeneratingHDVideo
-                              ? 'Generating...'
-                              : 'Generate HD Video'}
-                          </Button>
-                        </span>
-                      </TooltipTrigger>
-                      {(!hasHDVideoMinutesAccess ||
-                        hdVideoMinutesRemaining === 0) && (
-                        <TooltipContent>
-                          {!hasHDVideoMinutesAccess
-                            ? 'Not available in your plan'
-                            : 'No credits remaining'}
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
-                    {hdVideoError && (
-                      <p className="text-sm text-destructive mt-2">
-                        {hdVideoError}
-                      </p>
-                    )}
-                  </div>
-                </div>
-
-                {/* Relax Mode Actions */}
-                <div>
-                  <h3 className="text-sm font-medium text-muted-foreground mb-3">
-                    Relax Mode (Unlimited)
-                  </h3>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    {/* Generate Relax Mode Image */}
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="w-full">
-                          <Button
-                            onClick={handleGenerateRelaxImage}
-                            variant="outline"
-                            className="w-full transition-transform hover:-translate-y-px"
-                            disabled={
-                              !hasRelaxMode || isGeneratingRelaxImage
-                            }
-                          >
-                            {isGeneratingRelaxImage
-                              ? 'Generating...'
-                              : 'Generate Relax Image'}
-                          </Button>
-                        </span>
-                      </TooltipTrigger>
-                      {!hasRelaxMode && (
-                        <TooltipContent>
-                          Not available in your plan
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
-
-                    {/* Generate Relax Mode SD Video */}
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="w-full">
-                          <Button
-                            onClick={handleGenerateRelaxSDVideo}
-                            variant="outline"
-                            className="w-full transition-transform hover:-translate-y-px"
-                            disabled={
-                              !hasUnlimitedRelaxedSDVideo ||
-                              isGeneratingRelaxSDVideo
-                            }
-                          >
-                            {isGeneratingRelaxSDVideo
-                              ? 'Generating...'
-                              : 'Generate Relax SD Video'}
-                          </Button>
-                        </span>
-                      </TooltipTrigger>
-                      {!hasUnlimitedRelaxedSDVideo && (
-                        <TooltipContent>
-                          Not available in your plan
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
-                  </div>
-                </div>
-
-                {/* Credit Top-Ups */}
-                <div>
-                  <h3 className="text-sm font-medium text-muted-foreground mb-3">
-                    Purchase Additional Credits
-                  </h3>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    {/* Fast Generation Top-Up */}
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="w-full">
-                          <Button
-                            onClick={
-                              handlePurchaseFastGenerationTopUp
-                            }
-                            variant="secondary"
-                            className="w-full transition-transform hover:-translate-y-px relative"
-                            disabled={!hasOptionalTopUps}
-                          >
-                            <span className="flex items-center justify-center gap-2">
-                              Buy Fast Generations ($4.00 for 80)
-                              {hasPurchasedFastGenTopUp && (
-                                <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
-                              )}
-                            </span>
-                          </Button>
-                        </span>
-                      </TooltipTrigger>
-                      {!hasOptionalTopUps && (
-                        <TooltipContent>
-                          Not available in your plan
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
-
-                    {/* HD Video Minute Top-Up */}
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="w-full">
-                          <Button
-                            onClick={handlePurchaseHDVideoTopUp}
-                            variant="secondary"
-                            className="w-full transition-transform hover:-translate-y-px relative"
-                            disabled={!hasOptionalTopUps}
-                          >
-                            <span className="flex items-center justify-center gap-2">
-                              Buy HD Video Minutes ($10.00 for 10 min)
-                              {hasPurchasedHDVideoTopUp && (
-                                <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
-                              )}
-                            </span>
-                          </Button>
-                        </span>
-                      </TooltipTrigger>
-                      {!hasOptionalTopUps && (
-                        <TooltipContent>
-                          Not available in your plan
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
-                    {topUpError && (
-                      <p className="text-sm text-destructive mt-2">
-                        {topUpError}
-                      </p>
-                    )}
-                  </div>
-                </div>
-              </div>
-
-              {/* Usage Meters */}
-              <div className="space-y-6 pt-6 border-t">
-                <h3 className="text-sm font-medium text-muted-foreground">
-                  Usage Meters
-                </h3>
-                <div className="space-y-6">
-                  {/* Fast Generations Meter */}
-                  {/* Show if user has access OR if we have a balance (even if total is 0, show remaining) */}
-                  {(hasFastGenerationsAccess ||
-                    fastGenerationsRemaining > 0) && (
-                    <div className="space-y-2">
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm font-medium">
-                          Fast Generations
-                        </span>
-                        <span className="text-sm text-muted-foreground">
-                          {fastGenerationsRemaining}
-                          {fastGenerationsTotal > 0
-                            ? `/${fastGenerationsTotal}`
-                            : ''}{' '}
-                          credits
-                        </span>
-                      </div>
-                      <Progress
-                        value={
-                          fastGenerationsTotal > 0
-                            ? fastGenerationsProgress
-                            : 0
-                        }
-                        className="w-full"
-                      />
-                    </div>
-                  )}
-
-                  {/* HD Video Minutes Meter */}
-                  {/* Show if user has access OR if we have a balance (even if total is 0, show remaining) */}
-                  {(hasHDVideoMinutesAccess ||
-                    hdVideoMinutesRemaining > 0) && (
-                    <div className="space-y-2">
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm font-medium">
-                          HD Video Minutes
-                        </span>
-                        <span className="text-sm text-muted-foreground">
-                          {hdVideoMinutesRemaining}
-                          {hdVideoMinutesTotal > 0
-                            ? `/${hdVideoMinutesTotal}`
-                            : ''}{' '}
-                          minutes
-                        </span>
-                      </div>
-                      <Progress
-                        value={
-                          hdVideoMinutesTotal > 0
-                            ? hdVideoMinutesProgress
-                            : 0
-                        }
-                        className="w-full"
-                      />
-                    </div>
-                  )}
-                </div>
-              </div>
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No seat allocation found. Your plan may not include
+                  seats.
+                </p>
+              )}
             </CardContent>
           </Card>
+
+          {/* Team Members Card */}
+          {seatUsage && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Team Members</CardTitle>
+                <CardDescription>
+                  {claims.length === 0
+                    ? 'No team members assigned yet'
+                    : `${claims.length} seat${claims.length === 1 ? '' : 's'} assigned`}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {/* Claims List */}
+                {claims.length > 0 && (
+                  <div className="space-y-2">
+                    {claims.map((claim) => (
+                      <div
+                        key={claim.id}
+                        className="flex items-center justify-between rounded-lg border p-3"
+                      >
+                        <div className="flex flex-col">
+                          <span className="text-sm font-medium">
+                            {claim.externalId || 'Anonymous seat'}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            Added{' '}
+                            {new Date(
+                              claim.claimedAt
+                            ).toLocaleDateString()}
+                          </span>
+                        </div>
+                        {claim.externalId && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() =>
+                              handleReleaseSeat(claim.externalId!)
+                            }
+                            disabled={
+                              isReleasingOngoing === claim.externalId
+                            }
+                          >
+                            {isReleasingOngoing ===
+                            claim.externalId ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <Trash2 className="h-4 w-4" />
+                            )}
+                          </Button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* Add Member Form */}
+                <div className="flex gap-2">
+                  <Input
+                    type="email"
+                    placeholder="team@example.com"
+                    value={inviteEmail}
+                    onChange={(e) => setInviteEmail(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        handleClaimSeat()
+                      }
+                    }}
+                    disabled={isClaimingOngoing || available === 0}
+                  />
+                  <Button
+                    onClick={handleClaimSeat}
+                    disabled={
+                      isClaimingOngoing ||
+                      available === 0 ||
+                      !inviteEmail.trim()
+                    }
+                  >
+                    {isClaimingOngoing ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <>
+                        <UserPlus className="mr-2 h-4 w-4" />
+                        Add
+                      </>
+                    )}
+                  </Button>
+                </div>
+                {available === 0 && (
+                  <p className="text-xs text-muted-foreground">
+                    All seats are in use. Increase your seat count to
+                    add more members.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Adjust Seats Card */}
+          {seatUsage && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Adjust Seat Count</CardTitle>
+                <CardDescription>
+                  Change how many seats your subscription includes
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex items-center gap-4">
+                  <div className="flex items-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={() =>
+                        setNewQuantity(Math.max(1, newQuantity - 1))
+                      }
+                      disabled={newQuantity <= 1 || isAdjusting}
+                    >
+                      -
+                    </Button>
+                    <Input
+                      type="number"
+                      min={1}
+                      max={100}
+                      value={newQuantity}
+                      onChange={(e) =>
+                        setNewQuantity(
+                          Math.max(
+                            1,
+                            Math.min(
+                              100,
+                              parseInt(e.target.value) || 1
+                            )
+                          )
+                        )
+                      }
+                      className="w-20 text-center"
+                      disabled={isAdjusting}
+                    />
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={() =>
+                        setNewQuantity(Math.min(100, newQuantity + 1))
+                      }
+                      disabled={newQuantity >= 100 || isAdjusting}
+                    >
+                      +
+                    </Button>
+                    <span className="text-sm text-muted-foreground">
+                      {newQuantity === 1 ? 'seat' : 'seats'}
+                    </span>
+                  </div>
+                </div>
+
+                {newQuantity !== capacity && (
+                  <div className="text-sm">
+                    {newQuantity > capacity ? (
+                      <span className="text-green-600 dark:text-green-400">
+                        Adding {newQuantity - capacity} seat
+                        {newQuantity - capacity === 1 ? '' : 's'}
+                      </span>
+                    ) : (
+                      <span className="text-amber-600 dark:text-amber-400">
+                        Removing {capacity - newQuantity} seat
+                        {capacity - newQuantity === 1 ? '' : 's'}
+                      </span>
+                    )}
+                  </div>
+                )}
+
+                <Button
+                  onClick={handleAdjustSeats}
+                  disabled={isAdjusting || newQuantity === capacity}
+                  className="w-full"
+                >
+                  {isAdjusting ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Updating...
+                    </>
+                  ) : (
+                    'Update Subscription'
+                  )}
+                </Button>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Error Display */}
+          {error && (
+            <Card className="border-destructive">
+              <CardContent className="pt-6">
+                <p className="text-sm text-destructive">{error}</p>
+              </CardContent>
+            </Card>
+          )}
         </div>
       </main>
     </div>

--- a/playground/seat-based-billing/src/lib/seat-actions.ts
+++ b/playground/seat-based-billing/src/lib/seat-actions.ts
@@ -1,0 +1,73 @@
+'use server'
+
+import { headers } from 'next/headers'
+import { auth } from '@/lib/auth'
+import { flowglad } from '@/lib/flowglad'
+
+// Helper to get current organization ID
+async function getCustomerExternalId(): Promise<string> {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  })
+  if (!session?.session?.activeOrganizationId) {
+    throw new Error('No active organization')
+  }
+  return session.session.activeOrganizationId
+}
+
+export async function claimSeat(
+  email: string,
+  metadata?: Record<string, unknown>
+) {
+  const customerExternalId = await getCustomerExternalId()
+  const client = flowglad(customerExternalId)
+  return client.claimResource({
+    resourceSlug: 'seats',
+    externalId: email,
+    metadata,
+  })
+}
+
+export async function releaseSeat(email: string) {
+  const customerExternalId = await getCustomerExternalId()
+  const client = flowglad(customerExternalId)
+  return client.releaseResource({
+    resourceSlug: 'seats',
+    externalId: email,
+  })
+}
+
+export async function getSeats() {
+  const customerExternalId = await getCustomerExternalId()
+  const client = flowglad(customerExternalId)
+  return client.getResources()
+}
+
+export async function listSeatClaims() {
+  const customerExternalId = await getCustomerExternalId()
+  const client = flowglad(customerExternalId)
+  return client.listResourceClaims({ resourceSlug: 'seats' })
+}
+
+export async function adjustSeatCount(newQuantity: number) {
+  const customerExternalId = await getCustomerExternalId()
+  const client = flowglad(customerExternalId)
+
+  // Get current subscription to find the price
+  const billing = await client.getBilling()
+  const currentSub = billing.currentSubscriptions?.[0]
+  if (!currentSub) {
+    throw new Error('No active subscription')
+  }
+
+  return client.adjustSubscription({
+    subscriptionId: currentSub.id,
+    timing: 'immediately',
+    subscriptionItems: [
+      {
+        priceSlug: 'pro_monthly',
+        quantity: newQuantity,
+      },
+    ],
+  })
+}


### PR DESCRIPTION
## What Does this PR Do?

Implements Patch 2 (seat-actions.ts) and Patch 4 (home page UI) of the GP-75 gameplan. Replaces the usage-meter-based home page with a seat management dashboard for the seat-based-billing playground. Features include displaying seat capacity and usage, listing team members, adding/removing seats by email, and adjusting subscription quantity with validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the usage-based home page with a seat management dashboard so teams can view seat capacity/usage, invite/remove members by email, and adjust subscription seat count with validation.

- **New Features**
  - Seat usage card showing capacity, claimed, available, and progress.
  - Team list from resource claims; release seats per email with loading/error states.
  - Invite by email to claim a seat with simple validation and feedback.
  - Adjust seat count via subscription update; prevents lowering below currently claimed seats.
  - Server actions added: claimSeat, releaseSeat, getSeats, listSeatClaims, adjustSeatCount (uses active org from session, resourceSlug "seats", priceSlug "pro_monthly").
  - Redirects free-plan users to /pricing.

- **Migration**
  - Ensure a "seats" resource and a "pro_monthly" price exist; update priceSlug if your plan uses a different slug.
  - Requires an active non-free subscription; free plans will be redirected.

<sup>Written for commit 1b3c1e5539aa345355eea476861af536d0f852f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

