### PR TITLE
[trigger-transaction-consistency] Patch 2: Add test stubs for trigger task infrastructure

### DIFF
--- a/platform/flowglad-next/src/db/authenticatedTransaction.db.test.ts
+++ b/platform/flowglad-next/src/db/authenticatedTransaction.db.test.ts
@@ -1017,3 +1017,31 @@ describe('authenticatedTransactionWithResult', () => {
     expect(() => result.unwrap()).toThrow(errorMessage)
   })
 })
+
+describe('enqueueTriggerTask', () => {
+  it.skip('should not dispatch tasks if transaction rolls back', async () => {
+    // Setup: create a transaction that will roll back
+    // Action: enqueue a trigger task, then throw to cause rollback
+    // Expectation: the trigger task is NOT dispatched
+  })
+
+  it.skip('should dispatch tasks after commit and return handles', async () => {
+    // Setup: create a transaction that commits successfully
+    // Action: enqueue a trigger task
+    // Expectation: task is dispatched after commit, handle is returned
+  })
+
+  it.skip('should return handles keyed by user-provided key', async () => {
+    // Setup: create a transaction with multiple trigger tasks
+    // Action: enqueue tasks with different keys
+    // Expectation: triggerHandles map contains all keys with correct handles
+  })
+})
+
+describe('comprehensiveAuthenticatedTransaction triggerHandles', () => {
+  it.skip('should return result and triggerHandles at same level', async () => {
+    // Setup: create a comprehensive transaction
+    // Action: return a value and enqueue a trigger task
+    // Expectation: returned object has { result, triggerHandles } structure
+  })
+})

--- a/platform/flowglad-next/src/db/transactionEffectsHelpers.unit.test.ts
+++ b/platform/flowglad-next/src/db/transactionEffectsHelpers.unit.test.ts
@@ -1,0 +1,17 @@
+import { describe, it } from 'bun:test'
+
+describe('enqueueTriggerTask', () => {
+  it.skip('should accumulate trigger tasks in effects with key', async () => {
+    // Setup: create effects accumulator
+    // Action: call enqueueTriggerTask with key, task, payload
+    // Expectation: effects.triggerTasks contains the queued task with correct key
+  })
+})
+
+describe('dispatchTriggerTasksAfterCommit', () => {
+  it.skip('should log errors but not throw, omit failed from handles', async () => {
+    // Setup: create trigger tasks array with one that will fail
+    // Action: call dispatchTriggerTasksAfterCommit
+    // Expectation: returns map with only successful handles, error is logged
+  })
+})


### PR DESCRIPTION
## Summary
- Add skipped test stubs for the trigger task infrastructure that will be implemented in Patch 3
- Tests cover the `enqueueTriggerTask` callback and `dispatchTriggerTasksAfterCommit` helper

## Test Stubs Added

**transactionEffectsHelpers.unit.test.ts:**
- `enqueueTriggerTask > should accumulate trigger tasks in effects with key`
- `dispatchTriggerTasksAfterCommit > should log errors but not throw, omit failed from handles`

**authenticatedTransaction.db.test.ts:**
- `enqueueTriggerTask > should not dispatch tasks if transaction rolls back`
- `enqueueTriggerTask > should dispatch tasks after commit and return handles`
- `enqueueTriggerTask > should return handles keyed by user-provided key`
- `comprehensiveAuthenticatedTransaction triggerHandles > should return result and triggerHandles at same level`

## Test plan
- [x] `bun run check` passes
- [x] Unit test stubs are recognized (2 skipped)
- [x] DB test stubs are recognized (4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add skipped test stubs for the trigger task infrastructure to define expected behavior before implementation in Patch 3. Covers enqueueTriggerTask and dispatchTriggerTasksAfterCommit across unit and DB tests.

Tests assert: tasks dispatch only after commit (not on rollback), handles are keyed, errors are logged without throwing and failed tasks are omitted, and comprehensive transactions return { result, triggerHandles }.

<sup>Written for commit 4ab987dc67ce534f5bf6f17a605ba683bf1c1838. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Based on the provided summary, these are internal test scaffolding additions with no changes to public APIs or runtime behavior. There are no user-facing features, bug fixes, or functionality changes to report in end-user release notes. These changes are not applicable to external audiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->