### PR TITLE
[pricing-model-retrieval-with-auth-fallback] Server package exports

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -13,5 +13,14 @@ export {
   type RequestHandlerOutput,
   requestHandler,
 } from './requestHandler'
-export { routeToHandlerMap } from './subrouteHandlers'
+export {
+  hybridRouteToHandlerMap,
+  isHybridActionKey,
+  routeToHandlerMap,
+} from './subrouteHandlers'
+export type {
+  GetPricingModelResponse,
+  HybridSubRouteHandler,
+  SubRouteHandler,
+} from './subrouteHandlers/types'
 export { verifyWebhook, WebhookVerificationError } from './webhook'


### PR DESCRIPTION
## What Does this PR Do?
Exports new hybrid route-related types (`GetPricingModelResponse`, `HybridSubRouteHandler`, `SubRouteHandler`) and runtime maps (`routeToHandlerMap`, `hybridRouteToHandlerMap`, `isHybridActionKey`) from `packages/server/src/index.ts`. This makes them accessible for use by consumers and tests, addressing their previous internal scope within the `subrouteHandlers` directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b6eb644-bfe3-47c2-b67e-7d961d6df0df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7b6eb644-bfe3-47c2-b67e-7d961d6df0df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose hybrid route handler maps and types from the server package index so consumers and tests can import them directly.

- **New Features**
  - Export hybridRouteToHandlerMap, isHybridActionKey, and routeToHandlerMap.
  - Export types: GetPricingModelResponse, HybridSubRouteHandler, and SubRouteHandler.

<sup>Written for commit 1461305d05dc05711824cce1816992b40b945b47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

