### PR TITLE
fix(tests): use unique zset keys to isolate flaky LRU eviction tests

### DIFF
--- a/platform/flowglad-next/src/utils/cache.integration.test.ts
+++ b/platform/flowglad-next/src/utils/cache.integration.test.ts
@@ -47,6 +47,7 @@ import {
   invalidateDependencies,
   recomputeDependencies,
 } from '@/utils/cache'
+import { nanoid } from '@/utils/core'
 import {
   RedisKeyNamespace,
   removeFromLRU,
@@ -1461,10 +1462,8 @@ describeIfRedisKey('LRU Eviction Integration Tests', () => {
     // Use a namespace we can test with - we'll manually create a small sorted set
     // and then manually invoke eviction logic
     const namespace = RedisKeyNamespace.SubscriptionsByCustomer
-    const zsetKey = `${namespace}:lru`
-
-    // Clear the zset first to ensure test isolation (may have leftover entries from previous tests)
-    await client.del(zsetKey)
+    const testId = nanoid()
+    const zsetKey = `${namespace}:lru:test:${testId}`
 
     // Create 5 cache entries with incremental timestamps
     const cacheKeys: string[] = []
@@ -1579,7 +1578,8 @@ return 0
   it('LRU eviction atomically deletes cache entries and removes them from sorted set', async () => {
     const client = getRedisTestClient()
     const namespace = RedisKeyNamespace.SubscriptionsByCustomer
-    const zsetKey = `${namespace}:lru`
+    const testId = nanoid()
+    const zsetKey = `${namespace}:lru:test:${testId}`
 
     // Create entries that will be evicted
     const evictableKeys: string[] = []


### PR DESCRIPTION
## Summary
- Fix two flaky LRU eviction integration tests that were expecting 3 evictions but sometimes seeing 4
- Root cause: shared sorted set state (`subscriptionsByCustomer:lru`) across tests caused cross-test pollution
- Solution: use unique zset keys per test using `nanoid()` for complete test isolation

## Test plan
- [x] Verified tests pass consistently by running 10 consecutive times
- [x] Ran `bun run check` - lint passes (TypeScript errors are pre-existing and unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky LRU eviction integration tests by generating a unique Redis zset key per test using nanoid(), preventing cross-test pollution and restoring the expected 3 evictions consistently.

<sup>Written for commit 9c922cab46d1d61f36dd4d6fd90a0af7c483839d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

