### PR TITLE
Clean up stale vitest references and clarify bun:test usage

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -135,21 +135,11 @@ Please use the following guidelines when implementing new tests:
 
 ### Test Environments
 
-The test suite defaults to the `node` environment to ensure MSW (Mock Service Worker) can properly intercept HTTP requests for mocking external APIs like Stripe.
+This project uses **bun:test** for testing. The test suite defaults to the `node` environment to ensure MSW (Mock Service Worker) can properly intercept HTTP requests for mocking external APIs like Stripe.
 
-**Tests using React or DOM APIs** must include this directive at the top of the file:
-```typescript
-/**
- * @vitest-environment jsdom
- */
-```
+**Tests using React or DOM APIs** (React component tests, hook tests using `renderHook`) should use the happy-dom preloads configured in the test scripts. See `packages/react/bun.dom.preload.ts` and `packages/react/bun.frontend.setup.ts` for the DOM environment setup.
 
-This includes:
-- React component tests (`.test.tsx` files)
-- React hook tests using `renderHook` from `@testing-library/react`
-- Any test that needs DOM APIs like `document` or `window`
-
-This tells Vitest to run that specific test file in a jsdom environment.
+**Note:** Some packages under `packages/` (shared, server, flowglad) still use vitest. The main platform (`platform/flowglad-next/`) and `packages/react/` use bun:test.
 
 ### Parallel-Safe Test Patterns
 

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -14,6 +14,5 @@
       "@/*": ["./*"]
     }
   },
-  "types": ["vitest/globals", "@testing-library/jest-dom"],
-  "include": ["src", "./vitest.setup.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## What Does this PR Do?

Removes dead vitest configuration from packages/react/tsconfig.json and updates CLAUDE.md to clearly document bun:test as the primary test framework for the platform. The vitest types field was positioned outside compilerOptions (invalid) and vitest.setup.ts no longer exists. Platform uses bun:test for testing with happy-dom for React components. Clarifies that packages (shared, server, flowglad) still use vitest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies bun:test as the primary test framework for the platform and packages/react, updates DOM testing guidance to use happy‑dom preloads, and notes that shared/server/flowglad still use vitest. Removes stale vitest config from packages/react/tsconfig.json by deleting an invalid top‑level "types" field and the include for the deleted vitest.setup.ts.

<sup>Written for commit 65a32ac55405a55a118823307a3de3de8cd200ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing environment guidance for developers.

* **Chores**
  * Updated TypeScript configuration for build tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->