### PR TITLE
[flowglad-cli-package-structure] Patch 3: CLI framework and help command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@flowglad/javascript",
@@ -28,9 +27,25 @@
         "vercel": "^50.1.6",
       },
     },
+    "packages/flowglad": {
+      "name": "flowglad",
+      "version": "0.0.1",
+      "bin": {
+        "flowglad": "./dist/cli.js",
+      },
+      "dependencies": {
+        "cac": "^6.7.14",
+        "js-yaml": "^4.1.0",
+      },
+      "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
+        "typescript": "5.8.2",
+        "vitest": "3.0.5",
+      },
+    },
     "packages/nextjs": {
       "name": "@flowglad/nextjs",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "@flowglad/node": "0.29.0",
         "@flowglad/react": "workspace:*",
@@ -54,7 +69,7 @@
     },
     "packages/react": {
       "name": "@flowglad/react",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "@flowglad/node": "0.29.0",
         "@flowglad/shared": "workspace:*",
@@ -83,7 +98,7 @@
     },
     "packages/server": {
       "name": "@flowglad/server",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "@flowglad/node": "0.29.0",
         "@flowglad/shared": "workspace:*",
@@ -109,7 +124,7 @@
     },
     "packages/shared": {
       "name": "@flowglad/shared",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "@flowglad/node": "0.29.0",
         "date-fns": "4.1.0",
@@ -1260,6 +1275,8 @@
 
     "@types/istanbul-reports": ["@types/istanbul-reports@3.0.4", "", { "dependencies": { "@types/istanbul-lib-report": "*" } }, "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ=="],
 
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
+
     "@types/jsdom": ["@types/jsdom@20.0.1", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0" } }, "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -2085,6 +2102,8 @@
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
     "flow-enums-runtime": ["flow-enums-runtime@0.0.6", "", {}, "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw=="],
+
+    "flowglad": ["flowglad@workspace:packages/flowglad"],
 
     "fontfaceobserver": ["fontfaceobserver@2.3.0", "", {}, "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg=="],
 

--- a/packages/flowglad/src/cli/commands/help.test.ts
+++ b/packages/flowglad/src/cli/commands/help.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { printHelp } from './help'
+
+describe('help command', () => {
+  let consoleOutput: string[]
+  const originalLog = console.log
+
+  beforeEach(() => {
+    consoleOutput = []
+    console.log = (...args: unknown[]) => {
+      consoleOutput.push(args.map(String).join(' '))
+    }
+  })
+
+  afterEach(() => {
+    console.log = originalLog
+  })
+
+  it('displays the help message with all command names and descriptions when invoked', () => {
+    printHelp()
+
+    const output = consoleOutput.join('\n')
+
+    expect(output).toContain('Flowglad CLI')
+    expect(output).toContain('Usage: flowglad <command>')
+    expect(output).toContain('help')
+    expect(output).toContain('login')
+    expect(output).toContain('logout')
+    expect(output).toContain('link')
+    expect(output).toContain('pull')
+    expect(output).toContain('push')
+    expect(output).toContain('deploy')
+    expect(output).toContain('coming soon')
+    expect(output).toContain('https://flowglad.com/docs/cli')
+  })
+})

--- a/packages/flowglad/src/cli/commands/help.ts
+++ b/packages/flowglad/src/cli/commands/help.ts
@@ -1,0 +1,75 @@
+import type { CAC } from 'cac'
+
+interface CommandInfo {
+  name: string
+  description: string
+  status: 'available' | 'coming-soon'
+}
+
+const commands: CommandInfo[] = [
+  {
+    name: 'help',
+    description: 'Display this help message',
+    status: 'available',
+  },
+  {
+    name: 'login',
+    description: 'Authenticate via OAuth',
+    status: 'coming-soon',
+  },
+  {
+    name: 'logout',
+    description: 'Clear stored credentials',
+    status: 'coming-soon',
+  },
+  {
+    name: 'link',
+    description: 'Link to an organization and pricing model',
+    status: 'coming-soon',
+  },
+  {
+    name: 'pull',
+    description: 'Download pricing model to pricing.yaml',
+    status: 'coming-soon',
+  },
+  {
+    name: 'push',
+    description: 'Upload pricing.yaml to linked pricing model',
+    status: 'coming-soon',
+  },
+  {
+    name: 'deploy',
+    description: 'Promote test pricing model to live',
+    status: 'coming-soon',
+  },
+]
+
+export const printHelp = (): void => {
+  console.log('\nFlowglad CLI - Manage your Flowglad configuration\n')
+  console.log('Usage: flowglad <command> [options]\n')
+  console.log('Commands:\n')
+
+  const maxNameLength = Math.max(
+    ...commands.map((c) => c.name.length)
+  )
+
+  for (const cmd of commands) {
+    const padding = ' '.repeat(maxNameLength - cmd.name.length + 2)
+    const statusIndicator =
+      cmd.status === 'coming-soon' ? ' (coming soon)' : ''
+    console.log(
+      `  ${cmd.name}${padding}${cmd.description}${statusIndicator}`
+    )
+  }
+
+  console.log(
+    '\nRun `flowglad <command> --help` for command-specific help.\n'
+  )
+  console.log('Documentation: https://flowglad.com/docs/cli')
+}
+
+export const registerHelpCommand = (cli: CAC): void => {
+  cli.command('help', 'Display help information').action(() => {
+    printHelp()
+  })
+}

--- a/packages/flowglad/src/cli/commands/index.ts
+++ b/packages/flowglad/src/cli/commands/index.ts
@@ -1,0 +1,18 @@
+import type { CAC } from 'cac'
+import { registerHelpCommand } from './help'
+
+/**
+ * Register all CLI commands with the CLI instance.
+ * Add new commands here as they are implemented.
+ */
+export const registerCommands = (cli: CAC): void => {
+  registerHelpCommand(cli)
+
+  // Future commands (Milestone 1+):
+  // registerLoginCommand(cli)
+  // registerLogoutCommand(cli)
+  // registerLinkCommand(cli)
+  // registerPullCommand(cli)
+  // registerPushCommand(cli)
+  // registerDeployCommand(cli)
+}

--- a/packages/flowglad/src/cli/index.ts
+++ b/packages/flowglad/src/cli/index.ts
@@ -1,1 +1,13 @@
-console.log('flowglad cli placeholder')
+import cac from 'cac'
+import { registerCommands } from './commands'
+
+declare const PACKAGE_VERSION: string
+
+const cli = cac('flowglad')
+
+cli.version(PACKAGE_VERSION)
+cli.help()
+
+registerCommands(cli)
+
+cli.parse()


### PR DESCRIPTION
## What Does this PR Do?

Implements the cac-based CLI framework with the help command. Adds command registration pattern for extensibility, allowing future commands to be registered easily. The help command displays all available and planned commands with their status.

**Changes:**
- CLI framework using cac with version and help support
- Help command implementation with command registry
- Test coverage for help command output
- Extensible command registration pattern for future commands

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces the Flowglad CLI using cac and adds the initial help command. Provides versioning, global help, and a command registry to support future commands.

- **New Features**
  - CLI entry uses cac with version and global help.
  - Help command prints usage, all commands, and status (available/coming soon).
  - Centralized command registry for easy command additions.
  - Unit test covers help output content.

- **Dependencies**
  - Adds flowglad package bin and deps: cac, js-yaml, @types/js-yaml, vitest, typescript.

<sup>Written for commit 7dd193e1ebc6b5044c5c61a3d7ad1ae771817c49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functional help command to the Flowglad CLI, displaying available commands with status indicators and documentation links.
  * Implemented CLI bootstrap with modular command registration system supporting versioning and help metadata.

* **Tests**
  * Added test coverage validating help command output includes all expected command names, descriptions, and documentation references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->