### PR TITLE
Fix duplicate snapshot IDs in Drizzle migrations 0283/0284

### DIFF
--- a/platform/flowglad-next/drizzle-migrations/meta/0284_snapshot.json
+++ b/platform/flowglad-next/drizzle-migrations/meta/0284_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "c236ec7a-9cce-4efb-a4fe-5c5e0245b393",
-  "prevId": "8754cd6f-4cba-4d0c-bb6b-73e31cc03cbe",
+  "id": "71394bc3-cd8f-4639-a93f-b53f27faa1c6",
+  "prevId": "c236ec7a-9cce-4efb-a4fe-5c5e0245b393",
   "version": "7",
   "dialect": "postgresql",
   "tables": {


### PR DESCRIPTION
## What Does this PR Do?

Fixes the snapshot collision error that prevented migration generation. Updates 0284_snapshot.json to use a unique ID and correct the prevId chain. This resolves the migration generation failure without affecting already-applied migrations in any database.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a snapshot ID collision in Drizzle migrations 0283/0284, restoring migration generation. Updates 0284_snapshot.json with a unique id and a corrected prevId chain; no impact to already-applied migrations.

<sup>Written for commit c05c5910de26c57ca0d9993bf818bdd6af4bd172. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal database migration metadata. No user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->