### PR TITLE
Fix mock server health check to use wget instead of curl

### DIFF
--- a/.github/workflows/flowglad-next-sharded-unit-tests.yml
+++ b/.github/workflows/flowglad-next-sharded-unit-tests.yml
@@ -87,7 +87,7 @@ jobs:
           - 9002:9002
           - 9003:9003
         options: >-
-          --health-cmd "curl -f http://localhost:9001/health || exit 1"
+          --health-cmd "wget -q --spider http://localhost:9001/health || exit 1"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
## Summary
- The mock server Docker image uses alpine which doesn't include `curl` by default
- CI health checks were failing because they tried to use `curl`
- Changed health check command from `curl -f` to `wget -q --spider`

## Context
This is a one-line fix extracted from PR #1823 to unblock other PRs that are failing due to mock server health check failures.

## Test plan
- [ ] CI should pass with the updated health check command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the CI mock server health check from curl to wget (-q --spider) to match the Alpine-based image. This fixes failing health checks in the sharded unit test workflow and unblocks other PRs.

<sup>Written for commit 2c7bebf4a3eef3736deecc7fcb5fa41305aaf5e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal health check monitoring in CI/CD processes.

**Note:** This is an infrastructure update with no visible impact to end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->