### PR TITLE
Add /pm skill for incident postmortems and enhance resolve-checks

### DIFF
--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: pm
+description: Create incident postmortems by reading Slack incident channels and creating structured postmortem documents in Notion. Use when conducting postmortem reviews or documenting incident responses.
+---
+
+# Incident Postmortem Generator
+
+Create comprehensive incident postmortem documents by reading Slack incident channels and storing structured postmortems in Notion.
+
+## When to Use
+
+- After resolving a production incident
+- When conducting postmortem reviews
+- When documenting incident responses for team learning
+- To generate action items from incident discussions
+
+## Prerequisites
+
+This skill requires the following MCP servers to be configured:
+- **Slack MCP** - For reading incident channel history
+- **Notion MCP** - For creating postmortem documents in the Notes database
+
+Optional:
+- **Betterstack MCP** - For including telemetry and uptime links
+
+## Process
+
+### 1. Identify the Incident Channel
+
+Ask the user for the Slack channel name or ID. The channel should be the dedicated incident channel (typically named like `#incident-<name>` or `#inc-<date>-<description>`).
+
+### 2. Read Slack Channel History
+
+Use the Slack MCP to fetch the channel's message history:
+
+```
+mcp__slack__slack_list_channels
+```
+
+Find the channel ID, then fetch history:
+
+```
+mcp__slack__slack_get_channel_history with channel_id
+```
+
+For threaded discussions, also fetch thread replies:
+
+```
+mcp__slack__slack_get_thread_replies with channel_id and thread_ts
+```
+
+Get user information to resolve mentions:
+
+```
+mcp__slack__slack_get_users
+```
+
+### 3. Analyze the Incident
+
+From the Slack messages, extract:
+
+1. **Timeline**: Key events in chronological order
+   - When was the incident first detected?
+   - When was it acknowledged?
+   - What investigation steps were taken?
+   - When was it mitigated/resolved?
+
+2. **Root Cause**: The underlying technical issue
+   - What broke?
+   - Why did it break?
+   - What dependencies were involved?
+
+3. **Impact**: The effect on users/systems
+   - What services were affected?
+   - How many users impacted?
+   - What was the duration?
+
+4. **Open Questions**: Unresolved items from discussion
+   - Unclear technical details
+   - Areas needing further investigation
+   - Decisions that need to be made
+
+5. **Action Items**: Follow-up tasks with assignees
+   - Preventive measures
+   - Monitoring improvements
+   - Documentation updates
+   - Process changes
+
+### 4. Generate Postmortem Document
+
+Create a markdown document following this structure:
+
+```markdown
+# Incident Postmortem: [Brief Title]
+
+**Date:** [Incident Date]
+**Severity:** [P0/P1/P2/P3]
+**Duration:** [Total incident duration]
+**Author:** [Person creating postmortem]
+
+## Summary
+
+[2-3 sentence summary of what happened and the impact]
+
+## Timeline
+
+| Time (UTC) | Event |
+|------------|-------|
+| HH:MM | Incident detected via [source] |
+| HH:MM | Team alerted |
+| HH:MM | Investigation began |
+| HH:MM | Root cause identified |
+| HH:MM | Mitigation deployed |
+| HH:MM | Incident resolved |
+
+## Impact
+
+- **Services Affected:** [List of affected services]
+- **Users Impacted:** [Number or percentage]
+- **Duration:** [How long users were affected]
+- **Data Loss:** [Yes/No, details if applicable]
+
+## Root Cause Analysis
+
+### What Happened
+
+[Detailed technical explanation of the failure]
+
+### Why It Happened
+
+[Contributing factors, systemic issues]
+
+### Detection
+
+[How was the incident discovered? Could we have detected it sooner?]
+
+## Telemetry & Monitoring
+
+[If Betterstack MCP is available, include relevant links]
+
+- **Uptime Dashboard:** [Link]
+- **Error Metrics:** [Link]
+- **Relevant Alerts:** [Link]
+
+## Open Questions
+
+- [ ] [Unresolved question 1]
+- [ ] [Unresolved question 2]
+
+## Action Items
+
+| Action | Assignee | Priority | Status |
+|--------|----------|----------|--------|
+| [Action description] | @[username] | High/Medium/Low | Open |
+| [Action description] | @[username] | High/Medium/Low | Open |
+
+## Lessons Learned
+
+### What Went Well
+
+- [Positive aspects of incident response]
+
+### What Could Be Improved
+
+- [Areas for improvement]
+
+## References
+
+- **Incident Channel:** #[channel-name]
+- **Related PRs:** [Links to fix PRs]
+- **Related Docs:** [Links to relevant documentation]
+```
+
+### 5. Create Notion Page
+
+Use the Notion MCP to create the postmortem in the Notes database:
+
+First, search for the Notes database:
+
+```
+mcp__claude_ai_Notion__notion-search with query: "Notes"
+```
+
+Or use the Notion skill:
+
+```
+Skill: notion-search with "Notes database"
+```
+
+Then create the page with the postmortem content:
+
+```
+mcp__claude_ai_Notion__notion-create-pages with:
+- parent: Notes database ID
+- title: "Incident Postmortem: [Brief Title]"
+- content: [Generated markdown content]
+```
+
+**Important:** Add the required tags to the page:
+- `eng`
+- `postmortem`
+
+If the Notion MCP supports tags/properties, set them during creation. Otherwise, use the update page tool:
+
+```
+mcp__claude_ai_Notion__notion-update-page with:
+- page_id: [created page ID]
+- properties: { tags: ["eng", "postmortem"] }
+```
+
+### 6. Share Results
+
+After creating the postmortem:
+
+1. Provide the Notion page link to the user
+2. Optionally post a summary back to the Slack channel:
+
+```
+mcp__slack__slack_post_message with:
+- channel: [incident channel ID]
+- text: "Postmortem document created: [Notion link]"
+```
+
+## Tips for Quality Postmortems
+
+### Blameless Culture
+
+- Focus on systems and processes, not individuals
+- Use "the system failed to..." rather than "person X failed to..."
+- Treat failures as learning opportunities
+
+### Be Specific
+
+- Include exact timestamps when available
+- Reference specific commits, PRs, or deployments
+- Quantify impact with numbers when possible
+
+### Actionable Items
+
+- Each action item should be specific and achievable
+- Assign clear owners
+- Set priorities to help with planning
+
+### Capture Context
+
+- Include relevant Slack threads and discussions
+- Link to monitoring dashboards and alerts
+- Reference any related incidents
+
+## Output
+
+Provide to the user:
+
+1. **Summary** of what was extracted from Slack
+2. **Notion link** to the created postmortem
+3. **List of action items** for easy reference
+4. **Any gaps** that need manual filling (if information was missing from Slack)

--- a/.claude/skills/resolve-checks/SKILL.md
+++ b/.claude/skills/resolve-checks/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: resolve-checks
-description: Resolve all failing CI checks on the current branch's PR by running tests locally, fixing failures, and ensuring CI passes. Use when CI is red or before merging.
+description: Resolve all failing CI checks and address PR review feedback on the current branch's PR. Runs tests locally, fixes failures, incorporates valid review comments, and resolves addressed feedback. Use when CI is red, after receiving PR feedback, or before merging.
 ---
 
 # Resolve Checks
 
-Systematically resolve all failing CI checks by running tests locally first, fixing issues, and verifying CI passes.
+Systematically resolve all failing CI checks and address PR review feedback by running tests locally first, fixing issues, incorporating valid feedback, and verifying CI passes.
 
 ## When to Use
 
 - When CI checks are failing on your PR
+- When you have unresolved PR review comments
 - Before attempting to merge a PR
 - When you want to proactively verify all checks pass
 - After making changes and before pushing
+- After receiving code review feedback
 
 ## Core Principle
 
@@ -223,6 +225,98 @@ Repeat steps 4-7 until all checks pass. Common iteration scenarios:
 
 **Remember:** The goal is a stable, passing test suite - not a lucky CI run. Every fix should address the root cause.
 
+### 9. Address PR Review Feedback
+
+After CI checks pass, review and address any PR comments left by reviewers.
+
+#### Step 1: Fetch PR Comments
+
+Get all review comments on the PR:
+
+```
+mcp__github__get_pull_request_comments with owner, repo, and pull_number
+```
+
+Also get the formal reviews:
+
+```
+mcp__github__get_pull_request_reviews with owner, repo, and pull_number
+```
+
+#### Step 2: Categorize Each Comment
+
+For each comment, determine if it is:
+
+| Category | Description | Action |
+|----------|-------------|--------|
+| **Valid & Actionable** | Identifies a real issue, bug, or improvement | Implement the fix |
+| **Valid but Won't Fix** | Correct observation but intentional design choice | Reply explaining the rationale |
+| **Already Addressed** | Issue was fixed in a subsequent commit | Resolve the comment |
+| **Invalid/Misunderstanding** | Based on incorrect assumptions about the code | Reply with clarification |
+| **Nitpick/Optional** | Style preference or minor suggestion | Implement if quick, otherwise discuss |
+
+#### Step 3: Incorporate Valid Feedback
+
+For each valid comment:
+
+1. **Read the specific file and line** mentioned in the comment
+2. **Understand the concern** - What issue is the reviewer pointing out?
+3. **Implement the fix** - Make the necessary code changes
+4. **Reply to the comment** - Briefly explain what was changed
+
+```
+mcp__github__add_issue_comment with owner, repo, issue_number, and body
+```
+
+Or reply directly to the review comment thread.
+
+#### Step 4: Resolve Addressed Comments
+
+After incorporating feedback or providing clarification:
+
+**For comments you addressed:** The comment should be resolved to indicate the feedback was incorporated. If GitHub MCP supports resolving comments, use that. Otherwise, reply with "Done" or "Fixed in [commit hash]" to signal completion.
+
+**For invalid comments:** Reply with a clear, respectful explanation of why the current implementation is correct or intentional. Include:
+- What the code actually does
+- Why it's designed this way
+- Any relevant context the reviewer may have missed
+
+Example reply for invalid feedback:
+```
+This is intentional - the `userId` here refers to the authenticated user making the request, not the target user. The authorization check happens in the middleware at line 45, so by this point we know the user has permission.
+```
+
+#### Step 5: Handle Review Requests
+
+If the PR has "Changes Requested" status:
+
+1. Address all blocking comments from that review
+2. Re-request review from the reviewer once changes are made:
+   ```bash
+   gh pr edit <PR_NUMBER> --add-reviewer <USERNAME>
+   ```
+
+#### Common Review Feedback Patterns
+
+| Feedback Type | How to Address |
+|---------------|----------------|
+| Missing error handling | Add try/catch or Result type handling |
+| Type safety concerns | Add proper types, remove `any` |
+| Missing tests | Add test cases for the mentioned scenarios |
+| Security issues | Fix immediately, these are blocking |
+| Performance concerns | Evaluate and optimize if valid |
+| Code clarity | Rename variables, add comments, or refactor |
+| Breaking changes | Ensure backwards compatibility or document migration |
+
+### 10. Final Verification
+
+After addressing all feedback:
+
+1. **Re-run local tests** - Ensure your fixes didn't break anything
+2. **Push changes** - Trigger CI again
+3. **Verify CI passes** - All checks should be green
+4. **Verify comments resolved** - No unaddressed blocking feedback remains
+
 ## Quick Reference
 
 | Command | What It Tests |
@@ -242,12 +336,19 @@ For detailed test types, setup files, utilities, failure patterns, and parallel 
 
 Report the final status:
 
-**If all checks pass:**
+**If all checks pass and feedback addressed:**
 - Confirm all local tests pass
 - Confirm all CI checks are green
 - List any notable fixes made
+- Summarize PR feedback that was incorporated
+- Note any comments that were resolved with explanations (not code changes)
 
 **If checks still fail:**
 - List which checks are still failing
 - Describe what was attempted
 - Explain what remains to be investigated
+
+**If feedback remains unresolved:**
+- List comments that still need discussion
+- Explain any disagreements with reviewer feedback
+- Suggest next steps (e.g., "discuss with reviewer" or "waiting for clarification")


### PR DESCRIPTION
## Summary

- Add new `/pm` skill that creates incident postmortems by reading Slack incident channels and storing structured documents in Notion with `eng` and `postmortem` tags
- Enhance `/resolve-checks` skill to also handle PR review feedback - incorporating valid comments and resolving addressed/invalid feedback

## Test plan

- [ ] Verify `/pm` skill is discoverable and provides correct instructions for postmortem creation
- [ ] Verify `/resolve-checks` skill includes new PR feedback handling sections
- [ ] Test `/pm` with a real Slack incident channel and Notion workspace
- [ ] Test `/resolve-checks` on a PR with review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new /pm skill to auto-generate incident postmortems from Slack and save them as structured Notion pages tagged eng and postmortem. Updates /resolve-checks to handle PR review feedback alongside CI failures for cleaner merges.

- **New Features**
  - /pm: Reads incident channel history, builds timeline/root cause/impact, creates a Notion postmortem (with eng and postmortem tags), and optionally links Betterstack telemetry.
  - resolve-checks: Fetches PR comments and reviews, categorizes feedback, applies valid fixes, replies or resolves threads, supports “Changes Requested,” and adds a final verification checklist.

- **Migration**
  - Configure Slack MCP and Notion MCP (Notes database).
  - Ensure Notion pages are tagged eng and postmortem.
  - Optional: Configure Betterstack MCP for telemetry links.

<sup>Written for commit 0c309feee5c0e9766fda68772750e7ef4ebd44a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

