### PR TITLE
fix: Add uncancel-subscription-dialog.tsx to registry

### DIFF
--- a/platform/flowglad-next/registry.json
+++ b/platform/flowglad-next/registry.json
@@ -149,6 +149,10 @@
           "type": "registry:component"
         },
         {
+          "path": "src/registry/base/subscription-card/uncancel-subscription-dialog.tsx",
+          "type": "registry:component"
+        },
+        {
           "path": "src/registry/base/subscription-card/types.ts",
           "type": "registry:lib"
         },


### PR DESCRIPTION
## Summary
- Adds the missing `uncancel-subscription-dialog.tsx` to the subscription-card component in `registry.json`
- This file was being used by `subscription-actions.tsx` but wasn't registered, causing registry validation to flag it as orphaned

## Test plan
- [x] Ran `bun run check` - all linting, typechecking, and registry validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers uncancel-subscription-dialog.tsx in registry.json to resolve orphaned file validation errors. Ensures subscription-actions.tsx has its dialog dependency registered and keeps registry checks green.

<sup>Written for commit 7209556e61307142e7e90c7afda93a1edbd59b4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

