### PR TITLE
Fix: prevent publish-release workflow from triggering on revert PRs

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,10 +33,12 @@ jobs:
   publish:
     # Only run if:
     # - Manual dispatch (workflow_dispatch), OR
-    # - The PR was actually merged (not just closed) AND the PR title contains "chore: version packages" OR has "release" label
+    # - The PR was actually merged (not just closed) AND the PR title starts with "chore: version packages" OR has "release" label
     # This ensures we only publish when the version PR is merged, not other PRs
+    # Note: Using startsWith() instead of contains() to prevent triggering on revert PRs
+    # (e.g., 'Revert "chore: version packages (#1744)"' should NOT trigger)
     if: >
-      github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && (contains(github.event.pull_request.title, 'chore: version packages') || contains(github.event.pull_request.labels.*.name, 'release')))
+      github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && (startsWith(github.event.pull_request.title, 'chore: version packages') || contains(github.event.pull_request.labels.*.name, 'release')))
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## What Does this PR Do?

Hardens the `publish-release.yml` workflow to prevent accidental publishes when reverting version PRs. Changed the PR title check from `contains()` to `startsWith()` to ensure the workflow only triggers on actual version package PRs, not revert PRs that quote the original title (e.g., `Revert "chore: version packages (#1744)"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent accidental publishes by stopping the publish-release workflow from triggering on revert PRs.
Switches the PR title check from contains() to startsWith() so only actual "chore: version packages" PRs trigger; manual dispatch and 'release' label paths remain unchanged.

<sup>Written for commit f18e105846168768f0694960f744e080e896cb43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow conditions to prevent accidental triggers on revert pull requests while maintaining existing deployment safeguards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->