### PR TITLE
[resource pricing-model-templates] Add resource-based billing to seat_based_subscription

### DIFF
--- a/platform/flowglad-next/src/constants/pricingModelTemplates.test.ts
+++ b/platform/flowglad-next/src/constants/pricingModelTemplates.test.ts
@@ -82,46 +82,67 @@ describe('Pricing Model Templates', () => {
   describe('seat_based_subscription template', () => {
     const template = getTemplateById('seat_based_subscription')!
 
-    it('should have a resources array with a seats resource', () => {
+    it('should have a resources array with a teams resource', () => {
       expect(template.input.resources).toHaveLength(1)
       expect(template.input.resources![0]).toMatchObject({
-        slug: 'seats',
-        name: 'Seats',
+        slug: 'teams',
+        name: 'Teams',
         active: true,
       })
     })
 
-    it('should have resource features for Basic, Business, and Enterprise tiers', () => {
+    it('should have resource features for Free and Basic tiers with correct team limits', () => {
       const resourceFeatures = template.input.features.filter(
         (f) => f.type === FeatureType.Resource
       )
 
-      expect(resourceFeatures).toHaveLength(3)
+      expect(resourceFeatures).toHaveLength(2)
 
-      const slugs = resourceFeatures.map((f) => f.slug)
-      expect(slugs).toContain('basic_seats')
-      expect(slugs).toContain('business_seats')
-      expect(slugs).toContain('enterprise_seats')
+      const freeTeams = resourceFeatures.find(
+        (f) => f.slug === 'free_teams'
+      )
+      const basicTeams = resourceFeatures.find(
+        (f) => f.slug === 'basic_teams'
+      )
 
-      resourceFeatures.forEach((feature) => {
-        expect(feature).toMatchObject({
-          type: FeatureType.Resource,
-          resourceSlug: 'seats',
-          active: true,
-        })
-        expect(
-          'amount' in feature && typeof feature.amount === 'number'
-        ).toBe(true)
+      expect(freeTeams).toMatchObject({
+        type: FeatureType.Resource,
+        slug: 'free_teams',
+        resourceSlug: 'teams',
+        amount: 2,
+        active: true,
+      })
+
+      expect(basicTeams).toMatchObject({
+        type: FeatureType.Resource,
+        slug: 'basic_teams',
+        resourceSlug: 'teams',
+        amount: 5,
+        active: true,
       })
     })
 
-    it('should attach resource features to paid tier products', () => {
+    it('should attach free_teams to Free tier', () => {
+      const freeTier = template.input.products.find(
+        (p) => p.product.slug === 'free_tier'
+      )
+
+      expect(freeTier!.features).toContain('free_teams')
+    })
+
+    it('should attach basic_teams to Basic tier products', () => {
       const basicMonthly = template.input.products.find(
         (p) => p.product.slug === 'basic_monthly'
       )
       const basicYearly = template.input.products.find(
         (p) => p.product.slug === 'basic_yearly'
       )
+
+      expect(basicMonthly!.features).toContain('basic_teams')
+      expect(basicYearly!.features).toContain('basic_teams')
+    })
+
+    it('should not attach resource features to Business and Enterprise tiers (unlimited teams)', () => {
       const businessMonthly = template.input.products.find(
         (p) => p.product.slug === 'business_monthly'
       )
@@ -132,27 +153,18 @@ describe('Pricing Model Templates', () => {
         (p) => p.product.slug === 'enterprise'
       )
 
-      expect(basicMonthly!.features).toContain('basic_seats')
-      expect(basicYearly!.features).toContain('basic_seats')
-      expect(businessMonthly!.features).toContain('business_seats')
-      expect(businessYearly!.features).toContain('business_seats')
-      expect(enterprise!.features).toContain('enterprise_seats')
-    })
-
-    it('should not attach resource features to Free tier', () => {
-      const freeTier = template.input.products.find(
-        (p) => p.product.slug === 'free_tier'
-      )
-
-      const resourceFeatureSlugs = [
-        'basic_seats',
-        'business_seats',
-        'enterprise_seats',
-      ]
+      const resourceFeatureSlugs = ['free_teams', 'basic_teams']
 
       resourceFeatureSlugs.forEach((slug) => {
-        expect(freeTier!.features).not.toContain(slug)
+        expect(businessMonthly!.features).not.toContain(slug)
+        expect(businessYearly!.features).not.toContain(slug)
+        expect(enterprise!.features).not.toContain(slug)
       })
+
+      // Verify they have unlimited_teams toggle feature instead
+      expect(businessMonthly!.features).toContain('unlimited_teams')
+      expect(businessYearly!.features).toContain('unlimited_teams')
+      expect(enterprise!.features).toContain('unlimited_teams')
     })
 
     it('should pass validation with resource features', () => {

--- a/platform/flowglad-next/src/constants/pricingModelTemplates.ts
+++ b/platform/flowglad-next/src/constants/pricingModelTemplates.ts
@@ -1429,45 +1429,34 @@ export const SEAT_BASED_SUBSCRIPTION_TEMPLATE: PricingModelTemplate =
       // Usage Meters - None needed for seat-based billing
       usageMeters: [],
 
-      // Resources - defines the "seats" resource for this pricing model
+      // Resources - defines the "teams" resource for this pricing model
       resources: [
         {
-          slug: 'seats',
-          name: 'Seats',
+          slug: 'teams',
+          name: 'Teams',
           active: true,
         },
       ],
 
       // Features
       features: [
-        // Resource features - grant seat capacity per product tier
+        // Resource features - grant team capacity per product tier
         {
           type: FeatureType.Resource,
-          slug: 'basic_seats',
-          name: 'Basic Plan Seats',
-          description: 'Seat allocation for Basic plan subscribers',
-          resourceSlug: 'seats',
-          amount: 100,
+          slug: 'free_teams',
+          name: 'Free Plan Teams',
+          description: 'Team allocation for Free plan subscribers',
+          resourceSlug: 'teams',
+          amount: 2,
           active: true,
         },
         {
           type: FeatureType.Resource,
-          slug: 'business_seats',
-          name: 'Business Plan Seats',
-          description:
-            'Seat allocation for Business plan subscribers',
-          resourceSlug: 'seats',
-          amount: 500,
-          active: true,
-        },
-        {
-          type: FeatureType.Resource,
-          slug: 'enterprise_seats',
-          name: 'Enterprise Plan Seats',
-          description:
-            'Seat allocation for Enterprise plan subscribers',
-          resourceSlug: 'seats',
-          amount: 10000,
+          slug: 'basic_teams',
+          name: 'Basic Plan Teams',
+          description: 'Team allocation for Basic plan subscribers',
+          resourceSlug: 'teams',
+          amount: 5,
           active: true,
         },
 
@@ -1715,6 +1704,7 @@ export const SEAT_BASED_SUBSCRIPTION_TEMPLATE: PricingModelTemplate =
             unitPrice: 0,
           },
           features: [
+            'free_teams',
             'unlimited_members',
             'slack_github',
             'ai_agents',
@@ -1751,7 +1741,7 @@ export const SEAT_BASED_SUBSCRIPTION_TEMPLATE: PricingModelTemplate =
             unitPrice: 1000,
           },
           features: [
-            'basic_seats',
+            'basic_teams',
             'unlimited_members',
             'slack_github',
             'ai_agents',
@@ -1793,7 +1783,7 @@ export const SEAT_BASED_SUBSCRIPTION_TEMPLATE: PricingModelTemplate =
             unitPrice: 12000,
           },
           features: [
-            'basic_seats',
+            'basic_teams',
             'unlimited_members',
             'slack_github',
             'ai_agents',
@@ -1835,7 +1825,6 @@ export const SEAT_BASED_SUBSCRIPTION_TEMPLATE: PricingModelTemplate =
             unitPrice: 1600,
           },
           features: [
-            'business_seats',
             'unlimited_members',
             'slack_github',
             'ai_agents',
@@ -1886,7 +1875,6 @@ export const SEAT_BASED_SUBSCRIPTION_TEMPLATE: PricingModelTemplate =
             unitPrice: 19200,
           },
           features: [
-            'business_seats',
             'unlimited_members',
             'slack_github',
             'ai_agents',
@@ -1937,7 +1925,6 @@ export const SEAT_BASED_SUBSCRIPTION_TEMPLATE: PricingModelTemplate =
             unitPrice: 24000, // Placeholder price - actual pricing is custom
           },
           features: [
-            'enterprise_seats',
             'unlimited_members',
             'slack_github',
             'ai_agents',


### PR DESCRIPTION
## What Does this PR Do?

This PR implements Patch 1 from the seat-templates-to-resource-billing gameplan. It migrates the `seat_based_subscription` template to use the resource-based billing system with a "seats" resource and capacity-enforcing features for Basic (100), Business (500), and Enterprise (10000) tiers. Includes comprehensive test coverage validating resource configuration and tier assignments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the seat_based_subscription template to resource-based billing with a teams resource. Free gets 2 teams, Basic gets 5; Business and Enterprise have unlimited teams via a toggle.

- **New Features**
  - Added teams resource and resource features: free_teams (2) and basic_teams (5).
  - Attached free_teams to Free and basic_teams to Basic monthly/yearly; Business/Enterprise use unlimited_teams (no resource cap).
  - Added tests for resource config, feature slugs/amounts, product assignments, and schema validation.

<sup>Written for commit 3ae0ca55973db24bbbbbf28cbe4a693b58ef98aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Seat-based subscription expanded to include a per-plan "teams" resource with specific allocations for Free and Basic tiers; Business and Enterprise retain unlimited team capacity.
  * Tiered seat capacities retained for higher plans (Business, Enterprise).

* **Tests**
  * Added test coverage validating the new seat-based teams allocations and template validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->