### PR TITLE
[pricing-model-admin] Shared action key types

### DIFF
--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -641,4 +641,8 @@ export const flowgladActionValidators = {
     method: HTTPMethod.POST,
     inputValidator: getResourceUsageSchema,
   },
+  [FlowgladActionKey.GetPricingModel]: {
+    method: HTTPMethod.POST,
+    inputValidator: z.object({}),
+  },
 } as const satisfies FlowgladActionValidatorMap

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -52,10 +52,12 @@ export {
   type ResourceUsage,
 } from './types/resource'
 export {
+  type AuthenticatedActionKey,
   type BillingWithChecks,
   type FeatureItem,
   FlowgladActionKey,
   HTTPMethod,
+  type HybridActionKey,
   type SubscriptionExperimentalFields,
   type UsageMeterBalance,
 } from './types/sdk'

--- a/packages/shared/src/types/sdk.ts
+++ b/packages/shared/src/types/sdk.ts
@@ -18,7 +18,24 @@ export enum FlowgladActionKey {
   ClaimResource = 'resources/claim',
   ReleaseResource = 'resources/release',
   ListResourceClaims = 'resources/claims',
+  GetPricingModel = 'pricing-models/retrieve',
 }
+
+/**
+ * Action keys that require authentication.
+ * These routes will return 401 if no valid session exists.
+ */
+export type AuthenticatedActionKey = Exclude<
+  FlowgladActionKey,
+  HybridActionKey
+>
+
+/**
+ * Action keys that attempt authentication but gracefully fall back.
+ * These routes return customer-specific data if authenticated,
+ * or default data if not.
+ */
+export type HybridActionKey = typeof FlowgladActionKey.GetPricingModel
 
 export enum HTTPMethod {
   GET = 'GET',


### PR DESCRIPTION
## What Does this PR Do?
Introduces the `GetPricingModel` action key and type-level classifications (`AuthenticatedActionKey`, `HybridActionKey`) in the shared package. This enables the SDK to retrieve pricing models for both authenticated users (customer-specific) and unauthenticated visitors (default fallback), addressing pre-login use cases. The new types enforce and document authentication requirements at compile time.

---
<a href="https://cursor.com/background-agent?bcId=bc-0439a9df-422c-41e7-87ca-7f62606d6d97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0439a9df-422c-41e7-87ca-7f62606d6d97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GetPricingModel action and auth key types so the SDK can fetch pricing for logged-in users and visitors. Supports pre-login pricing with clear compile-time auth rules.

- **New Features**
  - Added FlowgladActionKey.GetPricingModel (POST) with empty input schema.
  - Added HybridActionKey for routes that try auth and fall back; GetPricingModel is hybrid.
  - Added AuthenticatedActionKey for routes that always require a session.
  - Exported new types and validator in shared.

<sup>Written for commit 171ae8f47a211f328dcff95a650660b146c5b2eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

