### PR TITLE
cli: Add credential storage implementation

### DIFF
--- a/packages/flowglad/src/cli/auth/config.test.ts
+++ b/packages/flowglad/src/cli/auth/config.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, rm, stat } from 'node:fs/promises'
+import { chmod, mkdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -172,6 +172,19 @@ describe('CLI credential storage', () => {
       expect(loaded?.userId).toBe('user_test_123')
       expect(loaded?.email).toBe('test@example.com')
       expect(loaded?.name).toBe('Test User')
+    })
+
+    it('returns null when credentials file contains invalid JSON', async () => {
+      const credentialsPath = getCredentialsPath()
+
+      // Write corrupted JSON directly
+      await writeFile(credentialsPath, 'not valid json {{{', {
+        mode: 0o600,
+      })
+
+      const result = await loadCredentials()
+
+      expect(result).toBeNull()
     })
   })
 


### PR DESCRIPTION
## What Does this PR Do?

Implements credential storage for the Flowglad CLI with security-first design. Stores both refresh tokens (Better Auth session) and optional access tokens (Unkey API keys) with atomic writes, proper file permissions (600 for files, 700 for directories), and graceful handling of corrupted files. Includes comprehensive tests covering all credential operations, token expiration checks, and edge cases like missing files and invalid JSON.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds secure credential storage for the Flowglad CLI. Stores refresh and optional access tokens with atomic writes, strict permissions, and safe reads.

- **New Features**
  - Credential schema with refresh token; optional access token plus org/pricing fields.
  - Config dir (~/.flowglad) helpers that create the dir and enforce 700 perms.
  - Atomic save in the same dir; credentials.json written with 600 perms.
  - Safe load (null on missing/invalid JSON), clear without error, and a refresh-token expiry check with buffer.
  - Tests cover read/write, permission fixes, corrupted files, and expiration logic.

<sup>Written for commit 59aa2c68661ea5aa7f3ae888f2dee26a4404101a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

