### PR TITLE
fix: display correct feature types in pricing model table

### DIFF
--- a/platform/flowglad-next/src/components/features/columns.tsx
+++ b/platform/flowglad-next/src/components/features/columns.tsx
@@ -11,7 +11,7 @@ import {
   EnhancedDataTableActionsMenu,
 } from '@/components/ui/enhanced-data-table-actions-menu'
 import type { Feature } from '@/db/schema/features'
-import { FeatureType, FeatureUsageGrantFrequency } from '@/types'
+import { FeatureType } from '@/types'
 
 export interface FeatureRow {
   feature: Feature.ClientRecord
@@ -67,15 +67,19 @@ export const columns: ColumnDef<FeatureRow>[] = [
     header: 'Type',
     cell: ({ row }) => {
       const feature = row.original.feature
-      let typeText = 'Toggle'
-      if (feature.type === FeatureType.UsageCreditGrant) {
-        if (
-          feature.renewalFrequency === FeatureUsageGrantFrequency.Once
-        ) {
-          typeText = 'One time grant'
-        } else {
-          typeText = 'Renews every cycle'
-        }
+      let typeText: string
+      switch (feature.type) {
+        case FeatureType.Toggle:
+          typeText = 'Toggle'
+          break
+        case FeatureType.UsageCreditGrant:
+          typeText = 'Usage Credit Grant'
+          break
+        case FeatureType.Resource:
+          typeText = 'Resource'
+          break
+        default:
+          typeText = 'Unknown'
       }
       return <div className="text-sm truncate">{typeText}</div>
     },


### PR DESCRIPTION
## What Does this PR Do?

Fixed the features table type column to display the correct feature type for each row. Previously, toggle types were displayed correctly, but usage grant types showed renewal frequency and resource types incorrectly showed "Toggle". Now each feature type displays its proper name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Type column in the pricing model features table to show the correct feature type for each row. Usage credit grants and resources now display as “Usage Credit Grant” and “Resource” instead of renewal frequency or “Toggle”.

<sup>Written for commit b05ae72a8f8483f5a51a4180d69aa874ffe36e8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Features now include pricing model information.

* **Refactor**
  * Improved feature type display logic to handle additional cases more reliably.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->