### PR TITLE
Add PR checkout to contextual review skill

### DIFF
--- a/.claude/skills/contextual-review/SKILL.md
+++ b/.claude/skills/contextual-review/SKILL.md
@@ -38,6 +38,10 @@ Read the relevant reference file(s) based on the diff to get area-specific check
 
 ## Review Process
 
+### 0. Checkout PR
+
+Run `gh pr checkout <PR>` to get the PR code locally. If it fails, continue with the review.
+
 ### 1. Gather Context
 
 First, understand the scope of changes:
@@ -176,8 +180,9 @@ This PR adds user authentication using JWT tokens with refresh token support.
 
 ## Workflow
 
-1. Get diff statistics with `GetWorkspaceDiff(stat: true)`
-2. Review changed files systematically
-3. Use `DiffComment` for inline feedback
-4. Provide overall summary and recommendation
-5. Offer to help fix any critical issues
+1. Attempt to checkout the PR with `gh pr checkout <PR>` (continue if it fails)
+2. Get diff statistics with `GetWorkspaceDiff(stat: true)`
+3. Review changed files systematically
+4. Use `DiffComment` for inline feedback
+5. Provide overall summary and recommendation
+6. Offer to help fix any critical issues


### PR DESCRIPTION
## What Does this PR Do?

Enhance the contextual review skill by adding an explicit step to checkout the PR code locally before performing reviews. This ensures reviewers are working with the latest PR state and improves the overall review workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a step to the contextual review skill to checkout the PR locally with `gh pr checkout <PR>` before reviewing. This ensures reviewers use the latest code; the workflow now starts with this step and continues if checkout fails.

<sup>Written for commit c61f22464dc32a60ef31c170b0efeea3262f7b81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated review process workflow to include a PR checkout verification step at the beginning of the review sequence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->