### PR TITLE
Fix stripe-mock healthcheck in docker-compose.test.yml

### DIFF
--- a/platform/flowglad-next/docker-compose.test.yml
+++ b/platform/flowglad-next/docker-compose.test.yml
@@ -4,7 +4,6 @@
 # CI uses GitHub Actions services (defined in workflow files) instead.
 # Keep service versions in sync with .github/workflows/flowglad-next-sharded-unit-tests.yml
 #
-version: '3.8'
 services:
   postgres:
     image: postgres:15
@@ -27,7 +26,8 @@ services:
       - '12112:12112'
     healthcheck:
       # Use a test API key directly - this is not a real secret, just satisfies stripe-mock's format requirement
-      test: ['CMD-SHELL', 'curl -fsS -H "Authorization: Bearer sk_test_healthcheck" http://localhost:12111/v1/customers > /dev/null'] # gitleaks:allow
+      # Note: stripe-mock image doesn't have curl, but does have wget
+      test: ['CMD-SHELL', 'wget -q -O /dev/null --header="Authorization: Bearer sk_test_healthcheck" http://localhost:12111/v1/customers'] # gitleaks:allow
       interval: 2s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- Fix stripe-mock container healthcheck by using `wget` instead of `curl` (which isn't installed in the stripe-mock image)
- Remove obsolete `version: '3.8'` attribute from docker-compose file

## Test plan
- [x] Verified `bun run test:setup` now completes successfully with both containers healthy
- [x] Confirmed stripe-mock responds correctly to healthcheck requests using wget

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch stripe-mock healthcheck to wget in docker-compose.test.yml to prevent failing checks (curl isn’t available in the image). Remove the obsolete Compose version attribute to silence the deprecation warning; test setup now runs with both containers healthy.

<sup>Written for commit bee382f573361a48c49f644be0bcb8823210e038. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

