### PR TITLE
fix: Prevent ZodError when CreateProductModal is not open

### DIFF
--- a/platform/flowglad-next/src/components/forms/CreateProductModal.tsx
+++ b/platform/flowglad-next/src/components/forms/CreateProductModal.tsx
@@ -52,6 +52,9 @@ export const CreateProductModal = ({
 }) => {
   const { organization } = useAuthenticatedContext()
   const createProduct = trpc.products.create.useMutation()
+  if (!isOpen) {
+    return null
+  }
   if (!organization) {
     return <></>
   }


### PR DESCRIPTION
## Summary
- Fixes client-side ZodError when viewing pricing models page
- The CreateProductModal was always rendered (just hidden when closed), causing `createProductFormSchema.parse()` to run on mount
- This failed validation because the default product has an empty name (`z.string().min(1, 'Name is required')`)

## Problem
When navigating to a pricing model page (e.g., `/pricing-models/pricing_model_xxx`), users see:
```
ZodError: [
  {
    "origin": "string",
    "code": "too_small",
    "minimum": 1,
    "inclusive": true,
    "path": ["product", "name"],
    "message": "Name is required"
  }
]
```

## Solution
Return `null` early when `isOpen` is `false`, preventing the schema validation from running until the modal actually needs to be displayed.

## Test plan
- [ ] Navigate to pricing models list
- [ ] Click on a pricing model to view details
- [ ] Verify no ZodError appears
- [ ] Click "Create Product" button
- [ ] Verify modal opens and works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent ZodError on pricing model pages by not rendering CreateProductModal until it’s opened. Return null early when isOpen is false so schema validation doesn’t run until the modal opens.

<sup>Written for commit 3cada7c63e31659a052f1f6c9a2be4ec18b62562. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The product creation modal now renders more efficiently when in a closed state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->