### PR TITLE
[result-migration] Patch 7c: Migrate Server Mutations

### DIFF
--- a/platform/flowglad-next/src/server/mutations/attemptDiscountCode.ts
+++ b/platform/flowglad-next/src/server/mutations/attemptDiscountCode.ts
@@ -2,7 +2,7 @@ import { CheckoutSessionType } from '@db-core/enums'
 import { attemptDiscountCodeInputSchema } from '@db-core/schema/discounts'
 import { Result } from 'better-result'
 import * as R from 'ramda'
-import { comprehensiveAdminTransaction } from '@/db/adminTransaction'
+import { adminTransactionWithResult } from '@/db/adminTransaction'
 import { selectDiscounts } from '@/db/tableMethods/discountMethods'
 import { selectProducts } from '@/db/tableMethods/productMethods'
 import {
@@ -30,96 +30,97 @@ export const attemptDiscountCode = publicProcedure
             type: CheckoutSessionType.Purchase,
           }
 
-    const isValid = await comprehensiveAdminTransaction(
-      async (ctx) => {
-        const { transaction } = ctx
-        if ('invoiceId' in input) {
-          throw new Error(
+    const result = await adminTransactionWithResult(async (ctx) => {
+      const { transaction } = ctx
+      if ('invoiceId' in input) {
+        return Result.err(
+          new Error(
             `Invoice checkout flow does not support discount codes. Invoice id: ${input.invoiceId}`
           )
-        }
-        const checkoutSession = await findCheckoutSession(
-          findInput,
+        )
+      }
+      const checkoutSession = await findCheckoutSession(
+        findInput,
+        transaction
+      )
+
+      if (!checkoutSession) {
+        return Result.ok(false)
+      }
+
+      const updateCheckoutSessionDiscount = (
+        discountId: string | null
+      ) => {
+        return editCheckoutSession(
+          {
+            checkoutSession: { ...checkoutSession, discountId },
+            purchaseId: R.propOr(null, 'purchaseId', input),
+          },
+          ctx
+        )
+      }
+
+      // Get the pricing model ID for this checkout
+      let pricingModelId: string | null = null
+      let organizationId: string | null = null
+
+      if ('productId' in input) {
+        const products = await selectProducts(
+          { id: input.productId },
           transaction
         )
-
-        if (!checkoutSession) {
-          return Result.ok(false)
+        const product = products[0]
+        if (product) {
+          pricingModelId = product.pricingModelId
+          organizationId = product.organizationId
         }
-
-        const updateCheckoutSessionDiscount = (
-          discountId: string | null
-        ) => {
-          return editCheckoutSession(
-            {
-              checkoutSession: { ...checkoutSession, discountId },
-              purchaseId: R.propOr(null, 'purchaseId', input),
-            },
-            ctx
-          )
-        }
-
-        // Get the pricing model ID for this checkout
-        let pricingModelId: string | null = null
-        let organizationId: string | null = null
-
-        if ('productId' in input) {
-          const products = await selectProducts(
-            { id: input.productId },
-            transaction
-          )
-          const product = products[0]
-          if (product) {
-            pricingModelId = product.pricingModelId
-            organizationId = product.organizationId
-          }
-        } else if ('purchaseId' in input) {
-          const purchaseResult = await selectPurchaseById(
+      } else if ('purchaseId' in input) {
+        const purchaseResult = await selectPurchaseById(
+          input.purchaseId,
+          transaction
+        )
+        if (Result.isOk(purchaseResult)) {
+          const purchase = purchaseResult.value
+          organizationId = purchase.organizationId
+          pricingModelId = await derivePricingModelIdFromPurchase(
             input.purchaseId,
             transaction
           )
-          if (Result.isOk(purchaseResult)) {
-            const purchase = purchaseResult.value
-            organizationId = purchase.organizationId
-            pricingModelId = await derivePricingModelIdFromPurchase(
-              input.purchaseId,
-              transaction
-            )
-          }
         }
-
-        if (!pricingModelId || !organizationId) {
-          await updateCheckoutSessionDiscount(null)
-          return Result.ok(false)
-        }
-
-        // Find active discounts with matching code AND pricing model
-        const matchingDiscounts = await selectDiscounts(
-          {
-            code: input.code,
-            pricingModelId,
-            active: true,
-          },
-          transaction
-        )
-
-        const discount = matchingDiscounts[0]
-
-        if (!discount) {
-          await updateCheckoutSessionDiscount(null)
-          return Result.ok(false)
-        }
-
-        // Verify organization matches
-        if (discount.organizationId !== organizationId) {
-          await updateCheckoutSessionDiscount(null)
-          return Result.ok(false)
-        }
-
-        await updateCheckoutSessionDiscount(discount.id)
-        return Result.ok(true)
       }
-    )
 
+      if (!pricingModelId || !organizationId) {
+        await updateCheckoutSessionDiscount(null)
+        return Result.ok(false)
+      }
+
+      // Find active discounts with matching code AND pricing model
+      const matchingDiscounts = await selectDiscounts(
+        {
+          code: input.code,
+          pricingModelId,
+          active: true,
+        },
+        transaction
+      )
+
+      const discount = matchingDiscounts[0]
+
+      if (!discount) {
+        await updateCheckoutSessionDiscount(null)
+        return Result.ok(false)
+      }
+
+      // Verify organization matches
+      if (discount.organizationId !== organizationId) {
+        await updateCheckoutSessionDiscount(null)
+        return Result.ok(false)
+      }
+
+      await updateCheckoutSessionDiscount(discount.id)
+      return Result.ok(true)
+    })
+
+    const isValid = result.unwrap()
     return { isValid }
   })

--- a/platform/flowglad-next/src/server/mutations/clearDiscountCode.ts
+++ b/platform/flowglad-next/src/server/mutations/clearDiscountCode.ts
@@ -1,6 +1,6 @@
 import { productIdOrPurchaseIdSchema } from '@db-core/schema/discounts'
 import { Result } from 'better-result'
-import { comprehensiveAdminTransaction } from '@/db/adminTransaction'
+import { adminTransactionWithResult } from '@/db/adminTransaction'
 import { publicProcedure } from '@/server/trpc'
 import { editCheckoutSession } from '@/utils/bookkeeping/checkoutSessions'
 import {
@@ -11,7 +11,7 @@ import {
 export const clearDiscountCode = publicProcedure
   .input(productIdOrPurchaseIdSchema)
   .mutation(async ({ input }) => {
-    return comprehensiveAdminTransaction(async (ctx) => {
+    const result = await adminTransactionWithResult(async (ctx) => {
       const { transaction } = ctx
       // FIXME: find a more elegant way to model this.
       const checkoutSession =
@@ -41,4 +41,5 @@ export const clearDiscountCode = publicProcedure
       )
       return Result.ok(true)
     })
+    return result.unwrap()
   })

--- a/platform/flowglad-next/src/server/mutations/confirmCheckoutSession.ts
+++ b/platform/flowglad-next/src/server/mutations/confirmCheckoutSession.ts
@@ -1,6 +1,6 @@
 import { Result } from 'better-result'
 import { z } from 'zod'
-import { comprehensiveAdminTransaction } from '@/db/adminTransaction'
+import { adminTransactionWithResult } from '@/db/adminTransaction'
 import { publicProcedure } from '@/server/trpc'
 import { confirmCheckoutSessionTransaction } from '@/utils/bookkeeping/confirmCheckoutSession'
 
@@ -16,11 +16,12 @@ const confirmCheckoutSessionInputSchema = z.object({
 export const confirmCheckoutSession = publicProcedure
   .input(confirmCheckoutSessionInputSchema)
   .mutation(async ({ input }) => {
-    return comprehensiveAdminTransaction(async (ctx) => {
-      const result = await confirmCheckoutSessionTransaction(
+    const result = await adminTransactionWithResult(async (ctx) => {
+      const value = await confirmCheckoutSessionTransaction(
         input,
         ctx
       )
-      return Result.ok(result)
+      return Result.ok(value)
     })
+    return result.unwrap()
   })

--- a/platform/flowglad-next/src/server/mutations/editCheckoutSession.ts
+++ b/platform/flowglad-next/src/server/mutations/editCheckoutSession.ts
@@ -1,14 +1,15 @@
 import { editCheckoutSessionInputSchema } from '@db-core/schema/checkoutSessions'
 import { Result } from 'better-result'
-import { comprehensiveAdminTransaction } from '@/db/adminTransaction'
+import { adminTransactionWithResult } from '@/db/adminTransaction'
 import { publicProcedure } from '@/server/trpc'
 import { editCheckoutSession as editCheckoutSessionFn } from '@/utils/bookkeeping/checkoutSessions'
 
 export const editCheckoutSession = publicProcedure
   .input(editCheckoutSessionInputSchema)
   .mutation(async ({ input }) => {
-    return comprehensiveAdminTransaction(async (ctx) => {
-      const result = await editCheckoutSessionFn(input, ctx)
-      return Result.ok(result)
+    const result = await adminTransactionWithResult(async (ctx) => {
+      const value = await editCheckoutSessionFn(input, ctx)
+      return Result.ok(value)
     })
+    return result.unwrap()
   })


### PR DESCRIPTION
## Summary

Migrate server mutation files from exception-based error handling (`comprehensiveAdminTransaction`) to Result-based error handling (`adminTransactionWithResult`) for explicit error control at boundaries.

### Changes

- **attemptDiscountCode.ts**: Convert `throw new Error(...)` to `Result.err(...)`, add `.unwrap()` at mutation boundary
- **clearDiscountCode.ts**: Replace `comprehensiveAdminTransaction` with `adminTransactionWithResult`, add `.unwrap()`
- **confirmCheckoutSession.ts**: Replace `comprehensiveAdminTransaction` with `adminTransactionWithResult`, add `.unwrap()`
- **editCheckoutSession.ts**: Replace `comprehensiveAdminTransaction` with `adminTransactionWithResult`, add `.unwrap()`

### Why

This enables procedures with multiple transactions to handle errors gracefully between them. The `adminTransactionWithResult` function returns `Result<T, Error>` instead of unwrapping automatically, allowing callers to:
- Chain multiple transactions and handle errors between them
- Return errors to callers without throwing
- Explicitly unwrap at the TRPC router boundary

### Dependencies

Depends on Patch 7a which added `adminTransactionWithResult` and `authenticatedTransactionWithResult` functions.

## Test plan

- [x] `bun run check` passes (lint, typecheck, registry validation)
- [ ] Manual testing of checkout flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated server mutations to Result-based transactions for explicit error handling and clean unwrapping at the TRPC boundary. This reduces thrown errors and makes multi-transaction flows safer.

- **Refactors**
  - attemptDiscountCode: use adminTransactionWithResult; convert throws to Result.err; unwrap at return.
  - clearDiscountCode: switch to adminTransactionWithResult; unwrap at return.
  - confirmCheckoutSession: switch to adminTransactionWithResult; unwrap at return.
  - editCheckoutSession: switch to adminTransactionWithResult; unwrap at return.

<sup>Written for commit dbeb2d3ef84c867ff6b4291c83bd3baed773cf8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

