### PR TITLE
[patch-5] Hide create button when org has livemode PM

### DIFF
--- a/platform/flowglad-next/src/app/pricing-models/InnerPricingModelsPage.tsx
+++ b/platform/flowglad-next/src/app/pricing-models/InnerPricingModelsPage.tsx
@@ -3,11 +3,23 @@ import { useState } from 'react'
 import CreatePricingModelModal from '@/components/forms/CreatePricingModelModal'
 import PageContainer from '@/components/PageContainer'
 import { PageHeaderNew } from '@/components/ui/page-header-new'
+import { useAuthContext } from '@/contexts/authContext'
 import { PricingModelsDataTable } from './data-table'
 
 const InnerPricingModelsPage = () => {
   const [isCreatePricingModelOpen, setIsCreatePricingModelOpen] =
     useState(false)
+
+  const { livemode } = useAuthContext()
+
+  // Track pricing model count to determine if create button should be shown
+  const [pricingModelCount, setPricingModelCount] = useState<
+    number | null
+  >(null)
+
+  // In testmode, always allow creation
+  // In livemode, only allow if no livemode PM exists (count === 0)
+  const canShowCreateButton = !livemode || pricingModelCount === 0
 
   return (
     <>
@@ -18,16 +30,21 @@ const InnerPricingModelsPage = () => {
           className="pb-2"
         />
         <PricingModelsDataTable
-          onCreatePricingModel={() =>
-            setIsCreatePricingModelOpen(true)
+          onCreatePricingModel={
+            canShowCreateButton
+              ? () => setIsCreatePricingModelOpen(true)
+              : undefined
           }
+          onTotalCountChange={setPricingModelCount}
           hiddenColumns={['id']}
         />
       </PageContainer>
-      <CreatePricingModelModal
-        isOpen={isCreatePricingModelOpen}
-        setIsOpen={setIsCreatePricingModelOpen}
-      />
+      {canShowCreateButton && (
+        <CreatePricingModelModal
+          isOpen={isCreatePricingModelOpen}
+          setIsOpen={setIsCreatePricingModelOpen}
+        />
+      )}
     </>
   )
 }

--- a/platform/flowglad-next/src/app/pricing-models/data-table.tsx
+++ b/platform/flowglad-next/src/app/pricing-models/data-table.tsx
@@ -33,12 +33,14 @@ export interface PricingModelsTableFilters {
 interface PricingModelsDataTableProps {
   filters?: PricingModelsTableFilters
   onCreatePricingModel?: () => void
+  onTotalCountChange?: (count: number | null) => void
   hiddenColumns?: string[]
 }
 
 export function PricingModelsDataTable({
   filters = {},
   onCreatePricingModel,
+  onTotalCountChange,
   hiddenColumns = [],
 }: PricingModelsDataTableProps) {
   const router = useRouter()
@@ -81,6 +83,11 @@ export function PricingModelsDataTable({
     goToFirstPage()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQuery])
+
+  // Report total count when data changes
+  React.useEffect(() => {
+    onTotalCountChange?.(data?.total ?? null)
+  }, [data?.total, onTotalCountChange])
 
   // Client-side state
   const [columnVisibility, setColumnVisibility] =

--- a/platform/flowglad-next/src/components/forms/CreatePricingModelModal.tsx
+++ b/platform/flowglad-next/src/components/forms/CreatePricingModelModal.tsx
@@ -50,6 +50,7 @@ const CreatePricingModelModal: React.FC<
   CreatePricingModelModalProps
 > = ({ isOpen, setIsOpen }) => {
   const router = useRouter()
+  const trpcUtils = trpc.useUtils()
 
   // Single modal with different views
   const [currentView, setCurrentView] = useState<ModalView>('choice')
@@ -73,6 +74,8 @@ const CreatePricingModelModal: React.FC<
     trpc.pricingModels.create.useMutation({
       onSuccess: ({ pricingModel }) => {
         toast.success('Pricing model created successfully')
+        // Invalidate to refresh the count for "can create" check
+        trpcUtils.pricingModels.getTableRows.invalidate()
         setIsOpen(false)
         router.push(`/pricing-models/${pricingModel.id}`)
         resetState()
@@ -89,6 +92,8 @@ const CreatePricingModelModal: React.FC<
         toast.success(
           'Pricing model created from template successfully'
         )
+        // Invalidate to refresh the count for "can create" check
+        trpcUtils.pricingModels.getTableRows.invalidate()
         setIsOpen(false)
         router.push(`/pricing-models/${pricingModel.id}`)
         resetState()


### PR DESCRIPTION
## What Does this PR Do?

Implements Patch 5 of the livemode pricing model uniqueness feature. This patch hides the "Create Pricing Model" button in the UI when a user is in livemode and their organization already has a livemode pricing model.

The implementation uses a lightweight client-side approach: we derive the "can create" check from the existing `getTableRows` query total count and the `livemode` context. When in testmode, creation is always allowed (unlimited testmode PMs). When in livemode, the button only shows if no pricing model exists yet (count === 0).

Additionally, query invalidation is added after pricing model mutations to ensure the UI refreshes immediately in the same tab.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the “Create Pricing Model” button in livemode when an organization already has a livemode pricing model. Testmode remains unlimited, and the UI refreshes immediately after creation.

- **New Features**
  - Compute canShowCreateButton from auth livemode and table total; allow creation only if count === 0 in livemode.
  - Added onTotalCountChange in PricingModelsDataTable to report total to page state.
  - Conditionally render the create button and modal; disable onCreatePricingModel when not allowed.
  - Invalidate pricingModels.getTableRows after mutations to keep the count in sync.

<sup>Written for commit 1cf57be8c3d185e0746dc3fe1c92f08519da0b3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pricing model creation now depends on authentication state and the number of existing models.
  * Create button and modal visibility are conditional based on live mode status.

* **Improvements**
  * Pricing model data automatically refreshes after successful model creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->