### PR TITLE
chore: improve new changelog intstructions

### DIFF
--- a/platform/flowglad-next/llm-prompts/new-changelog-notes.md
+++ b/platform/flowglad-next/llm-prompts/new-changelog-notes.md
@@ -2,9 +2,14 @@ You are creating a new changelog announcement. These changelog notes will be use
 
 Use the git log to determine what changes in packages/* have happened since the last changelog (search the git log for the last time we had a commit "chore: version packages"). Group the notes thematically into sections. They may be grouped around new features, improvements, bug fixes, etc.
 
-Include links to commits for each of the changes.
+Include links to commits for each individual change item (bullet points), but NOT for section headings. Section headings (###) are organizational and should not have commit links or commit hashes.
 
 Put your release notes in the markdown file found in the .changeset directory in project root.
+
+**Important formatting rules:**
+- Section headings (starting with `###`) should be plain text without commit links or hashes
+- Only individual change items (bullet points) should include commit links in the format `[commit-hash](url): description`
+- Never put commit hashes or links before section headings
 
 Here's an example:
 ---


### PR DESCRIPTION
## What Does this PR Do?
- instructions for new changelog

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the new changelog instructions to enforce proper formatting and avoid commit links on section headings. Commit links belong only on individual bullet items; section headings are plain text without hashes or links.

<sup>Written for commit 82b0c5d8548fbfce2fa7bc1c19316ab4f981b478. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

