### PR TITLE
fix: improve error messages for unsupported countries in Stripe Connect

### DIFF
--- a/platform/flowglad-next/src/utils/organizationHelpers.db.test.ts
+++ b/platform/flowglad-next/src/utils/organizationHelpers.db.test.ts
@@ -444,7 +444,7 @@ describe('createOrganizationTransaction', () => {
     })
 
     await expect(promise).rejects.toThrow(
-      /Stripe Connect contract type .* is not supported/
+      /The selected payment configuration is not available in .+\. See supported countries/
     )
   })
 

--- a/platform/flowglad-next/src/utils/organizationHelpers.ts
+++ b/platform/flowglad-next/src/utils/organizationHelpers.ts
@@ -31,8 +31,8 @@ import { createPricingModelBookkeeping } from '@/utils/bookkeeping'
 import type { CacheRecomputationContext } from '@/utils/cache'
 import core from '@/utils/core'
 import {
-  getEligibleFundsFlowsForCountry,
   countryNameByCountryCode,
+  getEligibleFundsFlowsForCountry,
 } from '@/utils/countries'
 import { defaultCurrencyForCountry } from '@/utils/stripe'
 


### PR DESCRIPTION
  - Use country names instead of codes (e.g., "Jordan" instead of "JO")     
  - Remove technical jargon ("Platform funds flow", "Stripe Connect contract
   type")                                                                   
  - Add link to supported countries documentation                           
  (https://docs.flowglad.com/countries)                                     
                                                                            
  Fixes #450    

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved Stripe Connect onboarding errors for unsupported countries: show full country names instead of codes, use plain language, and add a link to supported countries (https://docs.flowglad.com/countries). Clarifies availability for users and fulfills #450.

<sup>Written for commit 09ab3210d04d59ea1de3067bc15bb1cebdbe42d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages for unsupported payment countries now use friendly country names and include a link to supported countries documentation (https://docs.flowglad.com/countries).

* **Tests**
  * Updated test expectations to match the revised user-facing error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->