### PR TITLE
Run packages test on every CI run

### DIFF
--- a/.github/workflows/base-ci-cd.yml
+++ b/.github/workflows/base-ci-cd.yml
@@ -132,8 +132,7 @@ jobs:
         run: bun run build
 
   packages-test:
-    # Only run unit tests in the merge queue as the final pre-merge check.
-    if: github.event_name == 'merge_group'
+    # Run unit tests on every CI run (PRs and merge queue)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## What Does this PR Do?

Removes the merge_group-only condition from the packages-test job in the CI/CD workflow. The packages tests will now run on every CI run (PRs and merge queue), matching the behavior of platform/flowglad-next tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run packages unit tests on every CI run (PRs and merge queue) to catch issues earlier and match platform/flowglad-next behavior.
Removes the merge_group-only condition in .github/workflows/base-ci-cd.yml.

<sup>Written for commit d86e14bf0bcf6c3aeed62aa0889fd691395af960. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline testing execution: Unit tests now run more frequently during the development process, ensuring broader test coverage across pull requests and merge operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->