### PR TITLE
Improve fan-patches.sh session naming and output

### DIFF
--- a/platform/flowglad-next/llm-prompts/fan-patches.sh
+++ b/platform/flowglad-next/llm-prompts/fan-patches.sh
@@ -54,6 +54,12 @@ extract_base_branch() {
   echo "${branch:-main}"
 }
 
+# Extract patch number from patch name (e.g., "patch-1" -> "1")
+extract_patch_number() {
+  local patch_name="$1"
+  echo "$patch_name" | sed 's/patch-//'
+}
+
 # Find existing worktree for a branch (returns path or empty string)
 find_worktree_for_branch() {
   local branch="$1"
@@ -69,9 +75,11 @@ find_worktree_for_branch() {
 # Create worktrees and collect info
 declare -a WORKTREE_PATHS
 declare -a BRANCH_NAMES
+declare -a PATCH_NUMBERS
 
 for PATCH_FILE in "${PATCH_FILES[@]}"; do
   PATCH_NAME=$(basename "$PATCH_FILE" .md)
+  PATCH_NUMBER=$(extract_patch_number "$PATCH_NAME")
   BRANCH_NAME=$(extract_branch_name "$PATCH_FILE")
   BASE_BRANCH=$(extract_base_branch "$PATCH_FILE")
 
@@ -80,7 +88,7 @@ for PATCH_FILE in "${PATCH_FILES[@]}"; do
     BRANCH_NAME="$PROJECT_NAME/$PATCH_NAME"
   fi
 
-  echo "Setting up $PATCH_NAME..."
+  echo "Setting up patch $PATCH_NUMBER ($PATCH_NAME)..."
   echo "  Branch: $BRANCH_NAME (from $BASE_BRANCH)"
 
   # Check if branch already has a worktree somewhere
@@ -113,12 +121,13 @@ for PATCH_FILE in "${PATCH_FILES[@]}"; do
 
   WORKTREE_PATHS+=("$WORKTREE_PATH")
   BRANCH_NAMES+=("$BRANCH_NAME")
+  PATCH_NUMBERS+=("$PATCH_NUMBER")
 done
 
 echo ""
 echo "All worktrees ready. Creating tmux session..."
 
-SESSION_NAME="$PROJECT_NAME"
+SESSION_NAME="$GIT_REPO_NAME--$PROJECT_NAME"
 
 # Check if session already exists
 SESSION_EXISTS=false
@@ -138,12 +147,13 @@ fi
 
 # Create session if it doesn't exist (use first patch)
 if [ "$SESSION_EXISTS" = false ]; then
-  FIRST_PATCH="${PATCH_FILES[0]}"
-  FIRST_PATCH_NAME=$(basename "$FIRST_PATCH" .md)
+  FIRST_PATCH_NAME=$(basename "${PATCH_FILES[0]}" .md)
+  FIRST_PATCH_NUMBER="${PATCH_NUMBERS[0]}"
   FIRST_WORKTREE="${WORKTREE_PATHS[0]}"
 
   tmux new-session -d -s "$SESSION_NAME" -n "$FIRST_PATCH_NAME" -c "$FIRST_WORKTREE"
   tmux send-keys -t "$SESSION_NAME:$FIRST_PATCH_NAME" "claude 'AGENT_PROMPT.md'" Enter
+  echo "  Created window for patch $FIRST_PATCH_NUMBER"
   START_INDEX=1
 else
   START_INDEX=0
@@ -151,18 +161,19 @@ fi
 
 # Add windows for remaining patches (skip ones that already have windows)
 for ((i=START_INDEX; i<${#PATCH_FILES[@]}; i++)); do
-  PATCH_FILE="${PATCH_FILES[$i]}"
-  PATCH_NAME=$(basename "$PATCH_FILE" .md)
+  PATCH_NAME=$(basename "${PATCH_FILES[$i]}" .md)
+  PATCH_NUMBER="${PATCH_NUMBERS[$i]}"
   WORKTREE_PATH="${WORKTREE_PATHS[$i]}"
 
   # Check if window already exists
   if tmux list-windows -t "$SESSION_NAME" -F '#W' 2>/dev/null | grep -q "^${PATCH_NAME}$"; then
-    echo "  Window '$PATCH_NAME' already exists, skipping..."
+    echo "  Window for patch $PATCH_NUMBER already exists, skipping..."
     continue
   fi
 
   tmux new-window -t "$SESSION_NAME" -n "$PATCH_NAME" -c "$WORKTREE_PATH"
   tmux send-keys -t "$SESSION_NAME:$PATCH_NAME" "claude 'AGENT_PROMPT.md'" Enter
+  echo "  Created window for patch $PATCH_NUMBER"
 done
 
 echo ""
@@ -174,7 +185,7 @@ fi
 echo ""
 echo "Worktrees created:"
 for ((i=0; i<${#PATCH_FILES[@]}; i++)); do
-  echo "  - $(basename "${PATCH_FILES[$i]}" .md): ${WORKTREE_PATHS[$i]}"
+  echo "  - Patch ${PATCH_NUMBERS[$i]}: ${WORKTREE_PATHS[$i]}"
 done
 echo ""
 echo "Navigation: Ctrl-b n (next), Ctrl-b p (prev), Ctrl-b w (list)"


### PR DESCRIPTION
## Summary
- Add repo name prefix to tmux session name for better disambiguation when running patches across multiple repos
- Extract and display patch numbers in log output for clearer progress tracking
- Improve log messages to show "patch N" instead of full patch names

## Test plan
- [ ] Run fan-patches.sh and verify tmux session is named `{repo}--{project}`
- [ ] Verify log output shows "patch 1", "patch 2" etc. instead of full patch names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated fan-patches.sh to disambiguate tmux sessions and make patch progress clearer. Sessions are now named {repo}--{project}, and output shows "patch N" (from names like "patch-1") in setup, window creation, and the final worktree list.

<sup>Written for commit 499b17228cfe30426c540f2036f193ae4f70d0a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

