### PR TITLE
Patch 8: GitHub Action for auto-publishing skills

### DIFF
--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -39,11 +39,30 @@ jobs:
 
       - name: Publish skills to flowglad/skills
         run: |
+          set -euo pipefail
+
+          # Validate source skills directory exists and has content
+          if [ ! -d "$GITHUB_WORKSPACE/skills" ]; then
+            echo "Error: skills directory does not exist"
+            exit 1
+          fi
+
+          if [ -z "$(ls -A $GITHUB_WORKSPACE/skills)" ]; then
+            echo "Warning: skills directory is empty, nothing to publish"
+            exit 0
+          fi
+
           # Clone the target repository
           git clone git@github.com:flowglad/skills.git /tmp/skills-repo
+          cd /tmp/skills-repo
+
+          # Safety check: verify we're in a git repository before deleting
+          if [ ! -d .git ]; then
+            echo "Error: /tmp/skills-repo is not a git repository"
+            exit 1
+          fi
 
           # Remove existing content (except .git)
-          cd /tmp/skills-repo
           find . -maxdepth 1 -not -name '.git' -not -name '.' -exec rm -rf {} \;
 
           # Copy skills directory content to root of target repo


### PR DESCRIPTION
## What Does this PR Do?

Adds a GitHub Action workflow that automatically syncs the skills/ directory to the standalone flowglad/skills repository whenever changes are pushed to main. This enables developers to discover and install Flowglad integration skills via the skills.sh ecosystem.

The workflow triggers on changes to the skills/ directory, clones the target repository, syncs all content, and pushes back with full commit traceability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Action to auto-publish the skills/ directory to the flowglad/skills repo when changes land on main. Makes skills discoverable and installable via skills.sh.

- **New Features**
  - Triggers on changes to skills/** or manual run, uses SSH deploy key, and syncs content to flowglad/skills.
  - Cleans the target repo safely, copies files, adds strict error handling and safety checks, detects untracked changes, commits with source commit reference, and pushes to main.

- **Migration**
  - Create flowglad/skills and add a write-enabled deploy key; store the private key in the SKILLS_REPO_DEPLOY_KEY secret.
  - No app changes needed; only workflow credentials are required.

<sup>Written for commit d69a1250b719d9a97c4146931dfb1d1faaa13c9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

