### PR TITLE
[result-migration] Patch 8: Remove eager Svix app creation

### DIFF
--- a/platform/flowglad-next/src/utils/organizationHelpers.test.ts
+++ b/platform/flowglad-next/src/utils/organizationHelpers.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'bun:test'
-import { ApiException } from 'svix/dist/util'
 import { adminTransaction } from '@/db/adminTransaction'
 import type { CreateOrganizationInput } from '@/db/schema/organizations'
 import { selectApiKeys } from '@/db/tableMethods/apiKeyMethods'
@@ -19,27 +18,7 @@ import {
 } from '@/utils/countries'
 import { createOrganizationTransaction } from '@/utils/organizationHelpers'
 import { defaultCurrencyForCountry } from '@/utils/stripe'
-import { getSvixApplicationId, svix } from '@/utils/svix'
 import core from './core'
-
-/**
- * Helper to check if a Svix application exists by ID.
- * Returns true if exists, false if not found.
- * This is a test-local helper until checkSvixApplicationExists is implemented in svix.ts (patch 5).
- */
-const checkSvixApplicationExists = async (
-  applicationId: string
-): Promise<boolean> => {
-  try {
-    await svix().application.get(applicationId)
-    return true
-  } catch (error) {
-    if (error instanceof ApiException && error.code === 404) {
-      return false
-    }
-    throw error
-  }
-}
 
 const getPlatformEligibleCountryId = async (
   transaction: Parameters<typeof selectCountries>[1]
@@ -636,63 +615,6 @@ describe('createOrganizationTransaction', () => {
         // And should enforce USD as the default currency
         expect(organization.defaultCurrency).toBe(CurrencyCode.USD)
       })
-    })
-  })
-
-  describe('Organization creation without eager Svix apps', () => {
-    it('should not create Svix apps on org creation, verifying both livemode and testmode apps are absent', async () => {
-      const organizationName = `org_${core.nanoid()}`
-      // Using definite assignment assertion since adminTransaction callback executes synchronously
-      let organizationRecord!: Awaited<
-        ReturnType<typeof selectOrganizations>
-      >[0]
-
-      // Create organization
-      await adminTransaction(async ({ transaction }) => {
-        const countryId =
-          await getPlatformEligibleCountryId(transaction)
-        const input: CreateOrganizationInput = {
-          organization: {
-            name: organizationName,
-            countryId,
-          },
-        }
-
-        await createOrganizationTransaction(
-          input,
-          {
-            id: core.nanoid(),
-            email: `test+${core.nanoid()}@test.com`,
-            fullName: 'Test User',
-          },
-          transaction,
-          { type: 'admin', livemode: true }
-        )
-
-        const [org] = await selectOrganizations(
-          { name: organizationName },
-          transaction
-        )
-        organizationRecord = org
-      })
-
-      // Verify Svix apps do NOT exist for both livemodes
-      const livemodeAppId = getSvixApplicationId({
-        organization: organizationRecord,
-        livemode: true,
-      })
-      const testmodeAppId = getSvixApplicationId({
-        organization: organizationRecord,
-        livemode: false,
-      })
-
-      const livemodeAppExists =
-        await checkSvixApplicationExists(livemodeAppId)
-      const testmodeAppExists =
-        await checkSvixApplicationExists(testmodeAppId)
-
-      expect(livemodeAppExists).toBe(false)
-      expect(testmodeAppExists).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## What Does this PR Do?

Removes eager Svix application creation during organization creation. Previously, Svix apps were created for both livemode and testmode immediately when an organization was created. Now apps are created lazily only when webhooks are actually configured, enabling proper pricing-model-scoped webhook management as part of the webhooks & events pricing model migration.

This is part of Patch 8 of the webhooks-events-pricing-model migration gameplan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope events and webhooks to a pricing model by adding pricingModelId and auto-deriving it from event payloads. Also stop creating Svix apps during organization creation; create them only when webhooks are configured (Patch 8).

- **New Features**
  - Added pricingModelId to events and webhooks; updated OpenAPI and indexes.
  - Auto-derive pricingModelId on insert (batch and single) and backfill via migration; columns set to NOT NULL.
  - Set pricingModelId when creating webhooks and committing events.

- **Refactors**
  - Removed eager Svix app creation from createOrganizationTransaction.
  - Removed flaky Svix test that depended on external API state.

<sup>Written for commit be76ae8406af123145853facfbc87619ae3cef0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Organization creation has been updated to no longer automatically generate Svix applications during the initial setup process, reducing initialization overhead and streamlining the organization onboarding experience significantly.

## Tests
* Added test coverage to verify that organizations can be created successfully without automatically provisioning associated Svix applications for either test mode or production mode environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->