### PR TITLE
[result-migration] Patch 0b: Add RateLimitError and ExternalServiceError

### DIFF
--- a/platform/flowglad-next/src/errors.test.ts
+++ b/platform/flowglad-next/src/errors.test.ts
@@ -3,8 +3,10 @@ import {
   AuthorizationError,
   ConflictError,
   DomainError,
+  ExternalServiceError,
   NotFoundError,
   PaymentError,
+  RateLimitError,
   TerminalStateError,
   ValidationError,
 } from '@/errors'
@@ -125,5 +127,61 @@ describe('AuthorizationError', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error).toBeInstanceOf(DomainError)
     expect(error).toBeInstanceOf(AuthorizationError)
+  })
+})
+
+describe('RateLimitError', () => {
+  it('constructs with resource and limit, sets correct _tag, name, and message format', () => {
+    const error = new RateLimitError(
+      'API calls',
+      'exceeded 100 requests per minute'
+    )
+    expect(error._tag).toBe('RateLimitError')
+    expect(error.name).toBe('RateLimitError')
+    expect(error.message).toBe(
+      'Rate limit exceeded for API calls: exceeded 100 requests per minute'
+    )
+    expect(error.resource).toBe('API calls')
+    expect(error.limit).toBe('exceeded 100 requests per minute')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(DomainError)
+    expect(error).toBeInstanceOf(RateLimitError)
+  })
+})
+
+describe('ExternalServiceError', () => {
+  it('constructs with service and operation only, sets correct _tag, name, and message format without reason', () => {
+    const error = new ExternalServiceError(
+      'Stripe',
+      'create payment intent'
+    )
+    expect(error._tag).toBe('ExternalServiceError')
+    expect(error.name).toBe('ExternalServiceError')
+    expect(error.message).toBe('Stripe create payment intent failed')
+    expect(error.service).toBe('Stripe')
+    expect(error.operation).toBe('create payment intent')
+    expect(error.reason).toBeUndefined()
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(DomainError)
+    expect(error).toBeInstanceOf(ExternalServiceError)
+  })
+
+  it('constructs with service, operation, and reason, sets correct _tag, name, and message format with reason', () => {
+    const error = new ExternalServiceError(
+      'Stripe',
+      'create payment intent',
+      'connection timeout'
+    )
+    expect(error._tag).toBe('ExternalServiceError')
+    expect(error.name).toBe('ExternalServiceError')
+    expect(error.message).toBe(
+      'Stripe create payment intent failed: connection timeout'
+    )
+    expect(error.service).toBe('Stripe')
+    expect(error.operation).toBe('create payment intent')
+    expect(error.reason).toBe('connection timeout')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(DomainError)
+    expect(error).toBeInstanceOf(ExternalServiceError)
   })
 })

--- a/platform/flowglad-next/src/errors.ts
+++ b/platform/flowglad-next/src/errors.ts
@@ -68,3 +68,28 @@ export class AuthorizationError extends DomainError {
     )
   }
 }
+
+export class RateLimitError extends DomainError {
+  constructor(
+    public readonly resource: string,
+    public readonly limit: string
+  ) {
+    super(
+      'RateLimitError',
+      `Rate limit exceeded for ${resource}: ${limit}`
+    )
+  }
+}
+
+export class ExternalServiceError extends DomainError {
+  constructor(
+    public readonly service: string,
+    public readonly operation: string,
+    public readonly reason?: string
+  ) {
+    super(
+      'ExternalServiceError',
+      `${service} ${operation} failed${reason ? `: ${reason}` : ''}`
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Add `RateLimitError` tagged error class for rate limit exceeded scenarios
- Add `ExternalServiceError` tagged error class for external service failures
- Add comprehensive tests for both new error types

## Details
These two new error types extend `DomainError` and are part of the Result-based error handling migration:

### RateLimitError
For rate limiting scenarios with:
- `resource`: The resource being rate-limited (e.g., "API calls")
- `limit`: Description of the limit (e.g., "exceeded 100 requests per minute")

### ExternalServiceError
For external service failures with:
- `service`: The external service name (e.g., "Stripe")
- `operation`: The operation that failed (e.g., "create payment intent")
- `reason` (optional): Additional context about the failure

## Test plan
- [x] Unit tests for `RateLimitError` constructor and message formatting
- [x] Unit tests for `ExternalServiceError` with and without reason parameter
- [x] All existing error tests continue to pass
- [x] `bun run check` passes (lint + typecheck)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RateLimitError and ExternalServiceError to the Result-based error handling system. These give clear, consistent messages for rate limits and external service failures.

- **New Features**
  - RateLimitError: accepts resource and limit; message “Rate limit exceeded for {resource}: {limit}”.
  - ExternalServiceError: accepts service, operation, optional reason; message “{service} {operation} failed[: {reason}]”.
  - Unit tests added for both errors; existing error tests still pass.

<sup>Written for commit b9b1c35d2447bc810c26073a56030e761ccffd36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

