### PR TITLE
Patch 9: Add resourceContract to API verification

### DIFF
--- a/platform/flowglad-next/src/api-contract/resourceContract.ts
+++ b/platform/flowglad-next/src/api-contract/resourceContract.ts
@@ -1,0 +1,87 @@
+import type { Flowglad as FlowgladNode } from '@flowglad/node'
+import type { StandardLogger } from '@/types'
+import core from '@/utils/core'
+import { flowgladNode } from './nodeClient'
+
+const getResourceResource = (id: string, client: FlowgladNode) => {
+  return client.resources.retrieve(id)
+}
+
+const createResourceResource = (
+  params: FlowgladNode.Resources.ResourceCreateParams,
+  client: FlowgladNode
+) => {
+  return client.resources.create(params)
+}
+
+const updateResourceResource = (
+  id: string,
+  params: FlowgladNode.Resources.ResourceUpdateParams,
+  client: FlowgladNode
+) => {
+  return client.resources.update(id, params)
+}
+
+const getResourceListResource = (
+  params: FlowgladNode.Resources.ResourceListParams,
+  client: FlowgladNode
+) => {
+  return client.resources.list(params)
+}
+
+export const verifyResourceContract = async (
+  params: {
+    pricingModel: FlowgladNode.PricingModels.PricingModelClientSelectSchema
+  },
+  logger: StandardLogger
+) => {
+  const client = flowgladNode()
+  const testId = 'test-resource-' + core.nanoid()
+
+  const createdResource = await createResourceResource(
+    {
+      resource: {
+        name: testId,
+        pricingModelId: params.pricingModel.id,
+        slug: testId,
+      },
+    },
+    client
+  )
+  logger.info(`Created resource: ${createdResource.resource.id}`)
+
+  const getResourceResult = await getResourceResource(
+    createdResource.resource.id,
+    client
+  )
+  logger.info(`Got resource: ${getResourceResult.resource.id}`)
+
+  const updatedResource = await updateResourceResource(
+    createdResource.resource.id,
+    {
+      resource: {
+        id: createdResource.resource.id,
+        name: testId + '-updated',
+      },
+    },
+    client
+  )
+  logger.info(`Updated resource: ${updatedResource.resource.id}`)
+
+  const resourceListResult = await getResourceListResource(
+    {
+      pricingModelId: params.pricingModel.id,
+    },
+    client
+  )
+  logger.info(
+    `Got resource list: ${resourceListResult.resources.length}`
+  )
+
+  return {
+    resource: getResourceResult.resource,
+    createdResource,
+    updatedResource,
+    resourceListResult,
+  }
+}


### PR DESCRIPTION
## What Does this PR Do?

Implements `verifyResourceContract` with full CRUD operations (create, retrieve, update, list) as part of the API contract verification overhaul. Resources require a `pricingModelId` dependency, so this contract accepts a pricingModel parameter, similar to `priceContract` and `productFeatureContract`. The implementation follows the existing contract pattern used in the codebase.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds verifyResourceContract to the API verification suite to validate resource CRUD (create, retrieve, update, list) using a provided pricing model. This improves contract coverage and keeps resource checks consistent with price and product feature contracts.

- **New Features**
  - New resourceContract.ts implementing verifyResourceContract with helper calls for create/get/update/list.
  - Accepts a pricingModel param to populate pricingModelId for resource creation.
  - Logs each operation and returns structured results for downstream checks.

<sup>Written for commit ec6cc1a31c3a82715779b90adebd4bd6f327eee8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

