### PR TITLE
[org-member-removal] Patches 5+7: Remove member mutation

### DIFF
--- a/platform/flowglad-next/src/errors.ts
+++ b/platform/flowglad-next/src/errors.ts
@@ -115,26 +115,6 @@ export class ExternalServiceError extends DomainError {
   }
 }
 
-// Membership-related errors
-
-export class CannotRemoveOwnerError extends AuthorizationError {
-  constructor() {
-    super('remove', 'organization owner')
-  }
-}
-
-export class MembershipNotFoundError extends NotFoundError {
-  constructor(public readonly membershipId: string) {
-    super('Membership', membershipId)
-  }
-}
-
-export class MembershipAlreadyDeactivatedError extends ConflictError {
-  constructor(public readonly membershipId: string) {
-    super('Membership', `already deactivated: ${membershipId}`)
-  }
-}
-
 /**
  * Panic is used for invariant violations - code defects that indicate bugs.
  * Unlike Result.err(), panic throws immediately and should never be caught.


### PR DESCRIPTION
## What Does this PR Do?

Implements Patches 5 and 7 of the org-member-removal gameplan: the remove member mutation and router endpoint. Owners can remove any non-owner member; members can only remove themselves (leave org). Deactivation sets both `deactivatedAt` and `focused=false` to prevent stale auth scope. Includes error types and comprehensive authorization testing.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements org-member-removal patches 5 and 7 with a removeMemberFromOrganization mutation and router endpoint. Owners can remove non-owner members; members can leave the org. Deactivation sets deactivatedAt and focused=false to prevent stale auth scope.

- **New Features**
  - Authorization: owners remove non-owners; members remove themselves; owners cannot be removed; cross-org attempts return NotFound.
  - Errors: AuthorizationError (cannot remove owner), NotFoundError (missing or cross-org membership), ConflictError (already deactivated).
  - API: tRPC mutation wired to organizationsRouter.removeMember.
  - Tests: cover all auth paths, deactivation behavior, and info-leak prevention.

<sup>Written for commit 02ffca262d9adcac88226123f7f9a74892897aaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Added the ability to remove members from organizations. Owners can remove members; individual members can leave the organization.
* Includes proper error handling for attempting to remove owners, accessing non-existent memberships, and managing already-deactivated member states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->