### PR TITLE
docs: add Zod validation requirement for table methods

### DIFF
--- a/.claude/skills/contextual-review/platform-review.md
+++ b/.claude/skills/contextual-review/platform-review.md
@@ -194,10 +194,17 @@ export const getCustomerById = async (input: unknown) => {
 The most common violation is creating `selectFooById` or `selectFooByBar` methods when a general `selectFoos` method with filtering already exists.
 
 ```typescript
-// WRONG - creating a redundant method
-export const selectCustomerByEmail = async (email: string) => {
-  return db.query.customers.findFirst({ where: eq(customers.email, email) })
+// WRONG - creating a redundant method (even with proper Zod validation)
+const selectCustomerByEmailInputSchema = z.object({
+  email: z.string().email(),
+})
+
+export const selectCustomerByEmail = async (input: unknown) => {
+  const { email } = selectCustomerByEmailInputSchema.parse(input)
+  const result = await db.query.customers.findFirst({ where: eq(customers.email, email) })
+  return selectCustomerSchema.parse(result)
 }
+// This method is redundant because selectCustomers already supports email filtering
 
 // CORRECT - use the existing selectCustomers with a filter
 const customer = await selectCustomers({ filters: { email } })


### PR DESCRIPTION
## What Does this PR Do?

Adds comprehensive guidance to the platform review guidelines emphasizing that all methods in `db/tableMethods/` must have Zod validation for both inputs and outputs. This ensures full unity between runtime behavior and the type system, even when TypeScript types seem sufficient.

The guidance explains the rationale (types are erased at runtime, Drizzle type inference isn't always accurate), provides a concrete pattern example, and includes explicit review guidance to reject PRs without proper validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the platform review guidelines to require Zod validation for both inputs and outputs in all db/tableMethods/ methods, ban raw Drizzle calls in business logic in favor of tableMethods, and avoid redundant table methods when existing ones suffice. Adds the rationale, a simple pattern example, and explicit reviewer checks to enforce these rules.

<sup>Written for commit c5e448998263044702418c27d67f1fe72ce45511. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Strengthened database-access rules: centralized table-method usage enforced and business logic separation clarified.
  * New mandatory Table Methods guidance requiring input/output validation and explicit validation examples.
  * Added review criteria and rejection guidance for missing validations; clarified when new table methods are appropriate.
  * Emphasized validation and separation of concerns — documentation-only, no user-facing behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->