### PR TITLE
Fix migration 0275 DROP POLICY statements

### DIFF
--- a/platform/flowglad-next/drizzle-migrations/0275_cynical_magma.sql
+++ b/platform/flowglad-next/drizzle-migrations/0275_cynical_magma.sql
@@ -8,8 +8,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS "prices_usage_meter_is_default_unique_idx" ON 
 CREATE INDEX IF NOT EXISTS "usage_events_usage_meter_id_usage_date_idx" ON "usage_events" USING btree ("usage_meter_id","usage_date");--> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "prices_external_id_product_id_unique_idx" ON "prices" USING btree ("external_id","product_id") WHERE "prices"."type" != 'usage';--> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "prices_product_id_is_default_unique_idx" ON "prices" USING btree ("product_id") WHERE "prices"."is_default" AND "prices"."type" != 'usage';--> statement-breakpoint
-DROP POLICY "On update, ensure usage meter belongs to same organization as product" ON "prices" CASCADE;--> statement-breakpoint
-DROP POLICY "Ensure organization integrity with products parent table" ON "prices" CASCADE;--> statement-breakpoint
+DROP POLICY IF EXISTS "On update, ensure usage meter belongs to same organization as product" ON "prices" CASCADE;--> statement-breakpoint
+DROP POLICY IF EXISTS "Ensure organization integrity with products parent table" ON "prices" CASCADE;--> statement-breakpoint
 CREATE POLICY "Merchant access via product or usage meter FK" ON "prices" AS PERMISSIVE FOR ALL TO "merchant" USING ((
             ("type" = 'usage' AND "usage_meter_id" IN (SELECT "id" FROM "usage_meters"))
             OR ("type" != 'usage' AND "product_id" IN (SELECT "id" FROM "products"))


### PR DESCRIPTION
## What Does this PR Do?

Adds `IF EXISTS` to the DROP POLICY statements in migration 0275 to prevent failures on databases where these policies don't exist. This makes the migration idempotent and compatible with fresh databases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database migration robustness by updating policy removal operations to handle non-existent policies gracefully, reducing potential deployment errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->