### PR TITLE
docs: fix subscription enum

### DIFF
--- a/platform/docs/sdks/subscription-management.mdx
+++ b/platform/docs/sdks/subscription-management.mdx
@@ -55,7 +55,7 @@ There are three ways to specify the new plan:
 The `timing` parameter controls when the adjustment takes effect:
 - **`auto`** (default): Automatically determines timing based on whether this is an upgrade or downgrade. Upgrades happen immediately with proration; downgrades happen at the end of the current billing period.
 - **`immediately`**: Apply the change immediately. For upgrades, the customer is charged the prorated difference. For downgrades, the plan changes immediately but no refund is issued.
-- **`at_end_of_period`**: Apply the change at the end of the current billing period (only valid for downgrades).
+- **`at_end_of_current_billing_period`**: Apply the change at the end of the current billing period (only valid for downgrades).
 
 **How `auto` determines upgrade vs downgrade:**
 


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the subscription timing enum in SDK docs to match the API: replaced "at_end_of_period" with "at_end_of_current_billing_period". This removes ambiguity and ensures developers use the valid value in integrations.

<sup>Written for commit d30e1ab33fbef3cc8d3e407299aba1357d1bbf27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified subscription adjustment timing option naming in documentation to more accurately reflect billing period behavior and improve clarity on when changes take effect.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->