### PR TITLE
Add CLA check that automatically skips bots

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,40 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/flowglad/flowglad/blob/main/CLA.md'
+          branch: 'main'
+          # Skip bot users from CLA requirement - bots cannot sign CLAs
+          # This covers: dependabot[bot], github-actions[bot], renovate[bot], etc.
+          allowlist: 'dependabot[bot],github-actions[bot],renovate[bot],mergify[bot],allcontributors[bot],snyk-bot,greenkeeper[bot],semantic-release-bot,bot*'
+          custom-notsigned-prcomment: |
+            Thank you for your contribution! Before we can merge this PR, we need you to sign the Contributor License Agreement.
+
+            Please read the [CLA document](https://github.com/flowglad/flowglad/blob/main/CLA.md) and reply with the following comment to sign:
+
+            ```
+            I have read the CLA Document and I hereby sign the CLA
+            ```
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. Thank you!'
+          lock-pullrequest-aftermerge: true

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,37 @@
+# Flowglad Contributor License Agreement
+
+Thank you for your interest in contributing to Flowglad ("We" or "Us").
+
+This contributor license agreement ("Agreement") documents the rights granted by contributors to Us. This Agreement is intended to clarify the intellectual property rights granted with contributions to Flowglad from any person or entity.
+
+## 1. Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized by the copyright owner that is making this Agreement with Us.
+
+"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to Us for inclusion in, or documentation of, any of the products owned or managed by Us (the "Work").
+
+"Submit" means any form of electronic, verbal, or written communication sent to Us, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Us for the purpose of discussing and improving the Work.
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and to recipients of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and to recipients of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted.
+
+## 4. Representations
+
+You represent that:
+
+- You are legally entitled to grant the above license.
+- Each of Your Contributions is Your original creation.
+- Your Contribution submissions include complete details of any third-party license or other restriction of which you are personally aware and which are associated with any part of Your Contributions.
+
+## 5. Support
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all.
+
+## 6. Agreement
+
+By commenting "I have read the CLA Document and I hereby sign the CLA" on a pull request, You accept and agree to the terms and conditions of this Agreement for Your present and future Contributions submitted to Flowglad.


### PR DESCRIPTION
## What Does this PR Do?

Implement CLA Assistant Lite GitHub Action to automatically exempt bot users from signing the CLA. The workflow uses an allowlist to skip `dependabot[bot]`, `github-actions[bot]`, `renovate[bot]`, and any user ending with `[bot]` or `bot*` pattern, since bots cannot manually sign agreements.

This replaces the current cla-assistant.io hosted integration with a code-based, version-controlled solution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CLA Assistant GitHub Action that automatically skips bot accounts and moves CLA checks into code. This replaces the hosted cla-assistant.io integration and adds a CLA document.

- **New Features**
  - Workflow runs on pull_request_target and issue_comment (recheck/sign).
  - Allowlist skips bots: dependabot[bot], github-actions[bot], renovate[bot], mergify[bot], allcontributors[bot], snyk-bot, greenkeeper[bot], semantic-release-bot, bot*.
  - Stores signatures at signatures/cla.json on main, posts clear instructions, and locks PRs after merge.
  - Adds CLA.md with terms and signing instructions.

- **Migration**
  - Disable the cla-assistant.io integration after merge.
  - Ensure the signatures directory exists; the action will create/update cla.json.
  - Contributors sign by commenting: "I have read the CLA Document and I hereby sign the CLA".

<sup>Written for commit 375aaecf02f42eee37e05a21c384c27846c91b3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented a Contributor License Agreement requirement for pull requests. Contributors must sign the CLA via a designated comment before their contributions can be accepted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->