### PR TITLE
[extract-schema-for-subtree] Patch 8: Update src/db/types.ts to import from db-core

### DIFF
--- a/platform/flowglad-next/src/db/types.ts
+++ b/platform/flowglad-next/src/db/types.ts
@@ -1,84 +1,28 @@
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
-
-export type { PgTable, PgTransaction } from 'drizzle-orm/pg-core'
-
 import type { Event } from '@db-core/schema/events'
-import type { ColumnBaseConfig, SQLWrapper } from 'drizzle-orm'
-import type { PgColumn, PgTable } from 'drizzle-orm/pg-core'
 import type {
   CacheDependencyKey,
   CacheRecomputationContext,
 } from '@/utils/cache'
 import type { LedgerCommand } from './ledgerManager/ledgerManagerTypes'
 
-export type { SQLWrapper } from 'drizzle-orm'
+// Re-export pure types from db-core for backwards compatibility
+export type {
+  DbTransaction,
+  PgNumberColumn,
+  PgSerialColumn,
+  PgStringColumn,
+  PgTable,
+  PgTableWithCreatedAtAndId,
+  PgTableWithId,
+  PgTableWithIdAndPricingModelId,
+  PgTableWithPosition,
+  PgTimestampColumn,
+  PgTransaction,
+  SQLWrapper,
+} from '@db-core/schemaTypes'
 
-export type DbTransaction = Parameters<
-  Parameters<
-    PostgresJsDatabase<Record<string, never>>['transaction']
-  >[0]
->[0]
-
-export type PgNumberColumn = PgColumn<
-  ColumnBaseConfig<'number', 'number'>,
-  {},
-  {}
->
-
-export type PgSerialColumn = PgColumn<
-  ColumnBaseConfig<'number', 'serial'>,
-  {},
-  {}
->
-
-export type PgStringColumn = PgColumn<
-  ColumnBaseConfig<'string', 'string'>,
-  {},
-  {}
->
-
-// For timestampWithTimezoneColumn() columns only - stores ms as numbers, timezone-aware
-export type PgTimestampColumn = PgColumn<
-  {
-    name: string
-    tableName: string
-    dataType: 'custom'
-    columnType: 'PgCustomColumn'
-    data: number
-    driverParam: string | Date
-    notNull: boolean
-    hasDefault: boolean
-    isPrimaryKey: boolean
-    isAutoincrement: boolean
-    hasRuntimeDefault: boolean
-    enumValues: undefined
-    baseColumn: never
-    identity: undefined
-    generated: undefined
-  },
-  {},
-  {}
->
-
-export type PgTableWithId = PgTable & {
-  id: SQLWrapper
-}
-
-export type PgTableWithCreatedAtAndId = PgTable & {
-  createdAt: SQLWrapper
-  id: SQLWrapper
-}
-
-export type PgTableWithPosition = PgTable & {
-  position: SQLWrapper
-  createdAt: SQLWrapper
-  id: SQLWrapper
-}
-
-export type PgTableWithIdAndPricingModelId = PgTable & {
-  id: SQLWrapper
-  pricingModelId: SQLWrapper
-}
+// Import DbTransaction for use in this file's type definitions
+import type { DbTransaction } from '@db-core/schemaTypes'
 
 /**
  * Accumulated side effects collected during a transaction.


### PR DESCRIPTION
## Summary

- Update `src/db/types.ts` to re-export pure DB types from `@db-core/schemaTypes` instead of defining them locally
- Remove duplicate type definitions while maintaining backwards compatibility for existing imports
- Keep app-specific types that depend on application code (`TransactionEffects`, `TransactionCallbacks`, etc.)

## Changes

- Remove local definitions of `DbTransaction`, `PgNumberColumn`, `PgSerialColumn`, `PgStringColumn`, `PgTimestampColumn`, `PgTableWithId`, `PgTableWithCreatedAtAndId`, `PgTableWithPosition`, `PgTableWithIdAndPricingModelId`
- Remove local re-exports of `PgTable`, `PgTransaction`, `SQLWrapper` from drizzle-orm
- Add re-exports from `@db-core/schemaTypes` for all pure DB types

## Test plan

- [x] Run `bun run check` to verify lint/typecheck passes
- [x] Verify imports are correct with `grep "@db-core" platform/flowglad-next/src/db/types.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized pure DB type definitions by re-exporting them from @db-core/schemaTypes in src/db/types.ts. This removes duplicate local types and keeps app-specific transaction types; existing imports continue to work.

- **Refactors**
  - Replace local DB type definitions with re-exports from @db-core/schemaTypes (e.g., DbTransaction, PgColumn variants, PgTable helpers, SQLWrapper).
  - Remove drizzle-orm re-exports from this file.
  - Keep app-specific types that depend on cache and ledger code.

<sup>Written for commit bf1e1edcd17148eaca8e9d5a78b0e56588696345. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization to consolidate type definitions from a centralized module. No changes to functionality or user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->