### PR TITLE
Fix yq installation permissions on GitHub runners

### DIFF
--- a/.github/workflows/base-ci-cd.yml
+++ b/.github/workflows/base-ci-cd.yml
@@ -301,8 +301,8 @@ jobs:
     steps:
       - name: Install yq (for YAML parsing)
         run: |
-          wget https://github.com/mikefarah/yq/releases/download/v4.50.1/yq_linux_amd64 -O /usr/local/bin/yq
-          chmod +x /usr/local/bin/yq
+          sudo wget https://github.com/mikefarah/yq/releases/download/v4.50.1/yq_linux_amd64 -O /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Run dependency check
         run: ./ci/check_job_dependencies.sh


### PR DESCRIPTION
## What Does this PR Do?

Adds sudo to wget and chmod commands when installing yq to /usr/local/bin. GitHub-hosted runners require elevated privileges to write to system paths, and the commands would fail without sudo due to permission restrictions on this directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes yq install permission errors on GitHub runners by adding sudo to wget and chmod in the workflow. This allows writing to /usr/local/bin and prevents the step from failing.

<sup>Written for commit 7158402d9f7120395fc79cd954fdd97ea14bbcf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to ensure build environment setup completes successfully with proper system-level permissions during automated deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->