### PR TITLE
Remove dev-only guards from resources functionality

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@flowglad/javascript",

--- a/platform/flowglad-next/src/app/finance/subscriptions/[id]/InnerSubscriptionPage.tsx
+++ b/platform/flowglad-next/src/app/finance/subscriptions/[id]/InnerSubscriptionPage.tsx
@@ -33,7 +33,7 @@ import {
   FeatureUsageGrantFrequency,
   SubscriptionStatus,
 } from '@/types'
-import core, { IS_DEV } from '@/utils/core'
+import core from '@/utils/core'
 import { formatBillingPeriod, getCurrencyParts } from '@/utils/stripe'
 import { AddSubscriptionFeatureModal } from './AddSubscriptionFeatureModal'
 import { BillingHistorySection } from './BillingHistorySection'
@@ -273,17 +273,11 @@ const InnerSubscriptionPage = ({
             )}
           </div>
         </ExpandSection>
-        {/* FIXME: Resource UI is temporarily dev-only while resource features are gated behind devOnlyProcedure. Remove IS_DEV check when resources are ready for production. */}
-        {IS_DEV && (
-          <ExpandSection
-            title="Resource Usage"
-            defaultExpanded={false}
-          >
-            <SubscriptionResourceUsage
-              subscriptionId={subscription.id}
-            />
-          </ExpandSection>
-        )}
+        <ExpandSection title="Resource Usage" defaultExpanded={false}>
+          <SubscriptionResourceUsage
+            subscriptionId={subscription.id}
+          />
+        </ExpandSection>
         <BillingHistorySection
           subscriptionId={subscription.id}
           customerId={subscription.customerId}

--- a/platform/flowglad-next/src/app/pricing-models/[id]/InnerPricingModelDetailsPage.tsx
+++ b/platform/flowglad-next/src/app/pricing-models/[id]/InnerPricingModelDetailsPage.tsx
@@ -40,7 +40,6 @@ import {
 } from '@/components/ui/popover'
 import type { PricingModel } from '@/db/schema/pricingModels'
 import type { Resource } from '@/db/schema/resources'
-import { IS_DEV } from '@/utils/core'
 
 export type InnerPricingModelDetailsPageProps = {
   pricingModel: PricingModel.ClientRecord
@@ -301,26 +300,23 @@ function InnerPricingModelDetailsPage({
             buttonVariant="secondary"
           />
         </ExpandSection>
-        {/* FIXME: Resource UI is temporarily dev-only while resource features are gated behind devOnlyProcedure. Remove IS_DEV check when resources are ready for production. */}
-        {IS_DEV && (
-          <ExpandSection
-            title="Resources"
-            defaultExpanded={false}
-            contentPadding={false}
-          >
-            <ResourcesDataTable
-              filters={{ pricingModelId: pricingModel.id }}
-              onCreateResource={() =>
-                setIsCreateResourceModalOpen(true)
-              }
-              onEditResource={(resource) => {
-                setResourceToEdit(resource)
-                setIsEditResourceModalOpen(true)
-              }}
-              buttonVariant="secondary"
-            />
-          </ExpandSection>
-        )}
+        <ExpandSection
+          title="Resources"
+          defaultExpanded={false}
+          contentPadding={false}
+        >
+          <ResourcesDataTable
+            filters={{ pricingModelId: pricingModel.id }}
+            onCreateResource={() =>
+              setIsCreateResourceModalOpen(true)
+            }
+            onEditResource={(resource) => {
+              setResourceToEdit(resource)
+              setIsEditResourceModalOpen(true)
+            }}
+            buttonVariant="secondary"
+          />
+        </ExpandSection>
         <ExpandSection
           title="Customers"
           defaultExpanded={false}
@@ -363,23 +359,18 @@ function InnerPricingModelDetailsPage({
         defaultPricingModelId={pricingModel.id}
         hidePricingModelSelect={true}
       />
-      {/* FIXME: Resource modals are temporarily dev-only while resource features are gated behind devOnlyProcedure. Remove IS_DEV check when resources are ready for production. */}
-      {IS_DEV && (
-        <>
-          <CreateResourceModal
-            isOpen={isCreateResourceModalOpen}
-            setIsOpen={setIsCreateResourceModalOpen}
-            defaultPricingModelId={pricingModel.id}
-            hidePricingModelSelect={true}
-          />
-          {resourceToEdit && (
-            <EditResourceModal
-              isOpen={isEditResourceModalOpen}
-              setIsOpen={setIsEditResourceModalOpen}
-              resource={resourceToEdit}
-            />
-          )}
-        </>
+      <CreateResourceModal
+        isOpen={isCreateResourceModalOpen}
+        setIsOpen={setIsCreateResourceModalOpen}
+        defaultPricingModelId={pricingModel.id}
+        hidePricingModelSelect={true}
+      />
+      {resourceToEdit && (
+        <EditResourceModal
+          isOpen={isEditResourceModalOpen}
+          setIsOpen={setIsEditResourceModalOpen}
+          resource={resourceToEdit}
+        />
       )}
       <PricingModelIntegrationGuideModal
         isOpen={isGetIntegrationGuideModalOpen}

--- a/platform/flowglad-next/src/components/forms/FeatureFormFields.tsx
+++ b/platform/flowglad-next/src/components/forms/FeatureFormFields.tsx
@@ -27,7 +27,7 @@ import {
   usageCreditGrantFeatureDefaultColumns,
 } from '@/db/schema/features'
 import { FeatureType, FeatureUsageGrantFrequency } from '@/types'
-import core, { IS_DEV, titleCase } from '@/utils/core'
+import core, { titleCase } from '@/utils/core'
 import ResourcesSelect from './ResourcesSelect'
 import UsageMetersSelect from './UsageMetersSelect'
 
@@ -121,8 +121,7 @@ const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
                       usageCreditGrantFeatureDefaultColumns
                     ).forEach(assignFeatureValueFromTuple)
                   }
-                  // FIXME: Resource feature type is temporarily dev-only while resource features are gated behind devOnlyProcedure. Remove IS_DEV check when resources are ready for production.
-                  if (IS_DEV && value === FeatureType.Resource) {
+                  if (value === FeatureType.Resource) {
                     Object.entries(
                       resourceFeatureDefaultColumns
                     ).forEach(assignFeatureValueFromTuple)
@@ -149,17 +148,14 @@ const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
                       </div>
                     </div>
                   </SelectItem>
-                  {/* FIXME: Resource feature type is temporarily dev-only while resource features are gated behind devOnlyProcedure. Remove IS_DEV check when resources are ready for production. */}
-                  {IS_DEV && (
-                    <SelectItem value={FeatureType.Resource}>
-                      <div>
-                        <div>Resource</div>
-                        <div className="text-xs text-muted-foreground">
-                          Claimable capacity (seats, API keys, etc.)
-                        </div>
+                  <SelectItem value={FeatureType.Resource}>
+                    <div>
+                      <div>Resource</div>
+                      <div className="text-xs text-muted-foreground">
+                        Claimable capacity (seats, API keys, etc.)
                       </div>
-                    </SelectItem>
-                  )}
+                    </div>
+                  </SelectItem>
                 </SelectContent>
               </Select>
             </FormControl>
@@ -237,8 +233,7 @@ const FeatureFormFields = ({ edit = false }: { edit?: boolean }) => {
         </>
       )}
 
-      {/* FIXME: Resource form fields are temporarily dev-only while resource features are gated behind devOnlyProcedure. Remove IS_DEV check when resources are ready for production. */}
-      {IS_DEV && featureType === FeatureType.Resource && (
+      {featureType === FeatureType.Resource && (
         <>
           <FormField
             control={form.control}

--- a/platform/flowglad-next/src/server/routers/resourceClaimsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/resourceClaimsRouter.ts
@@ -22,7 +22,7 @@ import {
   releaseResourceInputSchema,
   releaseResourceTransaction,
 } from '@/resources/resourceClaimHelpers'
-import { devOnlyProcedure, router } from '@/server/trpc'
+import { protectedProcedure, router } from '@/server/trpc'
 import { FeatureType } from '@/types'
 import { trpcToRest } from '@/utils/openapi'
 
@@ -173,7 +173,7 @@ const validateSubscriptionOwnership = async (
   return { subscription, customerId: subscription.customerId }
 }
 
-const claimProcedure = devOnlyProcedure
+const claimProcedure = protectedProcedure
   .meta({
     openapi: {
       method: 'POST',
@@ -218,7 +218,7 @@ const claimProcedure = devOnlyProcedure
     )
   )
 
-const releaseProcedure = devOnlyProcedure
+const releaseProcedure = protectedProcedure
   .meta({
     openapi: {
       method: 'POST',
@@ -263,7 +263,7 @@ const releaseProcedure = devOnlyProcedure
     )
   )
 
-const getUsageProcedure = devOnlyProcedure
+const getUsageProcedure = protectedProcedure
   .meta({
     openapi: {
       method: 'GET',
@@ -426,7 +426,7 @@ const listResourceUsagesInputSchema = z
     id: 'ListResourceUsagesInput',
   })
 
-const listResourceUsagesProcedure = devOnlyProcedure
+const listResourceUsagesProcedure = protectedProcedure
   .meta({
     openapi: {
       method: 'GET',
@@ -588,7 +588,7 @@ const listResourceUsagesProcedure = devOnlyProcedure
     )
   )
 
-const listClaimsProcedure = devOnlyProcedure
+const listClaimsProcedure = protectedProcedure
   .meta({
     openapi: {
       method: 'GET',

--- a/platform/flowglad-next/src/server/routers/resourcesRouter.ts
+++ b/platform/flowglad-next/src/server/routers/resourcesRouter.ts
@@ -26,7 +26,7 @@ import {
   createPaginatedTableRowOutputSchema,
   idInputSchema,
 } from '@/db/tableUtils'
-import { devOnlyProcedure, router } from '@/server/trpc'
+import { protectedProcedure, router } from '@/server/trpc'
 import { generateOpenApiMetas, trpcToRest } from '@/utils/openapi'
 
 const { openApiMetas, routeConfigs } = generateOpenApiMetas({
@@ -43,7 +43,7 @@ const resourcesPaginatedListSchema = createPaginatedListQuerySchema(
   resourcesClientSelectSchema
 )
 
-const listProcedure = devOnlyProcedure
+const listProcedure = protectedProcedure
   .meta(openApiMetas.LIST)
   .input(z.object({ pricingModelId: z.string() }))
   .output(
@@ -66,7 +66,7 @@ const listProcedure = devOnlyProcedure
     )
   )
 
-const getProcedure = devOnlyProcedure
+const getProcedure = protectedProcedure
   .meta(openApiMetas.GET)
   .input(idInputSchema)
   .output(z.object({ resource: resourcesClientSelectSchema }))
@@ -83,7 +83,7 @@ const getProcedure = devOnlyProcedure
     )
   )
 
-const createProcedure = devOnlyProcedure
+const createProcedure = protectedProcedure
   .meta(openApiMetas.POST)
   .input(createResourceSchema)
   .output(z.object({ resource: resourcesClientSelectSchema }))
@@ -120,7 +120,7 @@ const createProcedure = devOnlyProcedure
     )
   )
 
-const updateProcedure = devOnlyProcedure
+const updateProcedure = protectedProcedure
   .meta(openApiMetas.PUT)
   .input(editResourceSchema)
   .output(z.object({ resource: resourcesClientSelectSchema }))
@@ -140,7 +140,7 @@ const updateProcedure = devOnlyProcedure
     )
   )
 
-const listPaginatedProcedure = devOnlyProcedure
+const listPaginatedProcedure = protectedProcedure
   .input(resourcesPaginatedSelectSchema)
   .output(resourcesPaginatedListSchema)
   .query(async ({ input, ctx }) => {
@@ -154,7 +154,7 @@ const listPaginatedProcedure = devOnlyProcedure
     )
   })
 
-const getTableRowsProcedure = devOnlyProcedure
+const getTableRowsProcedure = protectedProcedure
   .input(
     createPaginatedTableRowInputSchema(
       z.object({


### PR DESCRIPTION
## What Does this PR Do?

Opens the resources feature to all authenticated users by removing dev-only guards. Changes `devOnlyProcedure` to `protectedProcedure` in backend routers (resourcesRouter, resourceClaimsRouter) and removes `IS_DEV` conditional rendering from frontend components (InnerSubscriptionPage, InnerPricingModelDetailsPage, FeatureFormFields).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens the Resources feature to all authenticated users by removing dev-only guards across backend and frontend. Resource management and usage are now visible and usable in Subscription and Pricing Model views.

- **New Features**
  - Resources and claims APIs now use protectedProcedure (resourcesRouter, resourceClaimsRouter).
  - Resources UI enabled in InnerSubscriptionPage and InnerPricingModelDetailsPage.
  - Resource feature type and fields available in FeatureFormFields.

<sup>Written for commit e6f9d57ae92585d12d7eaf1e71b68c96e1849967. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource management capabilities are now available to all users (previously developer-only).
  * Billing history now displays customer names for improved clarity.

* **Security & Access Control**
  * Implemented organization-scoped authorization for resource operations to ensure proper data access controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->