### PR TITLE
Fix: Configure bun test to preload vitest setup for MSW

### DIFF
--- a/platform/flowglad-next/bunfig.toml
+++ b/platform/flowglad-next/bunfig.toml
@@ -1,2 +1,4 @@
 [install]
 autoInstall = false
+[test]
+preload = ["./vitest.setup.ts"]


### PR DESCRIPTION
## What Does this PR Do?

Configures Bun's test runner to preload `vitest.setup.ts`, enabling MSW HTTP request interception for `bun test` command.

Previously, `bun test` would execute Bun's built-in test runner without loading the vitest setup file, causing MSW to not intercept HTTP requests. This resulted in real API calls being made instead of mocked responses. By adding a `[test]` preload section to `bunfig.toml`, `bun test` now behaves identically to `bun run test`.

This single-line configuration change fixes all test HTTP interception issues without requiring changes to test files or test setup logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configures Bun’s test runner to preload vitest.setup.ts so MSW intercepts HTTP requests when running bun test. This prevents real API calls and makes bun test behave the same as bun run test.

<sup>Written for commit fc670711ac53384bda112edbe2392bdbc2ce90ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Configured test setup to preload initialization script before running tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->