### PR TITLE
Add lint rule for deprecated z.nativeEnum

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -54,6 +54,10 @@
         "./plugins/no-dynamic-imports-in-tests.grit",
         "./plugins/no-toBeDefined-or-toBeTruthy-in-tests.grit"
       ]
+    },
+    {
+      "includes": ["**/*.ts", "**/*.tsx"],
+      "plugins": ["./plugins/no-zod-native-enum.grit"]
     }
   ]
 }

--- a/platform/flowglad-next/seedDatabase.ts
+++ b/platform/flowglad-next/seedDatabase.ts
@@ -935,7 +935,7 @@ const setupSubscriptionPriceSchema = baseSetupPriceSchema.extend({
 const setupUsagePriceSchema =
   baseSetupPriceSchemaWithoutProductId.extend({
     type: z.literal(PriceType.Usage),
-    intervalUnit: z.nativeEnum(IntervalUnit).optional(),
+    intervalUnit: z.enum(IntervalUnit).optional(),
     intervalCount: z.number().optional(),
     usageMeterId: z.string(), // Required for Usage prices - replaces productId
     trialPeriodDays: z.never().optional(), // Usage prices don't have trial periods

--- a/platform/flowglad-next/src/db/schema/webhooks.ts
+++ b/platform/flowglad-next/src/db/schema/webhooks.ts
@@ -16,7 +16,7 @@ import { buildSchemas } from '../createZodSchemas'
 const TABLE_NAME = 'webhooks'
 
 export const webhookFilterTypes = z
-  .nativeEnum(FlowgladEventType)
+  .enum(FlowgladEventType)
   .array()
   .describe(
     'The list of event types for which this webhook will receive events.'

--- a/platform/flowglad-next/src/server/routers/organizationsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/organizationsRouter.ts
@@ -317,7 +317,7 @@ const getCurrentSubscribers = protectedProcedure.query(
 const getUsageVolumeInputSchema = z.object({
   startDate: z.date(),
   endDate: z.date(),
-  granularity: z.nativeEnum(RevenueChartIntervalUnit),
+  granularity: z.enum(RevenueChartIntervalUnit),
   usageMeterId: z.string(),
   productId: z.string().nullish(),
 })
@@ -374,7 +374,7 @@ const getUsageMetersWithEventsOutput = z.array(
   z.object({
     id: z.string(),
     name: z.string(),
-    aggregationType: z.nativeEnum(UsageMeterAggregationType),
+    aggregationType: z.enum(UsageMeterAggregationType),
     pricingModelId: z.string(), // For future UX enhancements
   })
 )

--- a/platform/flowglad-next/src/server/routers/subscriptionsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/subscriptionsRouter.ts
@@ -552,7 +552,7 @@ export const createSubscriptionInputSchema = z
         'The time when the subscription starts. If not provided, defaults to current time.'
       ),
     interval: z
-      .nativeEnum(IntervalUnit)
+      .enum(IntervalUnit)
       .optional()
       .describe(
         'The interval of the subscription. If not provided, defaults to the interval of the price provided by ' +

--- a/plugins/no-zod-native-enum.grit
+++ b/plugins/no-zod-native-enum.grit
@@ -1,0 +1,12 @@
+engine biome(1.0)
+language js
+
+// Detect z.nativeEnum() usage which is deprecated in Zod 4
+// Use z.enum() instead for type-safe enum validation.
+//
+// Bad:  z.nativeEnum(MyEnum)
+// Good: z.enum(MyEnum)
+
+`z.nativeEnum($args)` as $call where {
+  register_diagnostic(span=$call, message="z.nativeEnum() is deprecated in Zod 4. Use z.enum() instead.", severity="error")
+}


### PR DESCRIPTION
## What Does this PR Do?

Adds a custom Biome lint rule to flag deprecated `z.nativeEnum()` usage in Zod 4, guiding developers to use `z.enum(EnumType)` instead. Also fixes all existing violations in the codebase (5 occurrences across 4 files).

The new rule is configured in `biome.json` and enforced across all TypeScript files via `plugins/no-zod-native-enum.grit`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Biome lint rule that flags deprecated z.nativeEnum() in Zod 4 and updates the codebase to use z.enum(EnumType) instead. Prevents future breakage and keeps enum validation type-safe.

- **New Features**
  - Adds plugins/no-zod-native-enum.grit with an error diagnostic guiding devs to use z.enum().
  - Configures the rule in biome.json for all .ts/.tsx files.

<sup>Written for commit ad0f1f3a18cd83db19dbc22d15f6d9b2871d0b88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new validation rule to detect deprecated patterns in code analysis
  * Updated validation schemas across multiple backend services to use standard enum handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->