### PR TITLE
fix(tracing): unify Edge and Node.js traces with traceparent propagation

### DIFF
--- a/platform/flowglad-next/src/middleware.ts
+++ b/platform/flowglad-next/src/middleware.ts
@@ -23,8 +23,10 @@ function getTraceparentHeader(): string | null {
 
   // W3C Trace Context format: version-traceid-spanid-traceflags
   // version: 00 (current version)
-  // traceflags: 01 if sampled, 00 if not
-  const traceFlags = spanContext.traceFlags ? '01' : '00'
+  // traceflags: 8-bit field as 2-digit lowercase hex (preserves all flag bits)
+  const traceFlags = (spanContext.traceFlags & 0xff)
+    .toString(16)
+    .padStart(2, '0')
   return `00-${spanContext.traceId}-${spanContext.spanId}-${traceFlags}`
 }
 


### PR DESCRIPTION
## Summary

- Fixes the issue where each API request creates two separate root traces in BetterStack
- Previously, middleware (Edge runtime) and route handlers (Node.js runtime) created independent traces
- Now propagates trace context via W3C `traceparent` header from middleware to route handler

## Problem

Each user API request was resulting in two root traces because:
1. The middleware runs in Vercel's Edge runtime and creates its own trace
2. The route handler runs in the Node.js runtime and creates a completely separate trace
3. These are separate execution contexts, so the trace context wasn't being shared

Example from BetterStack - same request (`vercel_request_id`) producing two traces:
| Request ID | Middleware Trace | Route Handler Trace |
|------------|------------------|---------------------|
| `nk2xr-...` | `2e309d2b...` | `e90f385d...` |

## Solution

Extract the active span's trace context in the middleware and add it as a `traceparent` header to the request. The Node.js runtime's OpenTelemetry instrumentation will read this header and continue the trace instead of starting a new one.

## Test plan

- [ ] Deploy to staging/production
- [ ] Verify in BetterStack that requests now show a single unified trace
- [ ] Confirm middleware and route handler spans appear under the same trace ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies tracing between Edge middleware and Node.js route handlers by propagating the W3C traceparent header. This prevents duplicate root traces in BetterStack and keeps all spans under the same request trace.

- **Bug Fixes**
  - Extract the active span in Edge middleware and set a W3C-compliant traceparent header on the request (encodes traceFlags as 2-digit hex per spec).
  - Node.js OpenTelemetry continues the same trace, eliminating separate root traces for the same request.

<sup>Written for commit 64edcbd073d4980fa3c74262020d9dc5055e0c34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved trace propagation across service boundaries to enhance system monitoring capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->