### PR TITLE
fix: billing period dates for default free plan subscriptions

### DIFF
--- a/platform/flowglad-next/src/utils/bookkeeping.db.test.ts
+++ b/platform/flowglad-next/src/utils/bookkeeping.db.test.ts
@@ -729,6 +729,109 @@ describe('createCustomerBookkeeping', () => {
         'Subscription'
       )
     })
+
+    it('should create billing period with start date of now, not one month in the future', async () => {
+      // setup:
+      // - default price has interval unit (subscription type)
+      // - create a customer without payment method (like via UI)
+      // - billing period should start approximately now, not one month from now
+      //
+      // This test verifies the fix for a bug where activateSubscription was
+      // generating the "next" billing period from already-set dates, causing
+      // subscriptions created via UI to have billing periods starting one month
+      // in the future - which prevented migration and archival.
+
+      const now = Date.now()
+
+      const result = await comprehensiveAdminTransaction(
+        async ({
+          transaction,
+          invalidateCache,
+          emitEvent,
+          enqueueLedgerCommand,
+        }) => {
+          const output = await createCustomerBookkeeping(
+            {
+              customer: {
+                email: `test+${core.nanoid()}@example.com`,
+                name: 'Test Customer Billing Period Dates',
+                organizationId: organization.id,
+                externalId: `ext_${core.nanoid()}`,
+              },
+            },
+            withAdminCacheContext({
+              transaction,
+              organizationId: organization.id,
+              livemode,
+              invalidateCache,
+              emitEvent,
+              enqueueLedgerCommand,
+            })
+          )
+          return Result.ok(output)
+        }
+      )
+
+      // Verify subscription was created
+      expect(result.subscription).toMatchObject({})
+
+      // Get subscription and billing periods from database
+      const subscriptionInDb = await adminTransaction(
+        async ({ transaction }) => {
+          const sub = await selectSubscriptionAndItems(
+            {
+              customerId: result.customer.id,
+            },
+            transaction
+          )
+          return sub
+        }
+      )
+
+      const billingPeriods = await adminTransaction(
+        async ({ transaction }) => {
+          return await selectBillingPeriods(
+            { subscriptionId: result.subscription!.id },
+            transaction
+          )
+        }
+      )
+
+      // expects:
+      // - subscription's currentBillingPeriodStart should be approximately now
+      // - billing period record's startDate should be approximately now
+      // - neither should be one month (or more) in the future
+
+      expect(typeof subscriptionInDb).toBe('object')
+
+      // Subscription's billing period dates should start approximately now
+      const subscriptionBillingPeriodStart = new Date(
+        subscriptionInDb!.subscription.currentBillingPeriodStart!
+      ).getTime()
+
+      // Allow 5 minute tolerance for test execution time
+      const fiveMinutesTolerance = 5 * 60 * 1000
+      expect(
+        Math.abs(subscriptionBillingPeriodStart - now)
+      ).toBeLessThan(fiveMinutesTolerance)
+
+      // The billing period record should also start approximately now, not one month later
+      expect(billingPeriods.length).toBeGreaterThan(0)
+      const billingPeriodStartDate = new Date(
+        billingPeriods[0].startDate
+      ).getTime()
+      expect(Math.abs(billingPeriodStartDate - now)).toBeLessThan(
+        fiveMinutesTolerance
+      )
+
+      // Critical: billing period should NOT be one month in the future
+      // If the bug exists, startDate would be ~30 days from now
+      const oneMonthFromNow = now + 30 * 24 * 60 * 60 * 1000
+      const billingPeriodIsInFuture =
+        billingPeriodStartDate >
+        oneMonthFromNow - 2 * 24 * 60 * 60 * 1000 // 28+ days away
+      expect(billingPeriodIsInFuture).toBe(false)
+    })
   })
 
   describe('subscription behavior based on pricing model price type', () => {


### PR DESCRIPTION
## What Does this PR Do?

Fixes a bug where subscriptions created via UI with the default free plan were incorrectly generating billing periods starting one month in the future. This prevented customers from being migrated between pricing models and archived.

The fix checks if billing period dates are already set on the subscription and uses those directly, instead of regenerating them. This is necessary for subscriptions created without a payment method where dates are pre-set by `insertSubscriptionAndItems`.

Includes a test case that verifies billing periods start approximately "now" instead of one month in the future.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes billing period dates for default free plan subscriptions created via the UI. Periods now start immediately, enabling migration between pricing models and archival.

- **Bug Fixes**
  - Use existing currentBillingPeriodStart/End when set (from insertSubscriptionAndItems); only generate dates if missing. Preserve billingCycleAnchorDate when provided.
  - Added a test to ensure start dates are ~now (within 5 minutes), not ~30 days in the future.

<sup>Written for commit 8bb4e41506ae736196249d98f98e032dd627b79e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed billing periods incorrectly starting one month in the future; they now correctly begin at the current time.
  * Updated subscription activation to preserve existing billing dates when available.

* **Tests**
  * Added test to verify billing periods start at the current time rather than in the future.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->