### PR TITLE
[result-migration] Patch 7b: Migrate Server Routers

### DIFF
--- a/platform/flowglad-next/src/server/routers/productsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/productsRouter.ts
@@ -21,7 +21,6 @@ import {
   authenticatedProcedureComprehensiveTransaction,
   authenticatedProcedureTransaction,
   authenticatedTransaction,
-  comprehensiveAuthenticatedTransaction,
 } from '@/db/authenticatedTransaction'
 import { selectMembershipAndOrganizations } from '@/db/tableMethods/membershipMethods'
 import { selectPricesProductsAndPricingModelsForOrganization } from '@/db/tableMethods/priceMethods'

--- a/platform/flowglad-next/src/server/routers/subscriptionsRouter.ts
+++ b/platform/flowglad-next/src/server/routers/subscriptionsRouter.ts
@@ -36,7 +36,7 @@ import {
   authenticatedProcedureComprehensiveTransaction,
   authenticatedProcedureTransaction,
   authenticatedTransaction,
-  comprehensiveAuthenticatedTransaction,
+  authenticatedTransactionWithResult,
 } from '@/db/authenticatedTransaction'
 import { selectBillingPeriodById } from '@/db/tableMethods/billingPeriodMethods'
 import {
@@ -430,8 +430,8 @@ const adjustSubscriptionProcedure = protectedProcedure
     // This triggers the billing run but doesn't wait for it
     // Cache invalidations are handled automatically by the comprehensive transaction
     // Domain errors are automatically converted to TRPCErrors by domainErrorMiddleware
-    const adjustmentResult =
-      await comprehensiveAuthenticatedTransaction(
+    const adjustmentResult = (
+      await authenticatedTransactionWithResult(
         async (transactionCtx) => {
           return adjustSubscription(
             input,
@@ -443,6 +443,7 @@ const adjustSubscriptionProcedure = protectedProcedure
           apiKey: ctx.apiKey,
         }
       )
+    ).unwrap()
 
     const {
       subscription,


### PR DESCRIPTION
## Summary

- Migrate server router files from `comprehensiveAuthenticatedTransaction` and `comprehensiveAdminTransaction` to `authenticatedTransactionWithResult` and `adminTransactionWithResult`
- Add explicit `.unwrap()` at router boundaries to convert Result types back to exceptions for TRPC error handling
- Remove unused import from productsRouter.ts

## Files Changed

| File | Changes |
|------|---------|
| `subscriptionsRouter.ts` | Migrate `adjustSubscription` procedure |
| `organizationsRouter.ts` | Migrate `createOrganization` procedure |
| `customerBillingPortalRouter.ts` | Migrate `cancelSubscription`, `uncancelSubscription`, and `setDefaultPaymentMethod` procedures |
| `productsRouter.ts` | Remove unused `comprehensiveAuthenticatedTransaction` import |

## Test plan

- [ ] `bun run check` passes (verified locally)
- [ ] Existing tests continue to pass
- [ ] Manual testing of affected procedures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates server routers to Result-based transactions and unwraps at router boundaries to standardize TRPC error handling. No behavior changes; errors are surfaced consistently.

- **Refactors**
  - Replaced comprehensive*Transaction with authenticatedTransactionWithResult and adminTransactionWithResult.
  - Added .unwrap() after transactions at router boundaries.
  - Updated procedures: adjustSubscription, createOrganization, cancelSubscription, uncancelSubscription, setDefaultPaymentMethod.
  - Removed unused import in productsRouter.

<sup>Written for commit 09774ad7aa01af936b3cabd485272d8fc68111b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

