### PR TITLE
[result-migration] Patch 7a: add Result-returning transaction variants for gradual migration

### DIFF
--- a/platform/flowglad-next/src/db/adminTransaction.db.test.ts
+++ b/platform/flowglad-next/src/db/adminTransaction.db.test.ts
@@ -4,6 +4,7 @@ import { Result } from 'better-result'
 import { setupOrg } from '@/../seedDatabase'
 import {
   adminTransactionUnwrap,
+  adminTransactionWithResult,
   comprehensiveAdminTransaction,
 } from './adminTransaction'
 import { selectOrganizations } from './tableMethods/organizationMethods'
@@ -108,5 +109,146 @@ describe('adminTransactionUnwrap', () => {
     )
 
     expect(result).toBe('testmode_success')
+  })
+})
+
+describe('adminTransactionWithResult', () => {
+  let testOrg: Organization.Record
+
+  beforeEach(async () => {
+    const orgSetup = await setupOrg()
+    testOrg = orgSetup.organization
+  })
+
+  it('returns Result.ok on successful transaction', async () => {
+    // setup:
+    // - call adminTransactionWithResult with a function that returns Result.ok
+    // expects:
+    // - the result should be Result.ok with the value
+    const result = await adminTransactionWithResult(
+      async ({ transaction }) => {
+        const orgs = await selectOrganizations({}, transaction)
+        const foundOrg = orgs.find((o) => o.id === testOrg.id)
+        return Result.ok({ found: !!foundOrg, count: orgs.length })
+      },
+      { livemode: true }
+    )
+
+    expect(Result.isOk(result)).toBe(true)
+    if (Result.isOk(result)) {
+      expect(result.value.found).toBe(true)
+      expect(result.value.count).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  it('returns Result.err when callback returns Result.err (does not throw)', async () => {
+    // setup:
+    // - call adminTransactionWithResult with a function that returns Result.err
+    // expects:
+    // - the result should be Result.err with the error (not thrown)
+    const errorMessage =
+      'Admin validation failed: business rule violated'
+
+    const result = await adminTransactionWithResult(
+      async () => Result.err(new Error(errorMessage)),
+      { livemode: true }
+    )
+
+    expect(Result.isError(result)).toBe(true)
+    if (Result.isError(result)) {
+      expect(result.error.message).toBe(errorMessage)
+    }
+  })
+
+  it('returns Result.err when callback throws directly', async () => {
+    // setup:
+    // - throw an error directly inside the callback
+    // expects:
+    // - the result should be Result.err with the error (not thrown to caller)
+    const directErrorMessage = 'Direct throw converted to Result.err'
+
+    const result = await adminTransactionWithResult(
+      async () => {
+        throw new Error(directErrorMessage)
+      },
+      { livemode: true }
+    )
+
+    expect(Result.isError(result)).toBe(true)
+    if (Result.isError(result)) {
+      expect(result.error.message).toBe(directErrorMessage)
+    }
+  })
+
+  it('provides ComprehensiveAdminTransactionParams with all required callbacks', async () => {
+    // setup:
+    // - verify the params have all expected properties
+    // expects:
+    // - params should have transaction, invalidateCache, emitEvent, enqueueLedgerCommand
+    const result = await adminTransactionWithResult(
+      async (params) => {
+        expect(typeof params.transaction.execute).toBe('function')
+        expect(typeof params.invalidateCache).toBe('function')
+        expect(typeof params.emitEvent).toBe('function')
+        expect(typeof params.enqueueLedgerCommand).toBe('function')
+        expect(params.userId).toBe('ADMIN')
+        expect(typeof params.livemode).toBe('boolean')
+        return Result.ok('params_verified')
+      },
+      { livemode: true }
+    )
+
+    expect(Result.isOk(result)).toBe(true)
+    if (Result.isOk(result)) {
+      expect(result.value).toBe('params_verified')
+    }
+  })
+
+  it('respects livemode option', async () => {
+    // setup:
+    // - call with livemode: false
+    // expects:
+    // - transaction should complete successfully with test mode context
+    const result = await adminTransactionWithResult(
+      async (params) => {
+        expect(params.livemode).toBe(false)
+        return Result.ok('testmode_success')
+      },
+      { livemode: false }
+    )
+
+    expect(Result.isOk(result)).toBe(true)
+    if (Result.isOk(result)) {
+      expect(result.value).toBe('testmode_success')
+    }
+  })
+
+  it('can be unwrapped at the caller level', async () => {
+    // setup:
+    // - call adminTransactionWithResult and then unwrap the result
+    // expects:
+    // - unwrap should return the value directly on success
+    const result = await adminTransactionWithResult(
+      async () => Result.ok('unwrap_test'),
+      { livemode: true }
+    )
+
+    const value = result.unwrap()
+    expect(value).toBe('unwrap_test')
+  })
+
+  it('unwrap throws when result is an error', async () => {
+    // setup:
+    // - call adminTransactionWithResult with Result.err and then try to unwrap
+    // expects:
+    // - unwrap should throw the error
+    const errorMessage = 'Error to be thrown by unwrap'
+
+    const result = await adminTransactionWithResult(
+      async () => Result.err(new Error(errorMessage)),
+      { livemode: true }
+    )
+
+    expect(() => result.unwrap()).toThrow(errorMessage)
   })
 })


### PR DESCRIPTION
## Summary

- Add `adminTransactionWithResult` and `authenticatedTransactionWithResult` functions
- These return `Result<T, Error>` directly instead of unwrapping internally
- Enables gradual migration to explicit Result handling without breaking existing code

## Why This Approach

The original Patch 7 attempted to rename `comprehensiveAdminTransaction` → `adminTransaction` and change the return type in one go, which required updating 100+ files simultaneously and caused merge conflicts.

This PR takes a backwards-compatible approach:
1. **Patch 7a (this PR)**: Add new Result-returning variants alongside existing functions
2. **Patches 7b-7g**: Gradually migrate callers to use new functions (can be parallelized)
3. **Patch 7h**: Remove old functions and rename new ones

## Usage

```typescript
// New pattern - explicit Result handling
const result = await adminTransactionWithResult(async ({ transaction }) => {
  // ... operations ...
  return Result.ok(value)
})

// At router/API boundary:
return result.unwrap()

// Or handle errors explicitly:
if (Result.isError(result)) {
  // handle error
}
```

## Test plan

- [x] `bun run check` passes
- [x] Existing tests continue to pass (no breaking changes)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Result-returning transaction variants for admin and authenticated flows to support explicit error handling without throwing. This enables gradual migration without touching existing call sites.

- **New Features**
  - Added adminTransactionWithResult and authenticatedTransactionWithResult that return Result<T, Error>.
  - Converts thrown errors inside transactions to Result.err; preserves existing tracing and transaction effects.
  - Callers can unwrap() at boundaries or handle errors explicitly.

<sup>Written for commit a4549e213701513d1db7cf598e601310296197e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

