### PR TITLE
[sse-event-streaming-infrastructure] Patch 1: Sync Event Types and Schema

### DIFF
--- a/platform/flowglad-next/src/types/sync.test.ts
+++ b/platform/flowglad-next/src/types/sync.test.ts
@@ -222,6 +222,29 @@ describe('sync event types', () => {
       }
     })
 
+    it('rejects update event with undefined data', () => {
+      const updateEventWithUndefinedData = {
+        id: 'evt_123',
+        namespace: 'customerSubscriptions',
+        entityId: 'cus_456',
+        scopeId: 'org_789',
+        eventType: 'update',
+        data: undefined, // invalid - update events require actual data payload
+        sequence: '1706745600000-0',
+        timestamp: '2024-02-01T00:00:00.000Z',
+        livemode: true,
+      }
+
+      const result = syncEventSchema.safeParse(
+        updateEventWithUndefinedData
+      )
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ZodError)
+      }
+    })
+
     it('rejects delete event with non-null data (discriminated union enforcement)', () => {
       const deleteEventWithData = {
         id: 'evt_123',
@@ -325,6 +348,26 @@ describe('sync event types', () => {
 
       const result = syncEventInsertSchema.safeParse(
         updateInsertWithNullData
+      )
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ZodError)
+      }
+    })
+
+    it('rejects update insert with undefined data', () => {
+      const updateInsertWithUndefinedData = {
+        namespace: 'customerSubscriptions',
+        entityId: 'cus_456',
+        scopeId: 'org_789',
+        eventType: 'update',
+        data: undefined, // invalid - update events require actual data payload
+        livemode: true,
+      }
+
+      const result = syncEventInsertSchema.safeParse(
+        updateInsertWithUndefinedData
       )
 
       expect(result.success).toBe(false)

--- a/platform/flowglad-next/src/types/sync.ts
+++ b/platform/flowglad-next/src/types/sync.ts
@@ -100,10 +100,11 @@ const syncEventBaseSchema = {
 }
 
 /**
- * Schema for non-null unknown data (used for update events)
+ * Schema for non-null, non-undefined data (used for update events).
+ * Uses loose equality (!=) to reject both null and undefined.
  */
-const nonNullDataSchema = z.unknown().refine((val) => val !== null, {
-  message: 'data cannot be null for update events',
+const nonNullDataSchema = z.unknown().refine((val) => val != null, {
+  message: 'data is required for update events',
 })
 
 /**


### PR DESCRIPTION
## Summary
- Add `SyncEvent` and `SyncEventInsert` TypeScript interfaces for SSE event streaming
- Define `SyncNamespace` type with valid namespace values for cache dependencies
- Implement Zod schemas (`syncEventSchema`, `syncEventInsertSchema`) for runtime validation
- Add `isSyncNamespace()` type guard for namespace validation

## Test plan
- [x] All 15 unit tests pass for schema validation and type guards
- [x] Biome lint check passes
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed and validated payloads for SSE sync events, including allowed namespaces and event types, to standardize streaming and cache invalidation. This lays the core schema for the event streaming infrastructure.

- **New Features**
  - Added SyncEvent and SyncEventInsert TypeScript types using discriminated unions.
  - Introduced SYNC_NAMESPACES and SyncNamespace for valid cache namespaces; implemented isSyncNamespace type guard.
  - Added Zod schemas (syncEventSchema, syncEventInsertSchema) for runtime validation with event types limited to "update" and "delete", enforcing non-null data for updates and null data for deletes.

<sup>Written for commit 004d0bfdbed3bb62e19348bca0e3984d182af3b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive sync event structures with built-in validation for streaming operations, supporting update and delete event types with namespace scoping and complete event metadata tracking.

* **Tests**
  * Added extensive test suite validating sync event schemas, insertion operations, and namespace handling to ensure data integrity and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->