### PR TITLE
Remove needs-review label when PR is closed

### DIFF
--- a/.github/workflows/pr-closed-cleanup.yml
+++ b/.github/workflows/pr-closed-cleanup.yml
@@ -1,0 +1,40 @@
+name: PR Closed Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  remove-needs-review-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Remove needs-review label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'needs-review'
+              });
+              console.log('Removed needs-review label from closed PR');
+            } catch (e) {
+              // Label might not exist on this PR, that's fine
+              console.log('Label removal skipped:', e.message);
+            }
+
+  all-jobs-succeed:
+    runs-on: ubuntu-latest
+    needs: [remove-needs-review-label]
+    if: always()
+    steps:
+      - name: Verify all jobs succeeded
+        run: |
+          if [ "${{ needs.remove-needs-review-label.result }}" != "success" ] && [ "${{ needs.remove-needs-review-label.result }}" != "skipped" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## What Does this PR Do?

Automatically removes the `needs-review` label when any PR is closed, whether merged or dismissed. This ensures that no closed PRs remain in the needs review queue.

The new workflow (`pr-closed-cleanup.yml`) triggers on all PR close events and gracefully handles cases where the label doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically remove the needs-review label when any PR is closed to keep the review queue clean. Works for merged and dismissed PRs, and safely skips if the label isn't present.

- **New Features**
  - Added pr-closed-cleanup.yml GitHub Action triggered on pull_request.closed.
  - Removes the needs-review label via actions/github-script with graceful error handling.
  - Includes a follow-up job that verifies the removal step succeeded or was skipped.

<sup>Written for commit 8c3c94f9e815fc3956f12f820cae68af3f4065e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated label management for closed pull requests to streamline repository maintenance workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->