### PR TITLE
Patch 6: Add usageMeterContract for API verification

### DIFF
--- a/platform/flowglad-next/src/api-contract/usageMeterContract.ts
+++ b/platform/flowglad-next/src/api-contract/usageMeterContract.ts
@@ -1,0 +1,93 @@
+import type { Flowglad as FlowgladNode } from '@flowglad/node'
+import type { StandardLogger } from '@/types'
+import core from '@/utils/core'
+import { flowgladNode } from './nodeClient'
+
+const getUsageMeterResource = (id: string, client: FlowgladNode) => {
+  return client.usageMeters.retrieve(id)
+}
+
+const createUsageMeterResource = (
+  params: FlowgladNode.UsageMeters.UsageMeterCreateParams,
+  client: FlowgladNode
+) => {
+  return client.usageMeters.create(params)
+}
+
+const updateUsageMeterResource = (
+  id: string,
+  params: FlowgladNode.UsageMeters.UsageMeterUpdateParams,
+  client: FlowgladNode
+) => {
+  return client.usageMeters.update(id, params)
+}
+
+const getUsageMeterListResource = (client: FlowgladNode) => {
+  return client.usageMeters.list()
+}
+
+const getDefaultPricingModelResource = (client: FlowgladNode) => {
+  return client.pricingModels.retrieveDefault()
+}
+
+export const verifyUsageMeterContract = async (
+  logger: StandardLogger
+) => {
+  const client = flowgladNode()
+  const testId = 'test-usage-meter-' + core.nanoid()
+  logger.info(`Usage Meter test ID: ${testId}`)
+
+  // Get the default pricing model to use for creating usage meters
+  const defaultPricingModel =
+    await getDefaultPricingModelResource(client)
+  logger.info(
+    `Got default pricing model: ${defaultPricingModel.pricingModel.id}`
+  )
+
+  const createdUsageMeter = await createUsageMeterResource(
+    {
+      usageMeter: {
+        name: testId,
+        slug: testId,
+        pricingModelId: defaultPricingModel.pricingModel.id,
+        aggregationType: 'sum',
+      },
+    },
+    client
+  )
+  logger.info(
+    `Created usage meter: ${createdUsageMeter.usageMeter.id}`
+  )
+
+  const getUsageMeterResult = await getUsageMeterResource(
+    createdUsageMeter.usageMeter.id,
+    client
+  )
+  logger.info(`Got usage meter: ${getUsageMeterResult.usageMeter.id}`)
+
+  const updatedUsageMeter = await updateUsageMeterResource(
+    createdUsageMeter.usageMeter.id,
+    {
+      usageMeter: {
+        id: createdUsageMeter.usageMeter.id,
+        name: testId + '-updated',
+      },
+    },
+    client
+  )
+  logger.info(
+    `Updated usage meter: ${updatedUsageMeter.usageMeter.id}`
+  )
+
+  const usageMeterListResult = await getUsageMeterListResource(client)
+  logger.info(
+    `Got usage meter list: ${usageMeterListResult.data.length}`
+  )
+
+  return {
+    usageMeter: getUsageMeterResult.usageMeter,
+    createdUsageMeter,
+    updatedUsageMeter,
+    usageMeterListResult,
+  }
+}


### PR DESCRIPTION
## What Does this PR Do?

Implement Patch 6 of the API Contract Verification Overhaul: adds `usageMeterContract.ts` to test all SDK usage meter operations (create, retrieve, update, list). The contract retrieves the default pricing model to avoid external dependencies and can run independently early in the verification sequence.

This is part of extending API contract coverage from 15% to comprehensive across all endpoints.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds usageMeterContract to verify all SDK usage meter operations (create, retrieve, update, list) using the default pricing model. Runs independently early in the verification sequence to expand API contract coverage.

- **New Features**
  - Added verifyUsageMeterContract in platform/flowglad-next/src/api-contract/usageMeterContract.ts.
  - Uses pricingModels.retrieveDefault to avoid external setup.
  - Logs each step and returns structured results for follow-up checks.

<sup>Written for commit 90d5a732000775f325db7403267c40ea21b8e16b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

