### PR TITLE
[wire-recomputation-to-event-push] Patch 3: Syncable HOF with affectedBy

### DIFF
--- a/platform/flowglad-next/src/utils/redis.ts
+++ b/platform/flowglad-next/src/utils/redis.ts
@@ -183,6 +183,8 @@ export enum RedisKeyNamespace {
   ProductFeaturesByPricingModel = 'productFeaturesByPricingModel',
   // Sync stream for SSE event streaming
   SyncStream = 'syncStream',
+  // Cached Svix subscription checks (whether org has sync endpoints)
+  SyncSubscription = 'syncSubscription',
 }
 
 const evictionPolicy: Record<
@@ -257,6 +259,11 @@ const evictionPolicy: Record<
   [RedisKeyNamespace.SyncStream]: {
     maxlen: 100000, // Max 100k events per stream
     ttl: 60 * 60 * 24 * 7, // 7 days retention
+  },
+  // Cached Svix subscription checks (whether org has sync endpoints)
+  [RedisKeyNamespace.SyncSubscription]: {
+    max: 10000, // One per org
+    ttl: 60 * 5, // 5 minutes - balance between API cost and freshness
   },
 }
 

--- a/platform/flowglad-next/src/utils/syncable.ts
+++ b/platform/flowglad-next/src/utils/syncable.ts
@@ -1,0 +1,265 @@
+/**
+ * Syncable higher-order function for TRPC resolvers.
+ *
+ * This module provides the infrastructure for declaring which TRPC resolvers
+ * are "syncable" - meaning their outputs should be pushed to merchants via
+ * the sync event system when underlying data changes.
+ *
+ * Key concepts:
+ * - `syncable()` wraps a TRPC resolver and registers it for sync
+ * - `affectedBy` declares how to derive resolver inputs from invalidations
+ * - Registry populated at module load time (when TRPC router initializes)
+ */
+
+import type {
+  AnyDependency,
+  SyncDependency,
+  SyncPayload,
+} from '@/utils/dependency'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Sync dependency type names (what gets pushed over the wire) */
+type SyncDependencyType = SyncDependency['type']
+
+/** All dependency type names (including cache-only) */
+type DependencyType = AnyDependency['type']
+
+/**
+ * Configuration for a syncable resolver.
+ *
+ * @template TType - The sync dependency type this resolver handles
+ * @template TOutput - The resolver's output type
+ * @template TContext - The TRPC context type
+ */
+export interface SyncableConfig<
+  TType extends SyncDependencyType,
+  TOutput,
+  TContext,
+> {
+  /**
+   * The resolver function that fetches data for this sync type.
+   * Input type is enforced to match SyncPayload<TType>.
+   */
+  resolver: (opts: {
+    input: SyncPayload<TType>
+    ctx: TContext
+  }) => Promise<TOutput>
+
+  /**
+   * Declares which invalidation dependencies affect this sync type,
+   * and how to derive this resolver's input from each.
+   *
+   * Keys are dependency types that, when invalidated, should trigger
+   * recomputation of this sync type.
+   *
+   * Values are either:
+   * - 'direct': the invalidation payload IS the resolver input (1:1 mapping)
+   * - A function: computes the resolver input(s) from the invalidation payload
+   *
+   * The function form supports fan-out by returning an array of inputs.
+   */
+  affectedBy: {
+    [K in DependencyType]?:
+      | 'direct'
+      | ((params: {
+          payload: Extract<AnyDependency, { type: K }>['payload']
+          ctx: TContext
+        }) => Promise<SyncPayload<TType> | SyncPayload<TType>[]>)
+  }
+}
+
+/**
+ * Internal registry entry storing the resolver and its affectedBy mappings.
+ */
+interface SyncableRegistryEntry {
+  resolver: (opts: {
+    input: unknown
+    ctx: unknown
+  }) => Promise<unknown>
+  affectedBy: Record<
+    string,
+    | 'direct'
+    | ((params: {
+        payload: unknown
+        ctx: unknown
+      }) => Promise<unknown | unknown[]>)
+  >
+}
+
+// ============================================================================
+// Registry
+// ============================================================================
+
+/**
+ * Registry of all syncable configurations, populated at module load time.
+ *
+ * When TRPC routers are initialized, `syncable()` calls register their
+ * configurations here. This registry is used at runtime to:
+ * 1. Find which sync types are affected by a given invalidation
+ * 2. Run the affectedBy functions to compute resolver inputs
+ * 3. Execute resolvers and emit sync events
+ */
+export const syncableRegistry = new Map<
+  SyncDependencyType,
+  SyncableRegistryEntry
+>()
+
+// ============================================================================
+// Main API
+// ============================================================================
+
+/**
+ * Higher-order function that marks a TRPC resolver as syncable.
+ *
+ * TYPE SAFETY: The resolver's input type MUST match the payload type
+ * for the declared dependency type. This is enforced via SyncPayload<T>.
+ *
+ * At call time, registers this resolver and its affectedBy mappings in
+ * the global registry. The returned function is the original resolver,
+ * suitable for use in TRPC procedure definitions.
+ *
+ * When an invalidation dependency is triggered:
+ * 1. System finds all syncable types with matching affectedBy declarations
+ * 2. Runs the affectedBy function to compute resolver input(s)
+ * 3. Runs resolver with each computed input
+ * 4. Pushes results to sync stream
+ *
+ * @example
+ * export const getCustomerSubscriptions = protectedProcedure
+ *   .input(z.object({ customerId: z.string() }))
+ *   .query(
+ *     syncable('customerSubscriptions', {
+ *       resolver: async ({ input, ctx }) => {
+ *         return selectSubscriptionsWithDetails(input.customerId, ctx.transaction)
+ *       },
+ *       affectedBy: {
+ *         // Direct match - customerSubscriptions invalidation maps 1:1
+ *         customerSubscriptions: 'direct',
+ *
+ *         // Derived - when a subscription changes, look up its customer
+ *         subscription: async ({ payload, ctx }) => {
+ *           const sub = await getSubscription(payload.subscriptionId, ctx.transaction)
+ *           return { customerId: sub.customerId }
+ *         },
+ *       }
+ *     })
+ *   )
+ *
+ * @param dependencyType - The sync dependency type this resolver handles
+ * @param config - The resolver and affectedBy configuration
+ * @returns The resolver function (pass-through for TRPC procedure)
+ */
+export function syncable<
+  TType extends SyncDependencyType,
+  TOutput,
+  TContext,
+>(
+  dependencyType: TType,
+  config: SyncableConfig<TType, TOutput, TContext>
+): (opts: {
+  input: SyncPayload<TType>
+  ctx: TContext
+}) => Promise<TOutput> {
+  // Register in the global registry at call time
+  syncableRegistry.set(dependencyType, {
+    resolver: config.resolver as SyncableRegistryEntry['resolver'],
+    affectedBy:
+      config.affectedBy as SyncableRegistryEntry['affectedBy'],
+  })
+
+  // Return the resolver for use in TRPC procedure definition
+  return config.resolver
+}
+
+// ============================================================================
+// Query Functions
+// ============================================================================
+
+/**
+ * Result of finding syncables affected by an invalidation.
+ */
+export interface AffectedSyncable {
+  /** The sync type that should be recomputed */
+  syncType: SyncDependencyType
+  /** The affectedBy function or 'direct' marker */
+  affectedByFn:
+    | 'direct'
+    | ((params: {
+        payload: unknown
+        ctx: unknown
+      }) => Promise<unknown | unknown[]>)
+  /** The resolver function to execute */
+  resolver: (opts: {
+    input: unknown
+    ctx: unknown
+  }) => Promise<unknown>
+}
+
+/**
+ * Get all registered syncable configs that are affected by a given dependency type.
+ *
+ * Returns an array of { syncType, affectedByFn, resolver } for each syncable
+ * that has declared an `affectedBy` mapping for the given invalidation type.
+ *
+ * @example
+ * const affected = getSyncablesAffectedBy('subscription')
+ * // Returns array of syncables that declared affectedBy.subscription
+ *
+ * for (const { syncType, affectedByFn, resolver } of affected) {
+ *   const inputs = affectedByFn === 'direct'
+ *     ? [payload]
+ *     : await affectedByFn({ payload, ctx })
+ *   for (const input of Array.isArray(inputs) ? inputs : [inputs]) {
+ *     const data = await resolver({ input, ctx })
+ *     // emit sync event...
+ *   }
+ * }
+ *
+ * @param invalidationType - The dependency type that was invalidated
+ * @returns Array of affected syncables with their resolvers
+ */
+export function getSyncablesAffectedBy(
+  invalidationType: DependencyType
+): AffectedSyncable[] {
+  const results: AffectedSyncable[] = []
+
+  for (const [syncType, entry] of syncableRegistry) {
+    const affectedByFn = entry.affectedBy[invalidationType]
+    if (affectedByFn !== undefined) {
+      results.push({
+        syncType,
+        affectedByFn,
+        resolver: entry.resolver,
+      })
+    }
+  }
+
+  return results
+}
+
+/**
+ * Check if a sync dependency type has been registered.
+ *
+ * @param syncType - The sync dependency type to check
+ * @returns true if the type has been registered via syncable()
+ */
+export function isSyncTypeRegistered(
+  syncType: SyncDependencyType
+): boolean {
+  return syncableRegistry.has(syncType)
+}
+
+/**
+ * Get the registry entry for a specific sync type.
+ *
+ * @param syncType - The sync dependency type
+ * @returns The registry entry or undefined if not registered
+ */
+export function getSyncableConfig(
+  syncType: SyncDependencyType
+): SyncableRegistryEntry | undefined {
+  return syncableRegistry.get(syncType)
+}

--- a/platform/flowglad-next/src/utils/syncable.unit.test.ts
+++ b/platform/flowglad-next/src/utils/syncable.unit.test.ts
@@ -1,0 +1,390 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import {
+  getSyncableConfig,
+  getSyncablesAffectedBy,
+  isSyncTypeRegistered,
+  syncable,
+  syncableRegistry,
+} from './syncable'
+
+describe('syncable', () => {
+  beforeEach(() => {
+    // Clear registry between tests
+    syncableRegistry.clear()
+  })
+
+  it('registers resolver and affectedBy at call time', () => {
+    const mockResolver = async ({
+      input: _input,
+    }: {
+      input: { customerId: string }
+      ctx: unknown
+    }) => ({ data: [] })
+    const wrapped = syncable('customerSubscriptions', {
+      resolver: mockResolver,
+      affectedBy: {
+        customerSubscriptions: 'direct',
+        subscription: async ({ payload: _payload }) => ({
+          customerId: 'cust_123',
+        }),
+      },
+    })
+
+    expect(typeof wrapped).toBe('function')
+
+    const entry = syncableRegistry.get('customerSubscriptions')
+    expect(entry?.affectedBy.customerSubscriptions).toBe('direct')
+    expect(typeof entry?.affectedBy.subscription).toBe('function')
+  })
+
+  it('returns the original resolver function that can be invoked', async () => {
+    const expectedResult = { subscriptions: [{ id: 'sub_1' }] }
+    const mockResolver = async ({
+      input: _input,
+    }: {
+      input: { customerId: string }
+      ctx: { userId: string }
+    }) => expectedResult
+
+    const wrapped = syncable('customerSubscriptions', {
+      resolver: mockResolver,
+      affectedBy: {
+        customerSubscriptions: 'direct',
+      },
+    })
+
+    const result = await wrapped({
+      input: { customerId: 'cust_123' },
+      ctx: { userId: 'user_1' },
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it('overwrites previous registration when called twice with same type', () => {
+    const firstResolver = async ({
+      input: _input,
+    }: {
+      input: { customerId: string }
+      ctx: unknown
+    }) => ({
+      first: true,
+    })
+    const secondResolver = async ({
+      input: _input,
+    }: {
+      input: { customerId: string }
+      ctx: unknown
+    }) => ({
+      second: true,
+    })
+
+    syncable('customerSubscriptions', {
+      resolver: firstResolver,
+      affectedBy: { customerSubscriptions: 'direct' },
+    })
+
+    syncable('customerSubscriptions', {
+      resolver: secondResolver,
+      affectedBy: {
+        customerSubscriptions: 'direct',
+        subscription: async () => ({ customerId: 'derived' }),
+      },
+    })
+
+    expect(syncableRegistry.size).toBe(1)
+    const entry = syncableRegistry.get('customerSubscriptions')
+    expect(typeof entry?.affectedBy.subscription).toBe('function')
+  })
+})
+
+describe('getSyncablesAffectedBy', () => {
+  beforeEach(() => {
+    syncableRegistry.clear()
+  })
+
+  it('returns matching syncables when affectedBy declares the invalidation type', () => {
+    syncable('customerSubscriptions', {
+      resolver: async ({
+        input: _input,
+      }: {
+        input: { customerId: string }
+        ctx: unknown
+      }) => ({
+        data: [],
+      }),
+      affectedBy: {
+        customerSubscriptions: 'direct',
+        subscription: async ({ payload: _payload }) => ({
+          customerId: 'cust_123',
+        }),
+      },
+    })
+
+    const affected = getSyncablesAffectedBy('subscription')
+
+    expect(affected).toHaveLength(1)
+    expect(affected[0].syncType).toBe('customerSubscriptions')
+    expect(typeof affected[0].affectedByFn).toBe('function')
+    expect(typeof affected[0].resolver).toBe('function')
+  })
+
+  it('returns multiple syncables when multiple types are affected by same invalidation', () => {
+    syncable('customerSubscriptions', {
+      resolver: async ({
+        input: _input,
+      }: {
+        input: { customerId: string }
+        ctx: unknown
+      }) => ({
+        subscriptions: [],
+      }),
+      affectedBy: {
+        subscription: async ({ payload: _payload }) => ({
+          customerId: 'cust_from_sub',
+        }),
+      },
+    })
+
+    syncable('subscription', {
+      resolver: async ({
+        input: _input,
+      }: {
+        input: { subscriptionId: string }
+        ctx: unknown
+      }) => ({
+        subscription: null,
+      }),
+      affectedBy: {
+        subscription: 'direct',
+      },
+    })
+
+    const affected = getSyncablesAffectedBy('subscription')
+
+    expect(affected).toHaveLength(2)
+    const syncTypes = affected.map((a) => a.syncType).sort()
+    expect(syncTypes).toEqual([
+      'customerSubscriptions',
+      'subscription',
+    ])
+  })
+
+  it('returns empty array for unregistered invalidation type', () => {
+    syncable('customerSubscriptions', {
+      resolver: async ({
+        input: _input,
+      }: {
+        input: { customerId: string }
+        ctx: unknown
+      }) => ({
+        data: [],
+      }),
+      affectedBy: {
+        customerSubscriptions: 'direct',
+      },
+    })
+
+    // Cast to any since 'unknownType' is not a valid DependencyType
+    const affected = getSyncablesAffectedBy(
+      'unknownType' as 'customerSubscriptions'
+    )
+    expect(affected).toHaveLength(0)
+  })
+
+  it('returns empty array when registry is empty', () => {
+    const affected = getSyncablesAffectedBy('subscription')
+    expect(affected).toHaveLength(0)
+  })
+
+  it('returns direct marker as affectedByFn when mapping is direct', () => {
+    syncable('customerSubscriptions', {
+      resolver: async ({
+        input: _input,
+      }: {
+        input: { customerId: string }
+        ctx: unknown
+      }) => ({
+        data: [],
+      }),
+      affectedBy: {
+        customerSubscriptions: 'direct',
+      },
+    })
+
+    const affected = getSyncablesAffectedBy('customerSubscriptions')
+    expect(affected).toHaveLength(1)
+    expect(affected[0].affectedByFn).toBe('direct')
+  })
+})
+
+describe('isSyncTypeRegistered', () => {
+  beforeEach(() => {
+    syncableRegistry.clear()
+  })
+
+  it('returns true for registered sync types', () => {
+    syncable('customerSubscriptions', {
+      resolver: async ({
+        input: _input,
+      }: {
+        input: { customerId: string }
+        ctx: unknown
+      }) => ({}),
+      affectedBy: {},
+    })
+
+    expect(isSyncTypeRegistered('customerSubscriptions')).toBe(true)
+  })
+
+  it('returns false for unregistered sync types', () => {
+    expect(isSyncTypeRegistered('customerSubscriptions')).toBe(false)
+    expect(isSyncTypeRegistered('subscription')).toBe(false)
+  })
+})
+
+describe('getSyncableConfig', () => {
+  beforeEach(() => {
+    syncableRegistry.clear()
+  })
+
+  it('returns the registry entry for a registered sync type', () => {
+    const resolver = async ({
+      input: _input,
+    }: {
+      input: { customerId: string }
+      ctx: unknown
+    }) => ({
+      data: [],
+    })
+    const affectedByFn = async ({
+      payload: _payload,
+    }: {
+      payload: { subscriptionId: string }
+      ctx: unknown
+    }) => ({
+      customerId: 'derived',
+    })
+
+    syncable('customerSubscriptions', {
+      resolver,
+      affectedBy: {
+        customerSubscriptions: 'direct',
+        subscription: affectedByFn,
+      },
+    })
+
+    const config = getSyncableConfig('customerSubscriptions')
+
+    expect(config?.affectedBy.customerSubscriptions).toBe('direct')
+    expect(typeof config?.affectedBy.subscription).toBe('function')
+    expect(typeof config?.resolver).toBe('function')
+  })
+
+  it('returns undefined for unregistered sync type', () => {
+    const config = getSyncableConfig('customerSubscriptions')
+    expect(config).toBeUndefined()
+  })
+})
+
+describe('affectedBy function execution', () => {
+  beforeEach(() => {
+    syncableRegistry.clear()
+  })
+
+  it('affectedBy function receives payload and ctx and returns derived input', async () => {
+    let capturedPayload: unknown
+    let capturedCtx: unknown
+
+    syncable('customerSubscriptions', {
+      resolver: async ({
+        input: _input,
+      }: {
+        input: { customerId: string }
+        ctx: unknown
+      }) => ({
+        data: [],
+      }),
+      affectedBy: {
+        subscription: async ({ payload, ctx }) => {
+          capturedPayload = payload
+          capturedCtx = ctx
+          return { customerId: 'derived_customer' }
+        },
+      },
+    })
+
+    const affected = getSyncablesAffectedBy('subscription')
+    const affectedByFn = affected[0].affectedByFn
+
+    // Ensure it's a function (not 'direct')
+    expect(typeof affectedByFn).toBe('function')
+    if (typeof affectedByFn === 'function') {
+      const testPayload = { subscriptionId: 'sub_123' }
+      const testCtx = { userId: 'user_456', transaction: {} }
+
+      const result = await affectedByFn({
+        payload: testPayload,
+        ctx: testCtx,
+      })
+
+      expect(capturedPayload).toEqual(testPayload)
+      expect(capturedCtx).toEqual(testCtx)
+      expect(result).toEqual({ customerId: 'derived_customer' })
+    }
+  })
+
+  it('affectedBy function can return array for fan-out', async () => {
+    syncable('customerSubscriptions', {
+      resolver: async ({
+        input: _input,
+      }: {
+        input: { customerId: string }
+        ctx: unknown
+      }) => ({
+        data: [],
+      }),
+      affectedBy: {
+        subscription: async ({ payload: _payload }) => {
+          // Fan-out: single subscription affects multiple customers
+          return [
+            { customerId: 'cust_1' },
+            { customerId: 'cust_2' },
+            { customerId: 'cust_3' },
+          ]
+        },
+      },
+    })
+
+    const affected = getSyncablesAffectedBy('subscription')
+    const affectedByFn = affected[0].affectedByFn
+
+    expect(typeof affectedByFn).toBe('function')
+    if (typeof affectedByFn === 'function') {
+      const result = await affectedByFn({
+        payload: { subscriptionId: 'sub_123' },
+        ctx: {},
+      })
+
+      expect(Array.isArray(result)).toBe(true)
+      expect(result).toHaveLength(3)
+      expect(result).toEqual([
+        { customerId: 'cust_1' },
+        { customerId: 'cust_2' },
+        { customerId: 'cust_3' },
+      ])
+    }
+  })
+})
+
+// TYPE TEST: The following would cause TypeScript errors if uncommented,
+// demonstrating the type safety of the affectedBy function return type.
+//
+// syncable('customerSubscriptions', {
+//   resolver: async ({ input }) => {},
+//   affectedBy: {
+//     subscription: async ({ payload }) => ({ subscriptionId: '123' })
+//     // ERROR: Type '{ subscriptionId: string; }' is not assignable to
+//     // type 'SyncPayload<"customerSubscriptions">' (which is { customerId: string })
+//   }
+// })


### PR DESCRIPTION
## Summary
- Create `syncable()` higher-order function that wraps TRPC resolvers and registers them for sync events
- Add `affectedBy` declarations for deriving resolver inputs from invalidation dependencies
- Add `SyncSubscription` namespace to `RedisKeyNamespace` for cached Svix subscription checks

## Changes

### New: `src/utils/syncable.ts`
- `syncable(dependencyType, { resolver, affectedBy })` - registers resolver at call time, returns the resolver for TRPC
- `getSyncablesAffectedBy(invalidationType)` - find all syncables affected by an invalidation type
- `syncableRegistry` - Map of syncType → { resolver, affectedBy }
- `isSyncTypeRegistered()` and `getSyncableConfig()` helper functions

### Modified: `src/utils/redis.ts`
- Add `SyncSubscription` namespace with 5-minute TTL for caching Svix subscription checks

## Type Safety
- Resolver input type enforced to match `SyncPayload<TType>`
- `affectedBy` functions must return `SyncPayload<TType>` (or array for fan-out)

## Test Plan
- [x] `bun run check` passes (lint, format, typecheck)
- [x] All 14 unit tests pass in `syncable.unit.test.ts`
- [ ] Manual verification of registry pattern at module load time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a syncable() HOF to register TRPC resolvers for push-based recomputation using affectedBy mappings, enabling precise fan-out from invalidations. Also adds a Redis SyncSubscription namespace to cache Svix subscription checks for 5 minutes.

- **New Features**
  - syncable(dependencyType, { resolver, affectedBy }) registers a resolver and returns it for TRPC.
  - affectedBy supports 'direct' or an async function; functions can fan out by returning an array.
  - getSyncablesAffectedBy(invalidationType) locates all affected sync types for an invalidation.
  - Global syncableRegistry with isSyncTypeRegistered and getSyncableConfig helpers.
  - Redis SyncSubscription namespace for cached Svix subscription checks.

- **Migration**
  - Wrap relevant TRPC resolvers with syncable and declare affectedBy for each invalidation type.
  - Use getSyncablesAffectedBy in your invalidation handler to compute inputs, run resolvers, and emit sync events.

<sup>Written for commit 4a257ae30c7f5f1f45105c8c3335e440b027288d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

