### PR TITLE
Add pgcp --file support for restoring backups

### DIFF
--- a/platform/flowglad-next/package.json
+++ b/platform/flowglad-next/package.json
@@ -49,7 +49,8 @@
     "dev:dbCopy:prod:schema": "dotenvx run -f .env.local -- bun run src/scripts/dbCopy.ts --prod --schema-only",
     "dev:dbCopy:staging:migrate": "dotenvx run -f .env.local -- bun run src/scripts/dbCopy.ts --staging --run-migrations",
     "dev:dbCopy:prod:migrate": "dotenvx run -f .env.local -- bun run src/scripts/dbCopy.ts --prod --run-migrations",
-    "pgcp": "bun run src/scripts/pgcp.ts"
+    "pgcp": "bun run src/scripts/pgcp.ts",
+    "dev:dbCopy:file": "dotenvx run -f .env.local -- bun run src/scripts/dbCopy.ts --file"
   },
   "dependencies": {
     "@ai-sdk/openai": "^2.0.69",


### PR DESCRIPTION
## What Does this PR Do?

Adds file restore functionality to pgcp and dbCopy scripts. Users can now restore pg_dumpall backup files from the Supabase dashboard directly to their local Supabase instance using `bun run dev:dbCopy:file /path/to/backup.backup`.

The implementation uses psql with `ON_ERROR_STOP=0` to gracefully handle role conflicts that occur when restoring Supabase backups, which include CREATE ROLE statements for roles that already exist locally.

Changes include updates to pgcp.ts and dbCopy.ts to support both remote copy and file restore modes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds file restore support to pgcp and dbCopy, so you can restore Supabase dashboard pg_dumpall backups directly to your local Supabase. Handles expected role conflicts and verifies the restore.

- **New Features**
  - pgcp: `--file <path>` to restore a pg_dumpall backup to local Supabase (default port 54322).
  - Uses `psql -v ON_ERROR_STOP=0` to continue past role conflicts included in Supabase backups.
  - Adds restore verification by counting tables in the public schema.
  - Updates help, argument parsing, and step counter for file mode.
  - dbCopy: new `--file` flag and `dev:dbCopy:file` script; blocks mixing `--file` with `--staging/--prod`.
  - Remote copy remains unchanged; `--schema-only` and `--keep-dumps` apply only to remote mode.

<sup>Written for commit 849d7bc75feb9382e1b0bd2016a076f79f5e6d95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backup file restoration capability, allowing database recovery from local backup files via a new `--file` option as an alternative to staging/production sources.

* **Chores**
  * Updated development scripts to support file-based database restoration workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->