### PR TITLE
Fix CLI default API URL to use app.flowglad.com

### DIFF
--- a/packages/flowglad/src/cli/commands/login.ts
+++ b/packages/flowglad/src/cli/commands/login.ts
@@ -11,7 +11,7 @@ import {
   requestDeviceCode,
 } from '../auth/deviceFlow'
 
-const DEFAULT_BASE_URL = 'https://flowglad.com'
+const DEFAULT_BASE_URL = 'https://app.flowglad.com'
 
 /**
  * Gets the base URL for the Flowglad API.

--- a/packages/flowglad/src/cli/commands/logout.ts
+++ b/packages/flowglad/src/cli/commands/logout.ts
@@ -6,7 +6,7 @@ import { clearCredentials, loadCredentials } from '../auth/config'
  * Can be overridden with FLOWGLAD_API_URL environment variable (used for testing/development).
  */
 const getApiUrl = (): string => {
-  return process.env.FLOWGLAD_API_URL ?? 'https://flowglad.com'
+  return process.env.FLOWGLAD_API_URL ?? 'https://app.flowglad.com'
 }
 
 /**


### PR DESCRIPTION
## What Does this PR Do?

Fixes the CLI login and logout commands to use the correct default API base URL (https://app.flowglad.com instead of https://flowglad.com). This ensures device flow authentication works correctly when no FLOWGLAD_API_URL environment variable is set.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated CLI login and logout to use https://app.flowglad.com as the default API base URL. Fixes device flow authentication when FLOWGLAD_API_URL is not set.

<sup>Written for commit ecc03ebfcf690846186d3697a9b0de74d8b427fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API endpoint configuration for CLI authentication commands to align with infrastructure changes. The platform now routes all authentication requests to the new app domain. All existing functionality, user features, and capabilities remain fully operational and unchanged with complete backward compatibility maintained.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->