### PR TITLE
fix: Remove non-deterministic assertion in usage meter pricing test

### DIFF
--- a/platform/flowglad-next/src/db/tableMethods/pricingModelMethods.test.ts
+++ b/platform/flowglad-next/src/db/tableMethods/pricingModelMethods.test.ts
@@ -1570,8 +1570,11 @@ describe('Usage Meter Prices in Pricing Model Response', () => {
     expect(usageMeterResult!.prices.map((p) => p.id)).toContain(
       usagePrice2.id
     )
-    // Since usage prices don't have isDefault set, the first price becomes the default
-    expect(usageMeterResult!.defaultPrice?.id).toBe(usagePrice1.id)
+    // Since usage prices don't have isDefault set, one of them becomes the default
+    // (the specific choice depends on query ordering which is non-deterministic)
+    expect([usagePrice1.id, usagePrice2.id]).toContain(
+      usageMeterResult!.defaultPrice?.id
+    )
   })
 
   it('selectPricingModelForCustomer filters inactive usage prices from usage meters', async () => {


### PR DESCRIPTION
## What Does this PR Do?

This PR fixes a flaky test in the pricing model methods test suite. The test was asserting that a specific price would be the default when neither price had `isDefault` explicitly set. Since the database query lacks an `orderBy` clause, the result ordering is non-deterministic, causing the test to fail intermittently. The fix updates the assertion to verify the default price is one of the two created prices instead of assuming a specific one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a flaky test in pricing model methods by replacing a non-deterministic assertion on the default usage price. The test now checks the default is one of the two created prices, stabilizing results when query order is undefined.

<sup>Written for commit 5881d02c584d969587fc2e803b4affe13e5ebd69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations to account for non-deterministic default selection behavior in pricing model queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->