### PR TITLE
[flowglad-mock-server] Patch 4: Trigger Routes

### DIFF
--- a/packages/mock-server/src/index.ts
+++ b/packages/mock-server/src/index.ts
@@ -1,5 +1,6 @@
 import { handleHealth } from './routes/health'
 import { handleSvixRoute } from './routes/svix'
+import { handleTriggerRoute } from './routes/trigger'
 import { handleUnkeyRoute } from './routes/unkey'
 
 const SVIX_PORT = 9001
@@ -66,7 +67,11 @@ createServer({
   serviceName: 'unkey',
   routeHandler: handleUnkeyRoute,
 })
-createServer({ port: TRIGGER_PORT, serviceName: 'trigger' })
+createServer({
+  port: TRIGGER_PORT,
+  serviceName: 'trigger',
+  routeHandler: handleTriggerRoute,
+})
 
 console.log('\nMock servers started:')
 console.log(`  Svix:    http://localhost:${SVIX_PORT}/health`)

--- a/packages/mock-server/src/routes/trigger.test.ts
+++ b/packages/mock-server/src/routes/trigger.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  generateTriggerHandleId,
+  handleTriggerRoute,
+  handleTriggerTask,
+  parseTriggerPath,
+  type TriggerTaskResponse,
+} from './trigger'
+
+describe('generateTriggerHandleId', () => {
+  it('returns a string prefixed with "handle_"', () => {
+    const id = generateTriggerHandleId()
+    expect(id.startsWith('handle_')).toBe(true)
+  })
+
+  it('generates unique IDs on each call', () => {
+    const id1 = generateTriggerHandleId()
+    const id2 = generateTriggerHandleId()
+    expect(id1).not.toBe(id2)
+  })
+})
+
+describe('parseTriggerPath', () => {
+  it('extracts taskId from valid trigger path', () => {
+    const taskId = parseTriggerPath('/api/v1/tasks/my-task/trigger')
+    expect(taskId).toBe('my-task')
+  })
+
+  it('extracts taskId with hyphens and underscores', () => {
+    const taskId = parseTriggerPath(
+      '/api/v1/tasks/my-task_v2/trigger'
+    )
+    expect(taskId).toBe('my-task_v2')
+  })
+
+  it('extracts taskId with alphanumeric characters', () => {
+    const taskId = parseTriggerPath(
+      '/api/v1/tasks/attempt-billing-run/trigger'
+    )
+    expect(taskId).toBe('attempt-billing-run')
+  })
+
+  it('returns null for non-matching paths', () => {
+    expect(parseTriggerPath('/api/v1/tasks')).toBe(null)
+    expect(parseTriggerPath('/api/v1/tasks/my-task')).toBe(null)
+    expect(parseTriggerPath('/api/v2/tasks/my-task/trigger')).toBe(
+      null
+    )
+    expect(parseTriggerPath('/health')).toBe(null)
+    expect(parseTriggerPath('/')).toBe(null)
+  })
+
+  it('returns null for paths with extra segments after trigger', () => {
+    expect(
+      parseTriggerPath('/api/v1/tasks/my-task/trigger/extra')
+    ).toBe(null)
+  })
+})
+
+describe('handleTriggerTask', () => {
+  it('returns a Response with status 200', () => {
+    const response = handleTriggerTask('my-task')
+    expect(response.status).toBe(200)
+  })
+
+  it('returns Content-Type application/json header', () => {
+    const response = handleTriggerTask('my-task')
+    expect(response.headers.get('Content-Type')).toBe(
+      'application/json'
+    )
+  })
+
+  it('returns JSON body with id prefixed with "handle_" and status "QUEUED"', async () => {
+    const response = handleTriggerTask('my-task')
+    const body = (await response.json()) as TriggerTaskResponse
+    expect(body.id.startsWith('handle_')).toBe(true)
+    expect(body.status).toBe('QUEUED')
+  })
+
+  it('generates different handle IDs for different requests', async () => {
+    const response1 = handleTriggerTask('task-1')
+    const response2 = handleTriggerTask('task-2')
+    const body1 = (await response1.json()) as TriggerTaskResponse
+    const body2 = (await response2.json()) as TriggerTaskResponse
+    expect(body1.id).not.toBe(body2.id)
+    expect(body1.status).toBe('QUEUED')
+    expect(body2.status).toBe('QUEUED')
+  })
+})
+
+describe('handleTriggerRoute', () => {
+  it('returns Response for POST requests to valid trigger path', async () => {
+    const req = new Request(
+      'http://localhost/api/v1/tasks/my-task/trigger',
+      {
+        method: 'POST',
+      }
+    )
+    const response = handleTriggerRoute(
+      req,
+      '/api/v1/tasks/my-task/trigger'
+    )
+    expect(response).not.toBe(null)
+    expect(response!.status).toBe(200)
+    const body = (await response!.json()) as TriggerTaskResponse
+    expect(body.id.startsWith('handle_')).toBe(true)
+    expect(body.status).toBe('QUEUED')
+  })
+
+  it('returns null for GET requests', () => {
+    const req = new Request(
+      'http://localhost/api/v1/tasks/my-task/trigger',
+      {
+        method: 'GET',
+      }
+    )
+    const response = handleTriggerRoute(
+      req,
+      '/api/v1/tasks/my-task/trigger'
+    )
+    expect(response).toBe(null)
+  })
+
+  it('returns null for non-matching paths', () => {
+    const req = new Request('http://localhost/health', {
+      method: 'POST',
+    })
+    const response = handleTriggerRoute(req, '/health')
+    expect(response).toBe(null)
+  })
+})

--- a/packages/mock-server/src/routes/trigger.ts
+++ b/packages/mock-server/src/routes/trigger.ts
@@ -1,0 +1,69 @@
+import { generateId } from '../utils/ids'
+
+/**
+ * Response shape for a triggered task.
+ */
+export interface TriggerTaskResponse {
+  id: string
+  status: 'QUEUED'
+}
+
+/**
+ * Generate a Trigger.dev-style handle ID (prefixed with "handle_")
+ */
+export function generateTriggerHandleId(): string {
+  return generateId('handle_')
+}
+
+/**
+ * Handle POST /api/v1/tasks/:taskId/trigger
+ * Triggers a task and returns a handle ID with QUEUED status.
+ *
+ * @param _taskId - The task ID from the URL path (unused in stateless mock)
+ * @returns Response with handle ID and QUEUED status
+ */
+export function handleTriggerTask(_taskId: string): Response {
+  const response: TriggerTaskResponse = {
+    id: generateTriggerHandleId(),
+    status: 'QUEUED',
+  }
+
+  return new Response(JSON.stringify(response), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}
+
+/**
+ * Parse the task ID from a trigger endpoint path.
+ * Expected format: /api/v1/tasks/:taskId/trigger
+ *
+ * @param pathname - The URL pathname
+ * @returns The task ID if the path matches, null otherwise
+ */
+export function parseTriggerPath(pathname: string): string | null {
+  const match = pathname.match(/^\/api\/v1\/tasks\/([^/]+)\/trigger$/)
+  return match ? match[1] : null
+}
+
+/**
+ * Route handler for Trigger.dev mock server.
+ * Returns a Response if the route matches, null otherwise.
+ */
+export function handleTriggerRoute(
+  req: Request,
+  pathname: string
+): Response | null {
+  if (req.method !== 'POST') {
+    return null
+  }
+
+  const taskId = parseTriggerPath(pathname)
+  if (taskId) {
+    return handleTriggerTask(taskId)
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

- Add POST `/api/v1/tasks/:taskId/trigger` endpoint to the Trigger.dev mock server (port 9003)
- Returns JSON response with `{id: "handle_*", status: "QUEUED"}` matching Trigger.dev API format
- Includes unit tests for the trigger endpoint handler and path parsing

## Test plan

- [x] Run `bun test` in packages/mock-server - all 31 tests pass
- [x] Run `bun run check` - lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a POST /api/v1/tasks/:taskId/trigger endpoint to the Trigger.dev mock server that returns a handle ID and QUEUED status. This wires the route into the trigger service on port 9003.

- **New Features**
  - Handles POST /api/v1/tasks/:taskId/trigger for the trigger service (port 9003).
  - Adds parseTriggerPath and generateTriggerHandleId for strict path matching and unique handles.
  - Responds with application/json: { id: "handle_*", status: "QUEUED" }, with unit tests for the handler and parser.

<sup>Written for commit a775bdbbff9123386f40ccb82d57274b7f3be7d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mock server now exposes a trigger endpoint that accepts task identifiers and returns a queued-status response with a generated handle ID.

* **Tests**
  * Added comprehensive tests covering trigger path parsing, queued response format, and uniqueness of generated handle IDs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->