### PR TITLE
Improve Slack PR notification format

### DIFF
--- a/.github/workflows/pr-review-slack-notify.yml
+++ b/.github/workflows/pr-review-slack-notify.yml
@@ -20,13 +20,13 @@ jobs:
             exit 0
           fi
 
-          PAYLOAD=$(jq -n --arg title "$TITLE" --arg url "$URL" --arg author "$AUTHOR" '{
+          PAYLOAD=$(jq -n --arg title "$TITLE" --arg url "$URL" '{
             blocks: [
               {
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: ("🟡 <" + $url + "|" + $title + "> - " + $author)
+                  text: ("🟡 Needs Review: <" + $url + "|" + $title + "> <!channel>")
                 }
               },
               { type: "divider" }

--- a/.github/workflows/pr-review-slack-reply.yml
+++ b/.github/workflows/pr-review-slack-reply.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Post to Slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PULL_REQUEST_URL }}
+          SLACK_GITHUB_MAPPING: ${{ secrets.SLACK_GITHUB_MAPPING }}
           STATE: ${{ github.event.review.state }}
           TITLE: ${{ github.event.pull_request.title }}
           URL: ${{ github.event.pull_request.html_url }}
@@ -31,22 +32,37 @@ jobs:
           case "$STATE" in
             approved)
               EMOJI="🟢"
+              STATUS_LABEL="Approved:"
               ;;
             changes_requested|commented)
               EMOJI="🔴"
+              STATUS_LABEL="Needs Changes:"
               ;;
             *)
               EMOJI="🔴"
+              STATUS_LABEL="Needs Changes:"
               ;;
           esac
 
-          PAYLOAD=$(jq -n --arg emoji "$EMOJI" --arg title "$TITLE" --arg url "$URL" --arg author "$AUTHOR" '{
+          # Look up Slack ID for author (case-insensitive), fallback to GitHub username
+          AUTHOR_LOWER=$(echo "$AUTHOR" | tr '[:upper:]' '[:lower:]')
+          if [ -n "$SLACK_GITHUB_MAPPING" ]; then
+            SLACK_ID=$(echo "$SLACK_GITHUB_MAPPING" | jq -r --arg author "$AUTHOR_LOWER" 'to_entries | map(select(.key | ascii_downcase == $author)) | .[0].value // empty')
+          fi
+
+          if [ -n "$SLACK_ID" ]; then
+            MENTION="<@${SLACK_ID}>"
+          else
+            MENTION="$AUTHOR"
+          fi
+
+          PAYLOAD=$(jq -n --arg emoji "$EMOJI" --arg status "$STATUS_LABEL" --arg title "$TITLE" --arg url "$URL" --arg mention "$MENTION" '{
             blocks: [
               {
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: ($emoji + " <" + $url + "|" + $title + "> - " + $author)
+                  text: ($emoji + " " + $status + " <" + $url + "|" + $title + "> " + $mention)
                 }
               },
               { type: "divider" }


### PR DESCRIPTION
## Summary
- Add explicit status labels: `Needs Review:`, `Needs Changes:`, `Approved:`
- `@channel` when PR is labeled needs-review
- `@author` (via Slack member ID) when PR receives a review
- Fallback to GitHub username if no Slack mapping exists

## Configuration
Requires `SLACK_GITHUB_MAPPING` secret with JSON mapping of GitHub usernames to Slack member IDs:
```json
{"username":"U12345678"}
```

## Test plan
- [ ] Label a PR with `needs-review` → should see `🟡 Needs Review: [title] @channel`
- [ ] Approve a PR → should see `🟢 Approved: [title] @author`
- [ ] Request changes on a PR → should see `🔴 Needs Changes: [title] @author`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Slack PR notifications with clear status labels and mentions to increase visibility and prompt follow-up. Needs-review alerts ping the channel; review updates mention the PR author via Slack ID mapping with a GitHub username fallback.

- **New Features**
  - Adds explicit status labels: Needs Review, Needs Changes, Approved.
  - Needs-review notifications include <!channel>.
  - Review notifications mention the PR author via Slack member ID mapping; fallback to GitHub username.
  - Mapping lookup is case-insensitive.

- **Migration**
  - Add SLACK_GITHUB_MAPPING secret with JSON mapping of GitHub usernames to Slack member IDs (e.g., {"username":"U12345678"}).

<sup>Written for commit 122ff9ba87a05af1f4ca61692ab81284ca87676a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Slack notifications for pull request reviews with improved message formatting, status labels ("Approved" or "Needs Changes"), and channel mentions for better visibility.
  * Implemented GitHub-to-Slack username mapping to enable more accurate user mentions in review notifications with fallback to GitHub usernames.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->