### PR TITLE
[wire-recomputation-to-event-push] Patch 2: Structured Dependency Types

### DIFF
--- a/platform/flowglad-next/src/utils/dependency.ts
+++ b/platform/flowglad-next/src/utils/dependency.ts
@@ -1,0 +1,277 @@
+/**
+ * Structured dependency types for cache invalidation and sync events.
+ *
+ * ALL dependencies are typed objects with payloads - no string construction at call sites.
+ * Cache keys are derived internally from structured objects via `dependencyToCacheKey()`.
+ *
+ * The `syncEnabled` discriminator determines:
+ * - Compile time: overload resolution for sync-aware functions
+ * - Runtime: whether to queue sync events on invalidation
+ */
+
+// ============================================================================
+// Base Types
+// ============================================================================
+
+/**
+ * Base type for dependencies that trigger sync events on invalidation.
+ * These dependencies represent data that merchants want to replicate locally.
+ */
+export interface SyncEnabledDependency<
+  TType extends string,
+  TPayload,
+> {
+  readonly type: TType
+  readonly payload: TPayload
+  readonly syncEnabled: true
+}
+
+/**
+ * Base type for dependencies that only invalidate cache (no sync).
+ * These dependencies represent internal/system data not exposed via sync API.
+ */
+export interface CacheOnlyDependency<TType extends string, TPayload> {
+  readonly type: TType
+  readonly payload: TPayload
+  readonly syncEnabled: false
+}
+
+// ============================================================================
+// Sync-Enabled Dependency Types
+// ============================================================================
+
+/**
+ * Dependency for a customer's subscriptions.
+ * Invalidate when subscriptions for this customer change (create/delete/update).
+ */
+export type CustomerSubscriptionsDep = SyncEnabledDependency<
+  'customerSubscriptions',
+  { customerId: string }
+>
+
+/**
+ * Dependency for a single subscription.
+ * Invalidate when this subscription's content changes (status, dates, items, etc.).
+ */
+export type SubscriptionDep = SyncEnabledDependency<
+  'subscription',
+  { subscriptionId: string }
+>
+
+// ============================================================================
+// Cache-Only Dependency Types
+// ============================================================================
+
+/**
+ * Dependency for organization settings.
+ * Cache-only: not exposed via sync API.
+ */
+export type OrganizationSettingsDep = CacheOnlyDependency<
+  'organizationSettings',
+  { orgId: string }
+>
+
+/**
+ * Dependency for API key lookups.
+ * Cache-only: sensitive data not exposed via sync API.
+ */
+export type ApiKeyLookupDep = CacheOnlyDependency<
+  'apiKeyLookup',
+  { keyHash: string }
+>
+
+// ============================================================================
+// Union Types
+// ============================================================================
+
+/**
+ * Union of all sync-enabled dependency types.
+ * Extend this as new sync-enabled types are added.
+ */
+export type SyncDependency =
+  | CustomerSubscriptionsDep
+  | SubscriptionDep
+
+/**
+ * Union of all cache-only dependency types.
+ * Extend this as new cache-only types are added.
+ */
+export type CacheDependency =
+  | OrganizationSettingsDep
+  | ApiKeyLookupDep
+
+/**
+ * Union of all dependency types.
+ */
+export type AnyDependency = SyncDependency | CacheDependency
+
+// ============================================================================
+// Helper Types
+// ============================================================================
+
+/**
+ * Map of sync dependency type names to their payload types.
+ * Used by `SyncPayload<T>` to extract payload type by dependency type name.
+ */
+interface SyncPayloadMap {
+  customerSubscriptions: CustomerSubscriptionsDep['payload']
+  subscription: SubscriptionDep['payload']
+}
+
+/**
+ * Extract the payload type for a sync-enabled dependency by its type name.
+ *
+ * @example
+ * type CustomerInput = SyncPayload<'customerSubscriptions'>
+ * // { customerId: string }
+ */
+export type SyncPayload<T extends keyof SyncPayloadMap> =
+  SyncPayloadMap[T]
+
+/**
+ * Extract the dependency type name for all sync-enabled dependencies.
+ */
+export type SyncDependencyType = SyncDependency['type']
+
+// ============================================================================
+// Sync Emission Context
+// ============================================================================
+
+/**
+ * Context passed to sync emission handlers when dependencies are invalidated.
+ * Contains information needed to compute which sync events to emit.
+ */
+export interface SyncEmissionContext {
+  /**
+   * The dependency that was invalidated.
+   */
+  readonly dependency: SyncDependency
+
+  /**
+   * Timestamp when the invalidation occurred.
+   */
+  readonly invalidatedAt: Date
+
+  /**
+   * Optional transaction ID for correlation.
+   */
+  readonly transactionId?: string
+}
+
+// ============================================================================
+// Dependency Constructors
+// ============================================================================
+
+/**
+ * Factory functions for creating structured dependency objects.
+ *
+ * Use these instead of manually constructing dependency objects to ensure
+ * type safety and consistency.
+ *
+ * @example
+ * // Sync-enabled dependencies
+ * const dep1 = Dependency.customerSubscriptions({ customerId: 'cust_123' })
+ * const dep2 = Dependency.subscription({ subscriptionId: 'sub_456' })
+ *
+ * // Cache-only dependencies
+ * const dep3 = Dependency.organizationSettings({ orgId: 'org_789' })
+ * const dep4 = Dependency.apiKeyLookup({ keyHash: 'abc123' })
+ */
+export const Dependency = {
+  // === Sync-enabled ===
+
+  /**
+   * Create a customer subscriptions dependency.
+   * Sync-enabled: triggers sync events on invalidation.
+   */
+  customerSubscriptions: (payload: {
+    customerId: string
+  }): CustomerSubscriptionsDep => ({
+    type: 'customerSubscriptions',
+    payload,
+    syncEnabled: true,
+  }),
+
+  /**
+   * Create a subscription dependency.
+   * Sync-enabled: triggers sync events on invalidation.
+   */
+  subscription: (payload: {
+    subscriptionId: string
+  }): SubscriptionDep => ({
+    type: 'subscription',
+    payload,
+    syncEnabled: true,
+  }),
+
+  // === Cache-only ===
+
+  /**
+   * Create an organization settings dependency.
+   * Cache-only: no sync events on invalidation.
+   */
+  organizationSettings: (payload: {
+    orgId: string
+  }): OrganizationSettingsDep => ({
+    type: 'organizationSettings',
+    payload,
+    syncEnabled: false,
+  }),
+
+  /**
+   * Create an API key lookup dependency.
+   * Cache-only: no sync events on invalidation.
+   */
+  apiKeyLookup: (payload: { keyHash: string }): ApiKeyLookupDep => ({
+    type: 'apiKeyLookup',
+    payload,
+    syncEnabled: false,
+  }),
+} as const
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Derive a Redis cache key from a structured dependency.
+ *
+ * The key format is: `${type}:${payloadKey}:${payloadValue}`
+ * For dependencies with multiple payload fields, values are joined with ':'.
+ *
+ * @example
+ * dependencyToCacheKey(Dependency.customerSubscriptions({ customerId: 'cust_123' }))
+ * // => 'customerSubscriptions:cust_123'
+ *
+ * dependencyToCacheKey(Dependency.subscription({ subscriptionId: 'sub_456' }))
+ * // => 'subscription:sub_456'
+ */
+export function dependencyToCacheKey(dep: AnyDependency): string {
+  const payloadValues = Object.values(dep.payload)
+  return `${dep.type}:${payloadValues.join(':')}`
+}
+
+/**
+ * Type guard to check if a dependency is sync-enabled.
+ *
+ * @example
+ * const dep = Dependency.customerSubscriptions({ customerId: 'cust_123' })
+ * if (isSyncDependency(dep)) {
+ *   // dep is narrowed to SyncDependency
+ *   console.log('Will trigger sync:', dep.type)
+ * }
+ */
+export function isSyncDependency(
+  dep: AnyDependency
+): dep is SyncDependency {
+  return dep.syncEnabled === true
+}
+
+/**
+ * Type guard to check if a dependency is cache-only.
+ */
+export function isCacheOnlyDependency(
+  dep: AnyDependency
+): dep is CacheDependency {
+  return dep.syncEnabled === false
+}

--- a/platform/flowglad-next/src/utils/dependency.unit.test.ts
+++ b/platform/flowglad-next/src/utils/dependency.unit.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  type AnyDependency,
+  type CacheDependency,
+  type CustomerSubscriptionsDep,
+  Dependency,
+  dependencyToCacheKey,
+  isCacheOnlyDependency,
+  isSyncDependency,
+  type OrganizationSettingsDep,
+  type SubscriptionDep,
+  type SyncDependency,
+  type SyncPayload,
+} from '@/utils/dependency'
+
+describe('Dependency', () => {
+  describe('customerSubscriptions', () => {
+    it('creates a sync-enabled dependency with the correct type, payload, and syncEnabled flag', () => {
+      const dep = Dependency.customerSubscriptions({
+        customerId: 'cust_123',
+      })
+
+      expect(dep.type).toBe('customerSubscriptions')
+      expect(dep.payload).toEqual({ customerId: 'cust_123' })
+      expect(dep.syncEnabled).toBe(true)
+
+      // Type-level check: dep should be assignable to CustomerSubscriptionsDep
+      const _typedDep: CustomerSubscriptionsDep = dep
+      void _typedDep
+    })
+  })
+
+  describe('subscription', () => {
+    it('creates a sync-enabled dependency with the correct type, payload, and syncEnabled flag', () => {
+      const dep = Dependency.subscription({
+        subscriptionId: 'sub_456',
+      })
+
+      expect(dep.type).toBe('subscription')
+      expect(dep.payload).toEqual({ subscriptionId: 'sub_456' })
+      expect(dep.syncEnabled).toBe(true)
+
+      // Type-level check: dep should be assignable to SubscriptionDep
+      const _typedDep: SubscriptionDep = dep
+      void _typedDep
+    })
+  })
+
+  describe('organizationSettings', () => {
+    it('creates a cache-only dependency with the correct type, payload, and syncEnabled flag', () => {
+      const dep = Dependency.organizationSettings({
+        orgId: 'org_789',
+      })
+
+      expect(dep.type).toBe('organizationSettings')
+      expect(dep.payload).toEqual({ orgId: 'org_789' })
+      expect(dep.syncEnabled).toBe(false)
+
+      // Type-level check: dep should be assignable to OrganizationSettingsDep
+      const _typedDep: OrganizationSettingsDep = dep
+      void _typedDep
+    })
+  })
+
+  describe('apiKeyLookup', () => {
+    it('creates a cache-only dependency with the correct type, payload, and syncEnabled flag', () => {
+      const dep = Dependency.apiKeyLookup({ keyHash: 'abc123hash' })
+
+      expect(dep.type).toBe('apiKeyLookup')
+      expect(dep.payload).toEqual({ keyHash: 'abc123hash' })
+      expect(dep.syncEnabled).toBe(false)
+    })
+  })
+})
+
+describe('dependencyToCacheKey', () => {
+  it('derives the correct Redis key for customerSubscriptions dependency', () => {
+    const dep = Dependency.customerSubscriptions({
+      customerId: 'cust_123',
+    })
+    const key = dependencyToCacheKey(dep)
+
+    expect(key).toBe('customerSubscriptions:cust_123')
+  })
+
+  it('derives the correct Redis key for subscription dependency', () => {
+    const dep = Dependency.subscription({ subscriptionId: 'sub_456' })
+    const key = dependencyToCacheKey(dep)
+
+    expect(key).toBe('subscription:sub_456')
+  })
+
+  it('derives the correct Redis key for organizationSettings dependency', () => {
+    const dep = Dependency.organizationSettings({ orgId: 'org_789' })
+    const key = dependencyToCacheKey(dep)
+
+    expect(key).toBe('organizationSettings:org_789')
+  })
+
+  it('derives the correct Redis key for apiKeyLookup dependency', () => {
+    const dep = Dependency.apiKeyLookup({ keyHash: 'abc123hash' })
+    const key = dependencyToCacheKey(dep)
+
+    expect(key).toBe('apiKeyLookup:abc123hash')
+  })
+})
+
+describe('isSyncDependency', () => {
+  it('returns true for customerSubscriptions dependency', () => {
+    const dep = Dependency.customerSubscriptions({
+      customerId: 'cust_123',
+    })
+
+    expect(isSyncDependency(dep)).toBe(true)
+
+    // Verify type narrowing works
+    if (isSyncDependency(dep)) {
+      const _narrowed: SyncDependency = dep
+      void _narrowed
+    }
+  })
+
+  it('returns true for subscription dependency', () => {
+    const dep = Dependency.subscription({ subscriptionId: 'sub_456' })
+
+    expect(isSyncDependency(dep)).toBe(true)
+  })
+
+  it('returns false for organizationSettings dependency', () => {
+    const dep = Dependency.organizationSettings({ orgId: 'org_789' })
+
+    expect(isSyncDependency(dep)).toBe(false)
+  })
+
+  it('returns false for apiKeyLookup dependency', () => {
+    const dep = Dependency.apiKeyLookup({ keyHash: 'abc123hash' })
+
+    expect(isSyncDependency(dep)).toBe(false)
+  })
+})
+
+describe('isCacheOnlyDependency', () => {
+  it('returns false for customerSubscriptions dependency', () => {
+    const dep = Dependency.customerSubscriptions({
+      customerId: 'cust_123',
+    })
+
+    expect(isCacheOnlyDependency(dep)).toBe(false)
+  })
+
+  it('returns true for organizationSettings dependency', () => {
+    const dep = Dependency.organizationSettings({ orgId: 'org_789' })
+
+    expect(isCacheOnlyDependency(dep)).toBe(true)
+
+    // Verify type narrowing works
+    if (isCacheOnlyDependency(dep)) {
+      const _narrowed: CacheDependency = dep
+      void _narrowed
+    }
+  })
+
+  it('returns true for apiKeyLookup dependency', () => {
+    const dep = Dependency.apiKeyLookup({ keyHash: 'abc123hash' })
+
+    expect(isCacheOnlyDependency(dep)).toBe(true)
+  })
+})
+
+describe('Type-level tests', () => {
+  it('SyncPayload extracts correct payload types', () => {
+    // These are compile-time checks - if they compile, the types work correctly
+
+    // SyncPayload<'customerSubscriptions'> should be { customerId: string }
+    type CustomerPayload = SyncPayload<'customerSubscriptions'>
+    const _customerPayload: CustomerPayload = {
+      customerId: 'cust_123',
+    }
+    void _customerPayload
+
+    // SyncPayload<'subscription'> should be { subscriptionId: string }
+    type SubPayload = SyncPayload<'subscription'>
+    const _subPayload: SubPayload = { subscriptionId: 'sub_456' }
+    void _subPayload
+
+    // If the above compiles, the test passes
+    expect(true).toBe(true)
+  })
+
+  it('AnyDependency accepts all dependency types', () => {
+    // All dependency types should be assignable to AnyDependency
+    const deps: AnyDependency[] = [
+      Dependency.customerSubscriptions({ customerId: 'cust_123' }),
+      Dependency.subscription({ subscriptionId: 'sub_456' }),
+      Dependency.organizationSettings({ orgId: 'org_789' }),
+      Dependency.apiKeyLookup({ keyHash: 'abc123hash' }),
+    ]
+
+    expect(deps).toHaveLength(4)
+  })
+
+  it('SyncDependency only accepts sync-enabled dependencies', () => {
+    // These should compile
+    const syncDeps: SyncDependency[] = [
+      Dependency.customerSubscriptions({ customerId: 'cust_123' }),
+      Dependency.subscription({ subscriptionId: 'sub_456' }),
+    ]
+
+    // This would NOT compile (and is correctly rejected by TypeScript):
+    // const invalidSyncDep: SyncDependency = Dependency.organizationSettings({ orgId: 'org_789' })
+
+    expect(syncDeps).toHaveLength(2)
+  })
+
+  it('CacheDependency only accepts cache-only dependencies', () => {
+    // These should compile
+    const cacheDeps: CacheDependency[] = [
+      Dependency.organizationSettings({ orgId: 'org_789' }),
+      Dependency.apiKeyLookup({ keyHash: 'abc123hash' }),
+    ]
+
+    // This would NOT compile (and is correctly rejected by TypeScript):
+    // const invalidCacheDep: CacheDependency = Dependency.customerSubscriptions({ customerId: 'cust_123' })
+
+    expect(cacheDeps).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Summary
- Add structured dependency types with `syncEnabled` discriminator for cache invalidation and sync events
- Create `Dependency` factory object for creating typed dependency objects
- Add `dependencyToCacheKey()` helper for Redis key derivation
- Add `isSyncDependency()` and `isCacheOnlyDependency()` type guards
- Add comprehensive unit tests for all dependency types and helpers

## Test plan
- [x] Run `bun test src/utils/dependency.unit.test.ts` - all 19 tests pass
- [x] Run `bun run check` - lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a structured dependency model with a syncEnabled discriminator to drive cache invalidation and sync event wiring. Adds typed constructors, cache key derivation, and guards with full unit tests.

- **New Features**
  - Base types: SyncEnabledDependency, CacheOnlyDependency
  - Dependency types: customerSubscriptions, subscription, organizationSettings, apiKeyLookup
  - Dependency factory for typed constructors
  - dependencyToCacheKey for Redis keys
  - Type guards: isSyncDependency, isCacheOnlyDependency
  - SyncPayload helper and SyncEmissionContext
  - Unit tests for constructors, guards, and key derivation

<sup>Written for commit 757f305f3e4d3d13917a2bd3ba616131d47eed10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced internal infrastructure to standardize dependency management and cache handling, providing factory methods for creating typed dependencies and utilities for cache key generation and runtime type classification.

* **Tests**
  * Added comprehensive unit test coverage for dependency utilities, validating creation, cache key generation, type classification, and type safety constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->