### PR TITLE
[flowglad-mock-server] Patch 6: SDK Configuration

### DIFF
--- a/platform/flowglad-next/src/utils/svix.ts
+++ b/platform/flowglad-next/src/utils/svix.ts
@@ -25,13 +25,20 @@ import core from './core'
 /**
  * Create a Svix client configured from the `SVIX_API_KEY` environment variable.
  *
+ * When `SVIX_MOCK_HOST` is set, the client uses that URL as the server endpoint.
+ * This enables testing against a mock server (e.g., flowglad-mock-server) instead
+ * of the production Svix API.
+ *
  * @returns A Svix client instance initialized with the value of `SVIX_API_KEY`.
  */
 export function svix() {
   return new Svix(
     core.IS_TEST
       ? 'test_svix_api_key'
-      : core.envVariable('SVIX_API_KEY')
+      : core.envVariable('SVIX_API_KEY'),
+    {
+      serverUrl: process.env.SVIX_MOCK_HOST || undefined,
+    }
   )
 }
 

--- a/platform/flowglad-next/src/utils/unkey.ts
+++ b/platform/flowglad-next/src/utils/unkey.ts
@@ -28,11 +28,21 @@ export type VerifyApiKeyResult = {
   error: unknown | undefined
 }
 
+/**
+ * Create an Unkey client configured from the `UNKEY_ROOT_KEY` environment variable.
+ *
+ * When `UNKEY_MOCK_HOST` is set, the client uses that URL as the server endpoint.
+ * This enables testing against a mock server (e.g., flowglad-mock-server) instead
+ * of the production Unkey API.
+ *
+ * @returns An Unkey client instance.
+ */
 export const unkey = () =>
   new Unkey({
     rootKey: core.IS_TEST
       ? 'test_root_key'
       : core.envVariable('UNKEY_ROOT_KEY'),
+    serverURL: process.env.UNKEY_MOCK_HOST || undefined,
   })
 
 /**

--- a/platform/flowglad-next/src/utils/unkey.unit.test.ts
+++ b/platform/flowglad-next/src/utils/unkey.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it } from 'bun:test'
 import { FlowgladApiKeyType } from '@db-core/enums'
 import type { ApiKey } from '@/db/schema/apiKeys'
 import type { Organization } from '@/db/schema/organizations'
@@ -6,7 +6,48 @@ import {
   parseUnkeyMeta,
   type StandardCreateApiKeyParams,
   secretApiKeyInputToUnkeyInput,
+  unkey,
 } from './unkey'
+
+describe('unkey client configuration', () => {
+  const originalEnv = { ...process.env }
+
+  afterEach(() => {
+    // Restore original env
+    Object.keys(process.env).forEach((key) => {
+      if (!(key in originalEnv)) {
+        delete process.env[key]
+      }
+    })
+    Object.assign(process.env, originalEnv)
+  })
+
+  it('returns an Unkey client with expected API (keys property)', () => {
+    // Note: In test mode, @unkey/api is mocked with MockUnkey
+    // so we can't use instanceof Unkey. We verify the API shape instead.
+    const client = unkey()
+    expect(typeof client).toBe('object')
+    expect(typeof client.keys).toBe('object')
+    expect(typeof client.keys.createKey).toBe('function')
+    expect(typeof client.keys.deleteKey).toBe('function')
+  })
+
+  it('creates client without error when UNKEY_MOCK_HOST is set', () => {
+    // Set UNKEY_MOCK_HOST to simulate docker-compose test configuration
+    process.env.UNKEY_MOCK_HOST = 'http://localhost:9002'
+    const client = unkey()
+    expect(typeof client).toBe('object')
+    expect(typeof client.keys).toBe('object')
+  })
+
+  it('creates client without error when UNKEY_MOCK_HOST is unset', () => {
+    delete process.env.UNKEY_MOCK_HOST
+    const client = unkey()
+    // Client created without mock server config (uses real Unkey API)
+    expect(typeof client).toBe('object')
+    expect(typeof client.keys).toBe('object')
+  })
+})
 
 describe('secretApiKeyInputToUnkeyInput', () => {
   const mockOrganization: Pick<Organization.Record, 'id'> = {


### PR DESCRIPTION
## Summary

- Add `SVIX_MOCK_HOST` support to `svix()` function via `serverUrl` option
- Add `UNKEY_MOCK_HOST` support to `unkey()` function via `serverURL` option

This follows the stripe-mock pattern where SDKs accept a mock host URL to enable testing against a local mock server (flowglad-mock-server) instead of the real API.

**Note:** The Unkey SDK uses `serverURL` (not `baseUrl`) per its type definitions.

## Test plan

- [x] `bun run check` passes (lint, typecheck, registry validation)
- [x] Unit tests pass (existing tests still work)
- [ ] Integration test with mock server (Patch 7 - when MSW passthrough is configured)

**Why no SDK configuration unit tests:** The current test setup uses `mock.module()` to replace `@/utils/svix` and `@unkey/api` entirely, preventing unit tests from verifying real SDK configuration. Verification will occur in Patch 7 when MSW passthrough enables tests to call the mock server directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Unkey client utility for key management.

* **Refactor**
  * Enhanced Svix client configuration to support mock server targeting in test environments.

* **Tests**
  * Added comprehensive unit tests for Unkey client configuration and API validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->