### PR TITLE
Add changelog release notes for Flowglad CLI v0.18.0

### DIFF
--- a/.changeset/heavy-toys-leave.md
+++ b/.changeset/heavy-toys-leave.md
@@ -1,0 +1,28 @@
+---
+"flowglad": minor
+"@flowglad/nextjs": minor
+"@flowglad/server": minor
+"@flowglad/shared": minor
+"@flowglad/react": minor
+---
+
+### New Flowglad CLI Package
+
+- [be039709](https://github.com/flowglad/flowglad/commit/be039709): Initial release of the Flowglad CLI package
+  - Install globally with `npm install -g flowglad` or run directly with `npx flowglad`
+  - Built with `cac` CLI framework for lightweight, TypeScript-first command handling
+  - Requires Node.js 18.0.0 or higher
+  - Dual ESM/CJS output with TypeScript declarations
+
+- [95d77db4](https://github.com/flowglad/flowglad/commit/95d77db4): CLI framework and help command implementation
+  - `flowglad help` command displays available commands and roadmap
+  - Extensible command registration pattern for future commands
+  - Foundation for pricing-as-code workflow (login, link, pull, push, deploy coming soon)
+
+### Documentation
+
+Full CLI documentation available at [flowglad.com/docs/cli](https://flowglad.com/docs/cli)
+
+## Breaking Changes
+
+⚠️ **None** - This is an additive release introducing the new CLI package.

--- a/platform/flowglad-next/llm-prompts/new-packages-changelog-notes.md
+++ b/platform/flowglad-next/llm-prompts/new-packages-changelog-notes.md
@@ -1,5 +1,7 @@
 You are creating a new changelog announcement. These changelog notes will be used to also generate a github release as well. Please generate a new changelog file in the following format.
 
+**CRITICAL - Do not modify the frontmatter:** Preserve the existing package declarations in the changeset frontmatter exactly as they are. We release all Flowglad packages in lockstep (same version number across all packages), so even if a package has no code changes in this release, it must still be included in the frontmatter. Only write the release notes content below the frontmatter—never add or remove packages from the YAML block.
+
 Use the git log to determine what changes in packages/* have happened since the last changelog (search the git log for the last time we had a commit "chore: version packages"). Group the notes thematically into sections. They may be grouped around new features, improvements, bug fixes, etc.
 
 **To get the full context of package changes, run this git command:**


### PR DESCRIPTION
## What Does this PR Do?

Creates a changeset with release notes for the new Flowglad CLI package (v0.18.0). Documents the initial release including package scaffolding, CLI framework with cac, and the help command implementation. This is an additive release with no breaking changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a changeset with release notes for Flowglad CLI v0.18.0. Also updates the changelog prompt to enforce keeping all packages in the frontmatter for lockstep releases.

- **New Features**
  - Initial CLI package built on cac; requires Node 18+.
  - Install via npm -g or run with npx; ships ESM/CJS with TypeScript types.
  - Help command lists available commands and roadmap; extensible command pattern.
  - No breaking changes.

<sup>Written for commit 848230937b08ab6cedd17c87ac4c79dd0b63f2be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Flowglad CLI package now available for installation globally via npm
* Can be used immediately through npx without prior installation
* Minimum Node.js version 18 required
* Help command provides guidance on available options
* Built on extensible framework for future enhancements
* Supports both ESM and CommonJS module formats

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->