### PR TITLE
[resource pricing-model-templates] Add resource-based billing to ai_meeting_notes_subscription

### DIFF
--- a/platform/flowglad-next/src/constants/pricingModelTemplates.test.ts
+++ b/platform/flowglad-next/src/constants/pricingModelTemplates.test.ts
@@ -170,4 +170,89 @@ describe('Pricing Model Templates', () => {
       ).not.toThrow()
     })
   })
+
+  describe('ai_meeting_notes_subscription template', () => {
+    const template = getTemplateById('ai_meeting_notes_subscription')!
+
+    it('should have a resources array with a users resource', () => {
+      expect(template.input.resources).toHaveLength(1)
+      expect(template.input.resources![0]).toMatchObject({
+        slug: 'users',
+        name: 'Users',
+        active: true,
+      })
+    })
+
+    it('should have resource features for Basic, Business, and Enterprise tiers with 1 user each', () => {
+      const resourceFeatures = template.input.features.filter(
+        (f) => f.type === FeatureType.Resource
+      )
+
+      expect(resourceFeatures).toHaveLength(3)
+
+      const basicUsers = resourceFeatures.find(
+        (f) => f.slug === 'basic_users'
+      )
+      const businessUsers = resourceFeatures.find(
+        (f) => f.slug === 'business_users'
+      )
+      const enterpriseUsers = resourceFeatures.find(
+        (f) => f.slug === 'enterprise_users'
+      )
+
+      expect(basicUsers).toMatchObject({
+        type: FeatureType.Resource,
+        slug: 'basic_users',
+        resourceSlug: 'users',
+        amount: 1,
+        active: true,
+      })
+
+      expect(businessUsers).toMatchObject({
+        type: FeatureType.Resource,
+        slug: 'business_users',
+        resourceSlug: 'users',
+        amount: 1,
+        active: true,
+      })
+
+      expect(enterpriseUsers).toMatchObject({
+        type: FeatureType.Resource,
+        slug: 'enterprise_users',
+        resourceSlug: 'users',
+        amount: 1,
+        active: true,
+      })
+    })
+
+    it('should attach basic_users to Basic tier', () => {
+      const basicTier = template.input.products.find(
+        (p) => p.product.slug === 'basic'
+      )
+
+      expect(basicTier!.features).toContain('basic_users')
+    })
+
+    it('should attach business_users to Business tier', () => {
+      const businessTier = template.input.products.find(
+        (p) => p.product.slug === 'business'
+      )
+
+      expect(businessTier!.features).toContain('business_users')
+    })
+
+    it('should attach enterprise_users to Enterprise tier', () => {
+      const enterpriseTier = template.input.products.find(
+        (p) => p.product.slug === 'enterprise'
+      )
+
+      expect(enterpriseTier!.features).toContain('enterprise_users')
+    })
+
+    it('should pass validation with resource features', () => {
+      expect(() =>
+        validateSetupPricingModelInput(template.input)
+      ).not.toThrow()
+    })
+  })
 })

--- a/platform/flowglad-next/src/constants/pricingModelTemplates.ts
+++ b/platform/flowglad-next/src/constants/pricingModelTemplates.ts
@@ -1902,36 +1902,45 @@ export const AI_MEETING_NOTES_SUBSCRIPTION_TEMPLATE: PricingModelTemplate =
       // Usage Meters - None needed for seat-based billing
       usageMeters: [],
 
-      // Resources - defines the "seats" resource for this pricing model
+      // Resources - defines the "users" resource for this pricing model
       resources: [
         {
-          slug: 'seats',
-          name: 'Seats',
+          slug: 'users',
+          name: 'Users',
           active: true,
         },
       ],
 
       // Features
       features: [
-        // Resource features - grant seat capacity per product tier
+        // Resource features - grant user capacity per product tier (1 seat each, adjustSubscription handles scaling)
         {
           type: FeatureType.Resource,
-          slug: 'business_seats',
-          name: 'Business Plan Seats',
-          description:
-            'Seat allocation for Business plan subscribers',
-          resourceSlug: 'seats',
-          amount: 100,
+          slug: 'basic_users',
+          name: 'Basic Plan Users',
+          description: 'User allocation for Basic plan subscribers',
+          resourceSlug: 'users',
+          amount: 1,
           active: true,
         },
         {
           type: FeatureType.Resource,
-          slug: 'enterprise_seats',
-          name: 'Enterprise Plan Seats',
+          slug: 'business_users',
+          name: 'Business Plan Users',
           description:
-            'Seat allocation for Enterprise plan subscribers',
-          resourceSlug: 'seats',
-          amount: 1000,
+            'User allocation for Business plan subscribers',
+          resourceSlug: 'users',
+          amount: 1,
+          active: true,
+        },
+        {
+          type: FeatureType.Resource,
+          slug: 'enterprise_users',
+          name: 'Enterprise Plan Users',
+          description:
+            'User allocation for Enterprise plan subscribers',
+          resourceSlug: 'users',
+          amount: 1,
           active: true,
         },
         // Basic (Free) tier features
@@ -2097,6 +2106,7 @@ export const AI_MEETING_NOTES_SUBSCRIPTION_TEMPLATE: PricingModelTemplate =
             unitPrice: 0,
           },
           features: [
+            'basic_users',
             'ai_meeting_notes',
             '14_day_history',
             'ai_chat',
@@ -2131,7 +2141,7 @@ export const AI_MEETING_NOTES_SUBSCRIPTION_TEMPLATE: PricingModelTemplate =
             unitPrice: 1400,
           },
           features: [
-            'business_seats',
+            'business_users',
             'ai_meeting_notes',
             '14_day_history',
             'ai_chat',
@@ -2170,7 +2180,7 @@ export const AI_MEETING_NOTES_SUBSCRIPTION_TEMPLATE: PricingModelTemplate =
             unitPrice: 3500,
           },
           features: [
-            'enterprise_seats',
+            'enterprise_users',
             'ai_meeting_notes',
             '14_day_history',
             'ai_chat',


### PR DESCRIPTION
## What Does this PR Do?

Implements Patch 2 of the seat-based templates migration gameplan. Migrates the AI Meeting Notes Subscription template to use the resource-based billing system (`FeatureType.Resource`) instead of legacy quantity labels. Adds a 'seats' resource with Business (100 seats) and Enterprise (1000 seats) tier allocations, ensuring proper claim/release lifecycle tracking and capacity enforcement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the Meeting Notes Subscription pricing template to resource-based billing with a single "users" resource. Adds a 1-user allocation to Basic, Business, and Enterprise tiers; scaling is handled by subscription adjustments.

- **New Features**
  - Defines a "users" resource.
  - Adds resource features: basic_users, business_users, enterprise_users (amount: 1).
  - Attaches user allocations to all tiers.
  - Adds tests for resource features and tier attachments.

<sup>Written for commit 5f7bfbea3942c82246256dd30efb875aa2bc1369. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a "Users" seat-based resource for AI meeting notes to enable per-user seat allocation.
  * Added per-plan user-seat features for Basic, Business, and Enterprise tiers so each plan includes its respective seat allocation.

* **Tests**
  * Added tests validating the new Users resource, the three resource-based features, and their assignment to Basic/Business/Enterprise plans.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->