### PR TITLE
fix(tests): optimize resourceClaimsRouter tests by reducing setup overhead

### DIFF
--- a/platform/flowglad-next/src/server/routers/resourceClaimsRouter.test.ts
+++ b/platform/flowglad-next/src/server/routers/resourceClaimsRouter.test.ts
@@ -186,6 +186,8 @@ describe('resourceClaimsRouter', () => {
     )
 
     // Setup organization 2 for cross-tenant tests (shared)
+    // NOTE: org2's subscription is created in beforeAll (not beforeEach) because
+    // it's only used for read-only permission boundary tests, never mutated
     org2Data = await setupOrg()
     const userApiKeyOrg2 = await setupUserAndApiKey({
       organizationId: org2Data.organization.id,
@@ -412,7 +414,7 @@ describe('resourceClaimsRouter', () => {
 
     it('throws NOT_FOUND when the resource is not available on the subscription', async () => {
       // Create a resource that's not associated with the subscription
-      const unlinkedResource = await setupResource({
+      await setupResource({
         organizationId: organization.id,
         pricingModelId: pricingModel.id,
         slug: 'unlinked-resource',


### PR DESCRIPTION
## What Does this PR Do?

Refactors the resourceClaimsRouter test suite to reduce setup overhead and fix flaky CI timeouts. By moving shared data creation to `beforeAll` instead of `beforeEach`, tests now run ~70% faster while maintaining proper test isolation.

**Changes:**
- Moved shared setup (organizations, resources, products, prices, features) to `beforeAll`
- Kept per-test data (subscriptions, customers) in `beforeEach` for proper isolation
- Removed extended timeouts as performance is now sufficient for default 5000ms timeout
- Reduces setup from 30+ operations per test to 10, cutting setup time significantly

Fixes flaky CI failures for `listResourceUsages` tests that were timing out.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized the resourceClaimsRouter test suite by moving shared setup to beforeAll and keeping per-test data in beforeEach, cutting setup overhead and stopping flaky CI timeouts. Tests now run ~70% faster and work with the default 5s timeout.

- **Refactors**
  - Moved orgs, resources, product/price, and features to beforeAll.
  - Kept subscriptions and customers in beforeEach for isolation.
  - Reduced setup work per test from 30+ operations to ~10.

- **Bug Fixes**
  - Resolved CI timeouts in listResourceUsages tests by reducing setup overhead.

<sup>Written for commit c6e4682077c8921a0244307523c4c0a29f05dbbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized shared test fixture creation to reduce per-test setup time and improve execution speed.
  * Shifted large, common resource and product/price setup into a shared initialization while keeping per-test creation for isolated state.
  * Added cross-tenant test setup and clarified shared vs. per-test responsibilities to improve clarity and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->