### PR TITLE
Make database safety error message show actual script name

### DIFF
--- a/platform/flowglad-next/src/db/safety.ts
+++ b/platform/flowglad-next/src/db/safety.ts
@@ -68,6 +68,19 @@ export function maskDatabaseUrl(url: string): string {
 }
 
 /**
+ * Get the command to bypass the safety check.
+ * Uses npm_lifecycle_event when available (for `bun run <script>` commands),
+ * otherwise falls back to a generic placeholder.
+ */
+export function getBypassCommand(): string {
+  const scriptName = process.env.npm_lifecycle_event
+  if (scriptName) {
+    return `DANGEROUSLY_ALLOW_REMOTE_DB=1 bun run ${scriptName}`
+  }
+  return `DANGEROUSLY_ALLOW_REMOTE_DB=1 bun run <script>`
+}
+
+/**
  * Check if the safety check should be skipped based on environment.
  */
 export function shouldSkipSafetyCheck(): boolean {
@@ -101,7 +114,7 @@ Recognized local hosts:
 ${LOCAL_HOST_PATTERNS.map((p) => `  - ${p}`).join('\n')}
 
 To bypass this check:
-  DANGEROUSLY_ALLOW_REMOTE_DB=1 bun run <script>
+  ${getBypassCommand()}
 `
     throw new Error(message)
   }


### PR DESCRIPTION
## What Does this PR Do?

When bypassing the remote database safety check, the error message now shows the actual script name (e.g., `bun run dev`) instead of a generic placeholder. This makes it easier to copy-paste the bypass command directly and run it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the remote database safety error to display the actual script name (e.g., bun run dev), so the bypass command is copy-paste ready.
It uses npm_lifecycle_event when available and falls back to a placeholder otherwise.

<sup>Written for commit 54783cdaff255316c6e1c6c2a93881d761c56f3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal safety command handling by centralizing configuration logic for better maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->