### PR TITLE
docs: Add setup instructions to fan-gameplan patch template

### DIFF
--- a/platform/flowglad-next/llm-prompts/fan-gameplan.md
+++ b/platform/flowglad-next/llm-prompts/fan-gameplan.md
@@ -74,6 +74,13 @@ Do NOT attempt to use `WebFetch` or `curl` for Notion URLs—Notion requires aut
 ## Tests to Implement
 {Test stubs for this patch only, verbatim from gameplan}
 
+## Setup Instructions (REQUIRED)
+Before starting any development work, you MUST run the initialization script:
+```bash
+bun run init:flowglad-next
+```
+This script pulls environment variables and sets up the local development environment. Without this, builds and tests will fail.
+
 ## Git Instructions
 - Branch from: `{base branch determined in step 5 for this patch}`
 - Branch name: `{project-name}/patch-{N}-{descriptive-slug}`


### PR DESCRIPTION
## Summary
- Adds a required "Setup Instructions" section to the fan-gameplan patch template
- Instructs coding agents to run `bun run init:flowglad-next` before starting development work
- Ensures agents have environment variables and local dev environment properly configured

## Test plan
- [x] Verify the template update renders correctly in the markdown file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a required "Setup Instructions" section to the fan-gameplan patch template so agents run bun run init:flowglad-next before starting work. This ensures env vars and local dev setup are correct to prevent build and test failures.

<sup>Written for commit c9fcd5ab33e3cf9b703148044fb3864183cab1fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

