### PR TITLE
[extract-schema-for-subtree] Patch 13: Add CI workflow for schema export

### DIFF
--- a/.github/workflows/export-schema.yml
+++ b/.github/workflows/export-schema.yml
@@ -26,9 +26,18 @@ jobs:
             -b schema-export
           git push origin schema-export --force
 
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SCHEMA_SYNC_APP_ID }}
+          private-key: ${{ secrets.SCHEMA_SYNC_APP_PRIVATE_KEY }}
+          owner: flowglad
+          repositories: flowglad-internal
+
       - name: Notify internal repo
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.INTERNAL_REPO_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           repository: flowglad/flowglad-internal
           event-type: schema-updated


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow that exports the `db-core/` directory to a dedicated `schema-export` branch
- Triggers only on pushes to `main` that affect `platform/flowglad-next/db-core/**`
- Uses `git subtree split` to extract just the db-core directory history
- Notifies internal repo via repository dispatch using organization-owned GitHub App

## How It Works

1. **Trigger:** Workflow runs when changes to `db-core/` are pushed to main
2. **Split:** `git subtree split --prefix=platform/flowglad-next/db-core` extracts the subtree
3. **Push:** Force-pushes to `schema-export` branch to keep it current
4. **Auth:** Generates a token using the GitHub App (organization-owned, not tied to any user)
5. **Notify:** Dispatches `schema-updated` event to `flowglad/flowglad-internal`

## Required Secrets

Once the GitHub App is created, add these repository secrets:

| Secret | Description |
|--------|-------------|
| `SCHEMA_SYNC_APP_ID` | The GitHub App's App ID |
| `SCHEMA_SYNC_APP_PRIVATE_KEY` | The App's private key (PEM format) |

The App needs **Contents: Read & Write** permission and must be installed on `flowglad/flowglad-internal`.

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Add required secrets after App is created
- [ ] After merging, make a small change to `db-core/` and push to main
- [ ] Verify the workflow runs and creates/updates the `schema-export` branch
- [ ] Verify `schema-export` branch contains db-core files at root level

🤖 Generated with [Claude Code](https://claude.com/claude-code)