### PR TITLE
docs: add data migration guidance for drizzle

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -25,15 +25,44 @@ You run in an environment where `ast-grep` is available; whenever a search requi
 
 ## Database Migrations
 
-**IMPORTANT**: NEVER manually create or write migration files. This project uses Drizzle ORM with auto-generated migrations.
+This project uses Drizzle ORM for migrations. There are two types of migrations:
 
-When making database schema changes:
-1. Modify the schema definition files (e.g., files in `platform/flowglad-next/src/db/schema/`)
+### Schema Migrations (Auto-Generated)
+
+For changes to database structure (adding/removing tables, columns, indexes, constraints):
+
+1. Modify the schema definition files in `platform/flowglad-next/src/db/schema/`
 2. Run `bun run migrations:generate` from `platform/flowglad-next` to auto-generate the migration SQL
 
-**NEVER run `bun run migrations:push`** - applying migrations to the database should only be done by the user, not by agents.
+**NEVER manually write schema migration files.** Drizzle Kit analyzes your schema changes and generates the appropriate migration files automatically.
 
-Drizzle Kit analyzes your schema changes and generates the appropriate migration files automatically. Manually created migration files will likely have incorrect formatting, missing metadata, or cause conflicts with the migration system.
+### Data Migrations (Custom)
+
+For operations that don't change the schema but modify data:
+- Backfilling values for new columns
+- Transforming or migrating existing data
+- Populating lookup tables
+- Data cleanup or normalization
+
+Use the custom migration script to generate an empty, properly-tracked migration file:
+
+```bash
+cd platform/flowglad-next
+bun run migrations:generate-custom -- --name descriptive-migration-name
+```
+
+Then edit the generated SQL file with your data migration logic.
+
+**Examples of when to use `migrations:generate-custom`:**
+- "Backfill the `status` column with default values" → `bun run migrations:generate-custom -- --name backfill-status-defaults`
+- "Migrate data from old table to new table" → `bun run migrations:generate-custom -- --name migrate-users-to-accounts`
+- "Normalize email addresses to lowercase" → `bun run migrations:generate-custom -- --name normalize-emails`
+
+### Important Rules
+
+- **NEVER run `bun run migrations:push`** - applying migrations to the database should only be done by the user, not by agents
+- **NEVER manually create migration files** - always use `migrations:generate` for schema changes or `migrations:generate-custom` for data migrations
+- Data migrations should be idempotent when possible (safe to run multiple times)
 
 ## Testing Guidelines
 

--- a/platform/flowglad-next/package.json
+++ b/platform/flowglad-next/package.json
@@ -38,6 +38,7 @@
     "trigger:dev": "NODE_ENV=development bunx --bun trigger.dev@4.3.2 dev",
     "migrations:drop": "drizzle-kit drop",
     "migrations:generate": "drizzle-kit generate",
+    "migrations:generate-custom": "drizzle-kit generate --custom",
     "migrations:push": "bun run src/scripts/migrate.ts",
     "seed:countries": "bun run src/scripts/seed-countries.ts",
     "shadcn:build": "shadcn build --output 'public/ui'",


### PR DESCRIPTION
## What Does this PR Do?

Split migration documentation into schema migrations (auto-generated) and data migrations (custom). Adds `migrations:generate-custom` bun script wrapper and provides concrete examples of when to use each approach, helping Claude distinguish between schema changes and data-only operations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split Drizzle migration docs into schema (auto-generated) and data (custom), and added a Bun script to generate custom data migrations. This clarifies when to use each path and prevents pushing or hand-writing migrations.

- **New Features**
  - Added migrations:generate-custom script (drizzle-kit generate --custom) in platform/flowglad-next.
  - Updated docs: separate schema vs data migrations, include examples, and rules (no migrations:push, no manual files, prefer idempotent data migrations).

<sup>Written for commit 83b1564b99f189b2ce57cd89ec4314132a7c3f05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced database migration guidance with clearer instructions for schema and data migrations, including step-by-step workflows and examples.

* **Chores**
  * Added new command for creating custom data migrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->