### PR TITLE
SDK: Change usageEvents.list() response from items to data

### DIFF
--- a/platform/flowglad-next/openapi.json
+++ b/platform/flowglad-next/openapi.json
@@ -5765,23 +5765,26 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "items": {
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/UsageEventClientSelectSchema"
                       }
                     },
-                    "total": {
-                      "type": "number"
+                    "currentCursor": {
+                      "type": "string"
+                    },
+                    "nextCursor": {
+                      "type": "string"
                     },
                     "hasMore": {
                       "type": "boolean"
                     },
-                    "nextCursor": {
-                      "type": "string"
+                    "total": {
+                      "type": "number"
                     }
                   },
-                  "required": ["items", "total", "hasMore"],
+                  "required": ["data", "hasMore", "total"],
                   "additionalProperties": false
                 }
               }

--- a/platform/flowglad-next/slow-tests/server/routers/usageEventsRouter.test.ts
+++ b/platform/flowglad-next/slow-tests/server/routers/usageEventsRouter.test.ts
@@ -224,12 +224,12 @@ describe('usageEventsRouter', () => {
       expect(result.hasMore).toBe(false)
 
       // Should respect RLS policies - verify exact events by ID
-      const org1EventIds = result.items.map((event) => event.id)
+      const org1EventIds = result.data.map((event) => event.id)
       const expectedEventIds = usageEvents1.map((event) => event.id)
       expect(org1EventIds.sort()).toEqual(expectedEventIds.sort())
 
       // Verify all returned events belong to org1 (through customer relationship)
-      result.items.forEach((event) => {
+      result.data.forEach((event) => {
         expect(event.customerId).toBe(customer1.id)
       })
     })
@@ -247,7 +247,7 @@ describe('usageEventsRouter', () => {
       })
 
       // Should return empty array
-      expect(result.items).toEqual([])
+      expect(result.data).toEqual([])
       expect(result.total).toBe(0)
       expect(result.hasMore).toBe(false)
     })
@@ -285,7 +285,7 @@ describe('usageEventsRouter', () => {
       expect(typeof result.nextCursor).toBe('string')
 
       // Verify returned events are from our created events
-      const returnedEventIds = result.items.map((event) => event.id)
+      const returnedEventIds = result.data.map((event) => event.id)
       const createdEventIds = createdEvents.map((event) => event.id)
       expect(returnedEventIds).toHaveLength(3)
       returnedEventIds.forEach((eventId) => {
@@ -293,7 +293,7 @@ describe('usageEventsRouter', () => {
       })
 
       // Verify all returned events belong to org1 (through customer relationship)
-      result.items.forEach((event) => {
+      result.data.forEach((event) => {
         expect(event.customerId).toBe(customer1.id)
       })
     })

--- a/platform/flowglad-next/src/db/schema/usageEvents.ts
+++ b/platform/flowglad-next/src/db/schema/usageEvents.ts
@@ -8,6 +8,7 @@ import { usageMeters } from '@/db/schema/usageMeters'
 import {
   constructIndex,
   constructUniqueIndex,
+  createPaginatedListQuerySchema,
   createPaginatedSelectSchema,
   createPaginatedTableRowInputSchema,
   createPaginatedTableRowOutputSchema,
@@ -325,12 +326,8 @@ export const usageEventPaginatedSelectSchema =
     })
   )
 
-export const usageEventPaginatedListSchema = z.object({
-  items: z.array(usageEventsClientSelectSchema),
-  total: z.number(),
-  hasMore: z.boolean(),
-  nextCursor: z.string().optional(),
-})
+export const usageEventPaginatedListSchema =
+  createPaginatedListQuerySchema(usageEventsClientSelectSchema)
 
 // Table row data schema for enriched usage events with joins
 export const usageEventsTableRowDataSchema = z.object({

--- a/platform/flowglad-next/src/server/routers/usageEventsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/usageEventsRouter.ts
@@ -138,9 +138,10 @@ const listUsageEventsProcedure = protectedProcedure
           transaction
         )
         return {
-          items: result.data,
+          data: result.data,
           total: result.total,
           hasMore: result.hasMore,
+          currentCursor: result.currentCursor,
           nextCursor: result.nextCursor,
         }
       },


### PR DESCRIPTION
## What Does this PR Do?

Fixes the mismatch between the `usageEvents-list` endpoint and Stainless's pagination scheme. The endpoint was returning `items` instead of `data`, which prevented Stainless from recognizing the pagination pattern and generating the SDK `list()` method.

Updated the schema to use the standard `createPaginatedListQuerySchema` helper, which returns `data` and `currentCursor` fields to match all other list endpoints in the codebase. This allows Stainless to properly auto-generate the `UsageEvents.list()` method when it regenerates the SDK from the updated OpenAPI spec.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns usageEvents.list() with our standard pagination by returning data instead of items, enabling Stainless to generate the UsageEvents.list() SDK method. Also adds currentCursor to match other list endpoints.

- **Bug Fixes**
  - Switched usageEventPaginatedListSchema to createPaginatedListQuerySchema.
  - Updated OpenAPI response to use data, hasMore, total, currentCursor, nextCursor.
  - Router now returns data and currentCursor.
  - Tests updated to expect data instead of items.

- **Migration**
  - If calling the endpoint directly, read results from data instead of items.

<sup>Written for commit 79a9547e7d2daa1277e61415e422c32481958433. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved pagination structure for the usage events endpoint with cursor-based navigation fields for better data retrieval.

* **Tests**
  * Updated usage events endpoint tests to reflect pagination response field changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->