### PR TITLE
[result-migration] Patch 0: Create Tagged Error Types

### DIFF
--- a/platform/flowglad-next/src/errors.test.ts
+++ b/platform/flowglad-next/src/errors.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AuthorizationError,
+  ConflictError,
+  DomainError,
+  NotFoundError,
+  PaymentError,
+  TerminalStateError,
+  ValidationError,
+} from '@/errors'
+
+describe('DomainError', () => {
+  it('sets _tag, name, and message from constructor arguments', () => {
+    const error = new DomainError('TestTag', 'Test message')
+    expect(error._tag).toBe('TestTag')
+    expect(error.name).toBe('TestTag')
+    expect(error.message).toBe('Test message')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(DomainError)
+  })
+})
+
+describe('NotFoundError', () => {
+  it('constructs with resource and id, sets correct _tag, name, and message format', () => {
+    const error = new NotFoundError('User', 'user-123')
+    expect(error._tag).toBe('NotFoundError')
+    expect(error.name).toBe('NotFoundError')
+    expect(error.message).toBe('User not found: user-123')
+    expect(error.resource).toBe('User')
+    expect(error.id).toBe('user-123')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(DomainError)
+    expect(error).toBeInstanceOf(NotFoundError)
+  })
+})
+
+describe('ValidationError', () => {
+  it('constructs with field and reason, sets correct _tag, name, and message format', () => {
+    const error = new ValidationError(
+      'email',
+      'must be a valid email address'
+    )
+    expect(error._tag).toBe('ValidationError')
+    expect(error.name).toBe('ValidationError')
+    expect(error.message).toBe(
+      'Invalid email: must be a valid email address'
+    )
+    expect(error.field).toBe('email')
+    expect(error.reason).toBe('must be a valid email address')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(DomainError)
+    expect(error).toBeInstanceOf(ValidationError)
+  })
+})
+
+describe('ConflictError', () => {
+  it('constructs with resource and conflict, sets correct _tag, name, and message format', () => {
+    const error = new ConflictError('Subscription', 'already active')
+    expect(error._tag).toBe('ConflictError')
+    expect(error.name).toBe('ConflictError')
+    expect(error.message).toBe(
+      'Subscription conflict: already active'
+    )
+    expect(error.resource).toBe('Subscription')
+    expect(error.conflict).toBe('already active')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(DomainError)
+    expect(error).toBeInstanceOf(ConflictError)
+  })
+})
+
+describe('TerminalStateError', () => {
+  it('constructs with resource, id, and state, sets correct _tag, name, and message format', () => {
+    const error = new TerminalStateError('Invoice', 'inv-456', 'paid')
+    expect(error._tag).toBe('TerminalStateError')
+    expect(error.name).toBe('TerminalStateError')
+    expect(error.message).toBe(
+      'Invoice inv-456 is in terminal state: paid'
+    )
+    expect(error.resource).toBe('Invoice')
+    expect(error.id).toBe('inv-456')
+    expect(error.state).toBe('paid')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(DomainError)
+    expect(error).toBeInstanceOf(TerminalStateError)
+  })
+})
+
+describe('PaymentError', () => {
+  it('constructs with reason only, sets correct _tag, name, and uses reason as message', () => {
+    const error = new PaymentError('Card declined')
+    expect(error._tag).toBe('PaymentError')
+    expect(error.name).toBe('PaymentError')
+    expect(error.message).toBe('Card declined')
+    expect(error.reason).toBe('Card declined')
+    expect(error.paymentId).toBeUndefined()
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(DomainError)
+    expect(error).toBeInstanceOf(PaymentError)
+  })
+
+  it('constructs with reason and paymentId, sets correct _tag, name, message, and stores paymentId', () => {
+    const error = new PaymentError('Insufficient funds', 'pay-789')
+    expect(error._tag).toBe('PaymentError')
+    expect(error.name).toBe('PaymentError')
+    expect(error.message).toBe('Insufficient funds')
+    expect(error.reason).toBe('Insufficient funds')
+    expect(error.paymentId).toBe('pay-789')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(DomainError)
+    expect(error).toBeInstanceOf(PaymentError)
+  })
+})
+
+describe('AuthorizationError', () => {
+  it('constructs with action and resource, sets correct _tag, name, and message format', () => {
+    const error = new AuthorizationError('delete', 'Organization')
+    expect(error._tag).toBe('AuthorizationError')
+    expect(error.name).toBe('AuthorizationError')
+    expect(error.message).toBe(
+      'Not authorized to delete Organization'
+    )
+    expect(error.action).toBe('delete')
+    expect(error.resource).toBe('Organization')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(DomainError)
+    expect(error).toBeInstanceOf(AuthorizationError)
+  })
+})

--- a/platform/flowglad-next/src/errors.ts
+++ b/platform/flowglad-next/src/errors.ts
@@ -1,0 +1,70 @@
+// Base tagged error class
+export class DomainError extends Error {
+  readonly _tag: string
+  constructor(tag: string, message: string) {
+    super(message)
+    this._tag = tag
+    this.name = tag
+  }
+}
+
+export class NotFoundError extends DomainError {
+  constructor(
+    public readonly resource: string,
+    public readonly id: string
+  ) {
+    super('NotFoundError', `${resource} not found: ${id}`)
+  }
+}
+
+export class ValidationError extends DomainError {
+  constructor(
+    public readonly field: string,
+    public readonly reason: string
+  ) {
+    super('ValidationError', `Invalid ${field}: ${reason}`)
+  }
+}
+
+export class ConflictError extends DomainError {
+  constructor(
+    public readonly resource: string,
+    public readonly conflict: string
+  ) {
+    super('ConflictError', `${resource} conflict: ${conflict}`)
+  }
+}
+
+export class TerminalStateError extends DomainError {
+  constructor(
+    public readonly resource: string,
+    public readonly id: string,
+    public readonly state: string
+  ) {
+    super(
+      'TerminalStateError',
+      `${resource} ${id} is in terminal state: ${state}`
+    )
+  }
+}
+
+export class PaymentError extends DomainError {
+  constructor(
+    public readonly reason: string,
+    public readonly paymentId?: string
+  ) {
+    super('PaymentError', reason)
+  }
+}
+
+export class AuthorizationError extends DomainError {
+  constructor(
+    public readonly action: string,
+    public readonly resource: string
+  ) {
+    super(
+      'AuthorizationError',
+      `Not authorized to ${action} ${resource}`
+    )
+  }
+}

--- a/platform/flowglad-next/src/utils/errorMapping.test.ts
+++ b/platform/flowglad-next/src/utils/errorMapping.test.ts
@@ -1,0 +1,80 @@
+import { TRPCError } from '@trpc/server'
+import { describe, expect, it } from 'vitest'
+import {
+  AuthorizationError,
+  ConflictError,
+  NotFoundError,
+  PaymentError,
+  TerminalStateError,
+  ValidationError,
+} from '@/errors'
+import { toTRPCError } from '@/utils/errorMapping'
+
+describe('toTRPCError', () => {
+  it('maps NotFoundError to NOT_FOUND TRPCError with original message', () => {
+    const domainError = new NotFoundError('User', 'user-123')
+    const trpcError = toTRPCError(domainError)
+    expect(trpcError).toBeInstanceOf(TRPCError)
+    expect(trpcError.code).toBe('NOT_FOUND')
+    expect(trpcError.message).toBe('User not found: user-123')
+  })
+
+  it('maps ValidationError to BAD_REQUEST TRPCError with original message', () => {
+    const domainError = new ValidationError('email', 'must be valid')
+    const trpcError = toTRPCError(domainError)
+    expect(trpcError).toBeInstanceOf(TRPCError)
+    expect(trpcError.code).toBe('BAD_REQUEST')
+    expect(trpcError.message).toBe('Invalid email: must be valid')
+  })
+
+  it('maps ConflictError to CONFLICT TRPCError with original message', () => {
+    const domainError = new ConflictError(
+      'Subscription',
+      'already exists'
+    )
+    const trpcError = toTRPCError(domainError)
+    expect(trpcError).toBeInstanceOf(TRPCError)
+    expect(trpcError.code).toBe('CONFLICT')
+    expect(trpcError.message).toBe(
+      'Subscription conflict: already exists'
+    )
+  })
+
+  it('maps AuthorizationError to FORBIDDEN TRPCError with original message', () => {
+    const domainError = new AuthorizationError('update', 'Invoice')
+    const trpcError = toTRPCError(domainError)
+    expect(trpcError).toBeInstanceOf(TRPCError)
+    expect(trpcError.code).toBe('FORBIDDEN')
+    expect(trpcError.message).toBe('Not authorized to update Invoice')
+  })
+
+  it('maps PaymentError to INTERNAL_SERVER_ERROR TRPCError with original message', () => {
+    const domainError = new PaymentError('Card declined', 'pay-123')
+    const trpcError = toTRPCError(domainError)
+    expect(trpcError).toBeInstanceOf(TRPCError)
+    expect(trpcError.code).toBe('INTERNAL_SERVER_ERROR')
+    expect(trpcError.message).toBe('Card declined')
+  })
+
+  it('maps TerminalStateError to INTERNAL_SERVER_ERROR TRPCError with original message', () => {
+    const domainError = new TerminalStateError(
+      'Invoice',
+      'inv-456',
+      'paid'
+    )
+    const trpcError = toTRPCError(domainError)
+    expect(trpcError).toBeInstanceOf(TRPCError)
+    expect(trpcError.code).toBe('INTERNAL_SERVER_ERROR')
+    expect(trpcError.message).toBe(
+      'Invoice inv-456 is in terminal state: paid'
+    )
+  })
+
+  it('maps generic Error to INTERNAL_SERVER_ERROR TRPCError with original message', () => {
+    const genericError = new Error('Something went wrong')
+    const trpcError = toTRPCError(genericError)
+    expect(trpcError).toBeInstanceOf(TRPCError)
+    expect(trpcError.code).toBe('INTERNAL_SERVER_ERROR')
+    expect(trpcError.message).toBe('Something went wrong')
+  })
+})

--- a/platform/flowglad-next/src/utils/errorMapping.ts
+++ b/platform/flowglad-next/src/utils/errorMapping.ts
@@ -1,0 +1,36 @@
+import { TRPCError } from '@trpc/server'
+import {
+  AuthorizationError,
+  ConflictError,
+  NotFoundError,
+  ValidationError,
+} from '@/errors'
+
+export function toTRPCError(error: Error): TRPCError {
+  if (error instanceof NotFoundError) {
+    return new TRPCError({
+      code: 'NOT_FOUND',
+      message: error.message,
+    })
+  }
+  if (error instanceof ValidationError) {
+    return new TRPCError({
+      code: 'BAD_REQUEST',
+      message: error.message,
+    })
+  }
+  if (error instanceof ConflictError) {
+    return new TRPCError({ code: 'CONFLICT', message: error.message })
+  }
+  if (error instanceof AuthorizationError) {
+    return new TRPCError({
+      code: 'FORBIDDEN',
+      message: error.message,
+    })
+  }
+  // Default for unknown errors
+  return new TRPCError({
+    code: 'INTERNAL_SERVER_ERROR',
+    message: error.message,
+  })
+}


### PR DESCRIPTION
## Summary
- Add domain error types (`DomainError`, `NotFoundError`, `ValidationError`, `ConflictError`, `TerminalStateError`, `PaymentError`, `AuthorizationError`) for explicit, type-safe error handling
- Add `toTRPCError` helper function to map domain errors to TRPC error codes at the router level
- Add comprehensive unit tests for all error types and the error mapping function

## Test plan
- [x] Unit tests verify each error type's `_tag`, `name`, and `message` properties
- [x] Unit tests verify `toTRPCError` maps each domain error to the correct TRPC error code
- [x] All tests pass (`bun run test`)
- [x] Lint and typecheck pass (`bun run check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce tagged domain error types and a TRPC mapping helper to make errors explicit and consistent. This sets a baseline for result-migration by giving routers reliable error codes and messages.

- **New Features**
  - Added DomainError base and concrete types: NotFoundError, ValidationError, ConflictError, TerminalStateError, PaymentError, AuthorizationError.
  - Added toTRPCError: maps NotFound→NOT_FOUND, Validation→BAD_REQUEST, Conflict→CONFLICT, Authorization→FORBIDDEN; others default to INTERNAL_SERVER_ERROR.
  - Added unit tests covering each error type and the mapping behavior.

<sup>Written for commit 587354659c11dcd9e479cd19f7c26a1c38d740bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

