### PR TITLE
fix(tests): remove flaky null check assertion in cache recomputation test

### DIFF
--- a/platform/flowglad-next/src/utils/cache.recomputation.integration.test.ts
+++ b/platform/flowglad-next/src/utils/cache.recomputation.integration.test.ts
@@ -165,16 +165,8 @@ describeIfRedisKey('cache recomputation integration', () => {
       )
     })
 
-    // Step 4: Invalidate cache and trigger recomputation
-    // Note: invalidateDependencies deletes the cache AND triggers fire-and-forget
-    // recomputation internally, so we cannot reliably check for null here - by the
-    // time we check, recomputation may have already completed.
+    // Step 4: Invalidate cache (triggers fire-and-forget recomputation internally)
     await invalidateDependencies([dependencyKey])
-
-    // Note: recomputeDependencies is a no-op here because invalidateDependencies
-    // deletes the registry before triggering recomputation. The actual recomputation
-    // happens via the fire-and-forget call in invalidateDependencies.
-    await recomputeDependencies([dependencyKey])
 
     // Step 5: Poll until cache is repopulated by fire-and-forget recomputation
     const recomputedData = safeParseJsonNonNull<


### PR DESCRIPTION
## Summary
- Removed timing-dependent assertion that the cache should be null immediately after `invalidateDependencies()`
- The `invalidateDependencies()` function triggers fire-and-forget recomputation internally, so by the time the assertion ran, recomputation had sometimes already completed and repopulated the cache
- Test still validates the important behavior: after invalidation and recomputation, the cache contains fresh (updated) data

## Test plan
- [x] Ran the integration test 3 times consecutively - all passed
- [x] Ran `bun run check` - no lint/type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the flaky null-check in the cache recomputation integration test and deleted the redundant recomputeDependencies() call. invalidateDependencies() triggers fire-and-forget recomputation, so the test now waits for the cache to be repopulated and verifies the data is updated.

<sup>Written for commit 0b4dc414cbefec5c417ef069def9043e8e31183c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

