### PR TITLE
[customer-archive] Add archiveCustomer SDK convenience method (patch 6)

### DIFF
--- a/packages/server/src/FlowgladServer.archiveCustomer.test.ts
+++ b/packages/server/src/FlowgladServer.archiveCustomer.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FlowgladServer } from './FlowgladServer'
+import type { CoreCustomerUser } from './types'
+
+/**
+ * Mock customer data for testing
+ */
+const mockCustomer = {
+  id: 'cust_test_123',
+  externalId: 'test-user-id',
+  name: 'Test User',
+  email: 'test@example.com',
+  archived: false,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+  organizationId: 'org_123',
+  pricingModelId: 'pm_123',
+  livemode: false,
+  domain: null,
+  iconURL: null,
+  logoURL: null,
+  invoiceNumberBase: null,
+  userId: null,
+  billingAddress: null,
+}
+
+const mockArchivedCustomer = {
+  ...mockCustomer,
+  archived: true,
+}
+
+/**
+ * Creates a mock FlowgladServer with mocked flowgladNode methods
+ */
+const createMockFlowgladServer = () => {
+  const server = new FlowgladServer({
+    apiKey: 'test-api-key',
+    baseURL: 'http://localhost:3000',
+    getRequestingCustomer: async (): Promise<CoreCustomerUser> => ({
+      externalId: 'test-user-id',
+      name: 'Test User',
+      email: 'test@example.com',
+    }),
+  })
+
+  const mockPost = vi.fn()
+
+  // Access private properties for mocking
+  // @ts-expect-error - accessing private property for testing
+  server.flowgladNode = {
+    post: mockPost,
+  } as unknown
+
+  return {
+    server,
+    mocks: {
+      post: mockPost,
+    },
+  }
+}
+
+describe('FlowgladServer.archiveCustomer', () => {
+  it('calls the archive endpoint with the correct URL and returns the archived customer', async () => {
+    const { server, mocks } = createMockFlowgladServer()
+    mocks.post.mockResolvedValue({ customer: mockArchivedCustomer })
+
+    const result = await server.archiveCustomer('test-user-id')
+
+    expect(result).toEqual(mockArchivedCustomer)
+    expect(result.archived).toBe(true)
+    expect(mocks.post).toHaveBeenCalledWith(
+      '/api/v1/customers/test-user-id/archive',
+      { body: {} }
+    )
+  })
+
+  it('URL-encodes the externalId to handle special characters', async () => {
+    const { server, mocks } = createMockFlowgladServer()
+    const specialExternalId = 'user/with/slashes'
+    const customerWithSpecialId = {
+      ...mockArchivedCustomer,
+      externalId: specialExternalId,
+    }
+    mocks.post.mockResolvedValue({ customer: customerWithSpecialId })
+
+    const result = await server.archiveCustomer(specialExternalId)
+
+    expect(result.externalId).toEqual(specialExternalId)
+    expect(mocks.post).toHaveBeenCalledWith(
+      `/api/v1/customers/${encodeURIComponent(specialExternalId)}/archive`,
+      { body: {} }
+    )
+  })
+
+  it('propagates errors from the API', async () => {
+    const { server, mocks } = createMockFlowgladServer()
+    const apiError = new Error('Customer not found')
+    mocks.post.mockRejectedValue(apiError)
+
+    await expect(
+      server.archiveCustomer('nonexistent-user')
+    ).rejects.toThrow('Customer not found')
+  })
+})

--- a/packages/server/src/FlowgladServer.ts
+++ b/packages/server/src/FlowgladServer.ts
@@ -962,4 +962,37 @@ export class FlowgladServer {
       }
     )
   }
+
+  /**
+   * Archives a customer by setting archived=true and canceling all active subscriptions.
+   *
+   * This is a dedicated method for archiving customers because archiving is a significant
+   * state change with cascade effects (subscription cancellation), not just a field update.
+   *
+   * Behavior:
+   * - If customer is already archived, returns immediately (idempotent)
+   * - Cancels all active subscriptions with reason 'customer_archived'
+   * - Sets archived=true on the customer
+   *
+   * After archiving:
+   * - The customer's externalId is freed for reuse by a new customer
+   * - ExternalId lookups will not return this customer by default
+   * - Operations that create records attached to this customer will be blocked
+   *
+   * @param externalId - The external ID of the customer to archive
+   * @returns The archived customer record
+   */
+  public archiveCustomer = async (
+    externalId: string
+  ): Promise<FlowgladNode.Customers.CustomerClientSelectSchema> => {
+    const result = await this.flowgladNode.post<{
+      customer: FlowgladNode.Customers.CustomerClientSelectSchema
+    }>(
+      `/api/v1/customers/${encodeURIComponent(externalId)}/archive`,
+      {
+        body: {},
+      }
+    )
+    return result.customer
+  }
 }


### PR DESCRIPTION
## What Does this PR Do?

Implements Patch 6 of the customer-archive gameplan: Add a public `archiveCustomer()` convenience method to the `FlowgladServer` SDK class. This method provides a wrapper around the new `POST /customers/:externalId/archive` endpoint, allowing SDK users to easily archive customers with a simple method call.

The implementation properly URL-encodes the externalId parameter and returns the archived customer record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added archiveCustomer() to FlowgladServer to make archiving a customer a single, straightforward SDK call. It wraps the POST /customers/:externalId/archive endpoint and returns the archived customer.

- **New Features**
  - Adds FlowgladServer.archiveCustomer(externalId) calling /api/v1/customers/:externalId/archive.
  - URL-encodes externalId and returns the archived customer.
  - Tests cover success, special characters, and error propagation.

<sup>Written for commit 0e5bfdd587243559c36c40eaa94c4d528f33a78d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

