### PR TITLE
chore: Add protection headers

### DIFF
--- a/platform/flowglad-next/next.config.mjs
+++ b/platform/flowglad-next/next.config.mjs
@@ -62,7 +62,30 @@ const nextConfig = {
     // restrictions rather than using a global wildcard.
     //
     // Reference: https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing
-    return []
+    return [
+      {
+        // Apply security headers to all routes
+        source: '/:path*',
+        headers: [
+          {
+            // SECURITY: Prevent clickjacking attacks by disallowing iframe embedding.
+            // X-Frame-Options is supported by older browsers that don't support CSP frame-ancestors.
+            // Reference: https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/09-Testing_for_Clickjacking
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            // SECURITY: Modern clickjacking protection via CSP frame-ancestors directive.
+            // 'none' prevents embedding in any iframe, including same-origin.
+            // This is the CSP equivalent of X-Frame-Options: DENY and takes precedence
+            // in modern browsers that support it.
+            // Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
+            key: 'Content-Security-Policy',
+            value: "frame-ancestors 'none'",
+          },
+        ],
+      },
+    ]
   },
   experimental: {
     webpackMemoryOptimizations: true,


### PR DESCRIPTION
## Summary
- Adds `X-Frame-Options: DENY` header to prevent iframe embedding (legacy browser support)
- Adds `Content-Security-Policy: frame-ancestors 'none'` header (modern CSP standard)
- Mitigates clickjacking vulnerability reported for app.flowglad.com

## Context
A security researcher reported that app.flowglad.com could be embedded in third-party iframes, enabling potential clickjacking attacks. This fix prevents any external site from framing the application.

## Test plan
- [x] Verified locally that iframe embedding is blocked with fix applied
- [x] Verified locally that iframe embedding works without fix (vulnerable state)
- [ ] Deploy to staging and verify headers are present in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds clickjacking protection by blocking iframe embedding across all routes. Sets X-Frame-Options: DENY and Content-Security-Policy: frame-ancestors 'none' to cover legacy and modern browsers, mitigating the reported vulnerability on app.flowglad.com.

<sup>Written for commit 095af4a5a3480ee7ec98d9843d4aec18a5f1cf33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced application security by configuring protective headers across all routes to prevent clickjacking and unauthorized iframe embedding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->