### PR TITLE
fix(cache): clean up orphaned LRU entries during eviction

### DIFF
--- a/platform/flowglad-next/src/utils/cache.test.ts
+++ b/platform/flowglad-next/src/utils/cache.test.ts
@@ -36,14 +36,16 @@ function createMockRedisClient() {
   const zsets: Record<string, Map<string, number>> = {}
 
   // Helper for LRU eviction script simulation (used by both eval and evalsha)
+  // Returns JSON string matching the real Lua script: [evictedCount, orphansRemoved]
   const executeLruScript = (
     keys: string[],
     args: (string | number)[]
-  ): number => {
+  ): string => {
     const zsetKey = keys[0]
     const cacheKey = keys[1]
     const timestamp = Number(args[0])
     const maxSize = Number(args[1])
+    // args[2] is metadataPrefix, used in real script for cleanup
 
     // ZADD
     if (!zsets[zsetKey]) {
@@ -51,7 +53,9 @@ function createMockRedisClient() {
     }
     zsets[zsetKey].set(cacheKey, timestamp)
 
-    // Check size and evict
+    // Check size and evict (simplified - doesn't simulate orphan detection)
+    let evictedCount = 0
+    const orphansRemoved = 0 // Mock doesn't simulate TTL expiration
     const size = zsets[zsetKey].size
     if (size > maxSize) {
       const toEvictCount = size - maxSize
@@ -62,10 +66,10 @@ function createMockRedisClient() {
       for (const m of toEvict) {
         delete store[m]
         zsets[zsetKey].delete(m)
+        evictedCount++
       }
-      return toEvict.length
     }
-    return 0
+    return JSON.stringify([evictedCount, orphansRemoved])
   }
 
   return {

--- a/platform/flowglad-next/src/utils/redis.ts
+++ b/platform/flowglad-next/src/utils/redis.ts
@@ -433,25 +433,32 @@ export const resetDismissedBanners = async (
 }
 
 /**
- * Lua script for atomic LRU cache eviction.
+ * Lua script for atomic LRU cache eviction with orphan cleanup.
  *
  * This script:
  * 1. Adds the cache key to a namespace's sorted set (score = timestamp)
  * 2. Checks if the set size exceeds the max
- * 3. If so, evicts the oldest entries (lowest scores)
+ * 3. If so, iterates through oldest entries and:
+ *    - For orphans (expired TTL): removes from sorted set only
+ *    - For real entries: deletes cache key, metadata key, and removes from sorted set
+ *
+ * This lazy cleanup ensures that TTL-expired entries don't accumulate in the
+ * LRU sorted set, which would otherwise degrade eviction accuracy.
  *
  * KEYS[1] = ZSET key (namespace:lru)
  * KEYS[2] = cache key to add
  * ARGV[1] = current timestamp
  * ARGV[2] = max size
+ * ARGV[3] = metadata key prefix (e.g., "cacheRecompute:")
  *
- * Returns: number of entries evicted
+ * Returns: JSON array [evictedCount, orphansRemoved]
  */
 const LRU_EVICTION_SCRIPT = `
 local zsetKey = KEYS[1]
 local cacheKey = KEYS[2]
 local timestamp = tonumber(ARGV[1])
 local maxSize = tonumber(ARGV[2])
+local metadataPrefix = ARGV[3]
 
 -- Add the cache key with current timestamp as score
 redis.call('ZADD', zsetKey, timestamp, cacheKey)
@@ -459,21 +466,41 @@ redis.call('ZADD', zsetKey, timestamp, cacheKey)
 -- Check current size
 local size = redis.call('ZCARD', zsetKey)
 
-if size > maxSize then
-  -- Calculate how many to evict
-  local toEvictCount = size - maxSize
-  -- Get the oldest entries (lowest scores)
-  local toEvict = redis.call('ZRANGE', zsetKey, 0, toEvictCount - 1)
-  if #toEvict > 0 then
-    -- Delete the cache entries
-    redis.call('DEL', unpack(toEvict))
-    -- Remove from the ZSET
-    redis.call('ZREM', zsetKey, unpack(toEvict))
+local evictedCount = 0
+local orphansRemoved = 0
+local maxIterations = 100 -- Safety limit to prevent infinite loops
+
+-- While over max size and haven't hit iteration limit
+while size > maxSize and maxIterations > 0 do
+  maxIterations = maxIterations - 1
+
+  -- Get the oldest entry (lowest score)
+  local oldest = redis.call('ZRANGE', zsetKey, 0, 0)
+  if #oldest == 0 then
+    break
   end
-  return #toEvict
+
+  local oldestKey = oldest[1]
+
+  -- Check if the cache key still exists (not expired by TTL)
+  local exists = redis.call('EXISTS', oldestKey)
+
+  if exists == 1 then
+    -- Real entry - delete cache key and its metadata
+    redis.call('DEL', oldestKey)
+    redis.call('DEL', metadataPrefix .. oldestKey)
+    evictedCount = evictedCount + 1
+  else
+    -- Orphan (TTL expired) - just clean up the sorted set entry
+    orphansRemoved = orphansRemoved + 1
+  end
+
+  -- Remove from sorted set
+  redis.call('ZREM', zsetKey, oldestKey)
+  size = size - 1
 end
 
-return 0
+return cjson.encode({evictedCount, orphansRemoved})
 `
 
 /**
@@ -533,14 +560,19 @@ export function getMaxSizeForNamespace(
  * This function atomically:
  * 1. Adds the cache key to a sorted set (score = current timestamp)
  * 2. Checks if the set exceeds max size
- * 3. Evicts oldest entries (by score) if needed
+ * 3. Evicts oldest entries (by score) if needed, cleaning up orphans along the way
+ *
+ * Orphan cleanup: When iterating through oldest entries, the script checks if each
+ * cache key still exists. TTL-expired entries (orphans) are removed from the sorted
+ * set without attempting to delete the already-gone cache key. This prevents the
+ * LRU sorted set from accumulating stale entries over time.
  *
  * Uses EVALSHA to avoid sending the full script on every call. Falls back to
  * EVAL if the script isn't cached in Redis (which also caches it for future calls).
  *
  * @param namespace - The cache namespace
  * @param cacheKey - The full cache key being written
- * @returns Number of entries evicted (0 if none)
+ * @returns Number of real entries evicted (0 if none)
  */
 export async function trackAndEvictLRU(
   namespace: RedisKeyNamespace,
@@ -550,21 +582,32 @@ export async function trackAndEvictLRU(
     const zsetKey = `${namespace}:lru`
     const maxSize = getMaxSizeForNamespace(namespace)
     const timestamp = Date.now()
+    const metadataPrefix = `${RedisKeyNamespace.CacheRecomputeMetadata}:`
 
-    const evicted = await evalWithShaFallback<unknown>(
+    const result = await evalWithShaFallback<string>(
       LRU_EVICTION_SCRIPT,
       LRU_EVICTION_SCRIPT_SHA,
       [zsetKey, cacheKey],
-      [timestamp, maxSize]
+      [timestamp, maxSize, metadataPrefix]
     )
 
-    const evictedCount =
-      typeof evicted === 'number' ? evicted : Number(evicted) || 0
+    // Parse the JSON array result [evictedCount, orphansRemoved]
+    let evictedCount = 0
+    let orphansRemoved = 0
+    try {
+      const parsed = JSON.parse(result) as [number, number]
+      evictedCount = parsed[0] ?? 0
+      orphansRemoved = parsed[1] ?? 0
+    } catch {
+      // Fallback for unexpected format
+      evictedCount = typeof result === 'number' ? result : 0
+    }
 
-    if (evictedCount > 0) {
+    if (evictedCount > 0 || orphansRemoved > 0) {
       logger.debug('LRU eviction performed', {
         namespace,
         evictedCount,
+        orphansRemoved,
         maxSize,
       })
     }


### PR DESCRIPTION
## Summary
- Fix memory leak where TTL-expired cache entries left orphaned entries in the LRU sorted set
- LRU eviction script now checks if cache keys exist before evicting
- Orphans are removed from sorted set only; real entries are properly deleted with metadata

## Problem
When cache entries expire via TTL, Redis automatically deletes the cache key, but the corresponding entry in the LRU sorted set remained. Over time, this caused:
- Sorted set to fill with "ghost" entries pointing to non-existent keys
- LRU eviction targeting already-expired entries instead of real ones
- Degraded cache eviction accuracy

## Solution
Updated the Lua eviction script to implement lazy orphan cleanup:
1. Iterate through oldest entries one-by-one (instead of batch)
2. Check `EXISTS` for each cache key
3. **Orphan** (TTL expired): just `ZREM` from sorted set
4. **Real entry**: `DEL` cache + metadata, then `ZREM`
5. Continue until under max size (with 100 iteration safety limit)

## Test plan
- [x] Unit tests pass (`bun run test src/utils/cache.test.ts`)
- [x] Integration tests pass (`bun run test:integration src/utils/cache.integration.test.ts`)
- [x] Type checks pass (`bun run check`)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LRU eviction to remove orphaned entries left after TTL expiration. Prevents sorted set growth and restores accurate eviction.

- **Bug Fixes**
  - Lua script iterates oldest entries, checks EXISTS, removes orphans (ZREM), and deletes real entries plus metadata (DEL + ZREM).
  - Returns JSON [evictedCount, orphansRemoved] for clearer logging.
  - Adds a 100-iteration safety cap per call.
  - Updates test mock to match the new JSON return format.

<sup>Written for commit feefd27dfbdd7dfdd81261ac2d4ae1665d2a645e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

