### PR TITLE
[extract-schema-for-subtree] Patch 2: Create db-core/schemaTypes.ts with pure DB types

### DIFF
--- a/platform/flowglad-next/db-core/schemaTypes.ts
+++ b/platform/flowglad-next/db-core/schemaTypes.ts
@@ -1,0 +1,66 @@
+// db-core/schemaTypes.ts
+
+import type { ColumnBaseConfig, SQLWrapper } from 'drizzle-orm'
+import type { PgColumn, PgTable } from 'drizzle-orm/pg-core'
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
+
+export type { SQLWrapper } from 'drizzle-orm'
+export type { PgTable, PgTransaction } from 'drizzle-orm/pg-core'
+
+export type DbTransaction = Parameters<
+  Parameters<
+    PostgresJsDatabase<Record<string, never>>['transaction']
+  >[0]
+>[0]
+
+export type PgNumberColumn = PgColumn<
+  ColumnBaseConfig<'number', 'number'>,
+  {},
+  {}
+>
+export type PgSerialColumn = PgColumn<
+  ColumnBaseConfig<'number', 'serial'>,
+  {},
+  {}
+>
+export type PgStringColumn = PgColumn<
+  ColumnBaseConfig<'string', 'string'>,
+  {},
+  {}
+>
+export type PgTimestampColumn = PgColumn<
+  {
+    name: string
+    tableName: string
+    dataType: 'custom'
+    columnType: 'PgCustomColumn'
+    data: number
+    driverParam: string | Date
+    notNull: boolean
+    hasDefault: boolean
+    isPrimaryKey: boolean
+    isAutoincrement: boolean
+    hasRuntimeDefault: boolean
+    enumValues: undefined
+    baseColumn: never
+    identity: undefined
+    generated: undefined
+  },
+  {},
+  {}
+>
+
+export type PgTableWithId = PgTable & { id: SQLWrapper }
+export type PgTableWithCreatedAtAndId = PgTable & {
+  createdAt: SQLWrapper
+  id: SQLWrapper
+}
+export type PgTableWithPosition = PgTable & {
+  position: SQLWrapper
+  createdAt: SQLWrapper
+  id: SQLWrapper
+}
+export type PgTableWithIdAndPricingModelId = PgTable & {
+  id: SQLWrapper
+  pricingModelId: SQLWrapper
+}


### PR DESCRIPTION
## Summary

- Create `db-core/schemaTypes.ts` with pure database types extracted from `src/db/types.ts`
- Types have no application-specific dependencies, making db-core portable for git subtree sharing

## Types Exported

- `DbTransaction` - Database transaction type for Drizzle ORM
- `PgNumberColumn`, `PgSerialColumn`, `PgStringColumn`, `PgTimestampColumn` - Column type definitions
- `PgTableWithId`, `PgTableWithCreatedAtAndId`, `PgTableWithPosition`, `PgTableWithIdAndPricingModelId` - Table constraint types
- Re-exports: `PgTable`, `PgTransaction`, `SQLWrapper`

## Test Plan

- [x] `bun run check` passes (lint + typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts pure Drizzle DB types into db-core/schemaTypes.ts to decouple db-core from app code and make it portable for git subtree sharing. Consumers can now import standardized transaction, column, and table helper types from a stable module.

- **Refactors**
  - Added db-core/schemaTypes.ts with DbTransaction and common Pg column/table helper types.
  - Re-exported PgTable, PgTransaction, and SQLWrapper for downstream use.
  - Types depend only on drizzle-orm and postgres-js; no app-specific dependencies.

<sup>Written for commit a08f57294a618dd4da5816d8ddc350f1d10d6b3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

