### PR TITLE
Lock destination environment to testmode in clone pricing model

### DIFF
--- a/platform/flowglad-next/src/components/forms/ClonePricingModelModal.tsx
+++ b/platform/flowglad-next/src/components/forms/ClonePricingModelModal.tsx
@@ -73,6 +73,7 @@ const ClonePricingModelModal: React.FC<
       <ClonePricingModelFormFields
         hasLivemodePricingModel={hasLivemodePricingModel}
         onWarningChange={handleWarningChange}
+        livemode={livemode ?? false}
       />
     </FormModal>
   )


### PR DESCRIPTION
## What Does this PR Do?

Locks the destination environment dropdown to testmode when cloning a pricing model in testmode. The dropdown is now disabled and prevents users from attempting invalid operations. In livemode, the dropdown remains fully interactive to allow cloning to either environment. This follows the existing pattern from EditUsagePriceModal where selectors are disabled when there's only one valid option due to business logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock the destination environment to testmode when cloning a pricing model in testmode to prevent invalid clones. In livemode, the destination remains fully selectable.

- **New Features**
  - Disable and auto-set Destination Environment to Testmode when in testmode.
  - Keep full destination selection in livemode; warning logic applies only in livemode.
  - Pass livemode to form fields and mirror the EditUsagePriceModal pattern for single-option selectors.

<sup>Written for commit 3edc874ea93aa91c9669184908eaba0a72b4eda0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

