### PR TITLE
[require-product-slugs] Patch 3: Add NOT NULL + CHECK constraints

### DIFF
--- a/platform/flowglad-next/db-core/migrations/0295_add-product-slug-notnull.sql
+++ b/platform/flowglad-next/db-core/migrations/0295_add-product-slug-notnull.sql
@@ -1,0 +1,23 @@
+-- Patch 3: Add NOT NULL and CHECK constraints to products.slug
+-- Requires Patch 1 (backfill) to have run first
+
+-- Validation block: Ensure no products have invalid slugs
+DO $$
+DECLARE
+  invalid_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO invalid_count
+  FROM products WHERE slug IS NULL OR slug = '';
+
+  IF invalid_count > 0 THEN
+    RAISE EXCEPTION 'Cannot add constraint: % products have invalid slug', invalid_count;
+  END IF;
+END $$;
+--> statement-breakpoint
+
+-- Add NOT NULL constraint
+ALTER TABLE "products" ALTER COLUMN "slug" SET NOT NULL;
+--> statement-breakpoint
+
+-- Add CHECK constraint to prevent empty strings
+ALTER TABLE "products" ADD CONSTRAINT "products_slug_not_empty" CHECK (slug <> '');

--- a/platform/flowglad-next/db-core/migrations/meta/_journal.json
+++ b/platform/flowglad-next/db-core/migrations/meta/_journal.json
@@ -2059,6 +2059,13 @@
       "when": 1770000000000,
       "tag": "0294_backfill-product-slugs",
       "breakpoints": true
+    },
+    {
+      "idx": 295,
+      "version": "7",
+      "when": 1770000000001,
+      "tag": "0295_add-product-slug-notnull",
+      "breakpoints": true
     }
   ]
 }

--- a/platform/flowglad-next/db-core/schema/products.ts
+++ b/platform/flowglad-next/db-core/schema/products.ts
@@ -73,7 +73,7 @@ const columns = {
    */
   externalId: text('external_id'),
   default: boolean('default').notNull().default(false),
-  slug: text('slug'),
+  slug: text('slug').notNull(),
 }
 
 export const products = pgTable(


### PR DESCRIPTION
## Summary

- Adds `.notNull()` to the `slug` column in the products schema
- Creates migration `0295_add-product-slug-notnull.sql` that:
  - Validates no products have null/empty slugs (fails fast if backfill incomplete)
  - Adds `NOT NULL` constraint to `products.slug`
  - Adds `CHECK` constraint `products_slug_not_empty` to prevent empty strings

This is Patch 3 from the `require-product-slugs` gameplan. It depends on Patch 1 (backfill) having run first.

## Test plan

- [ ] Run migration against test database with backfilled data - should succeed
- [ ] Run migration against database with null/empty slugs - should fail with clear error
- [ ] Verify TypeScript types reflect non-null slug
- [ ] `bun run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make product slugs required and non-empty to enforce data integrity and reflect this in the TypeScript schema.

- **Migration**
  - Run Patch 1 (backfill) first.
  - Apply migration 0295; it aborts if any product has a null or empty slug.

<sup>Written for commit 4deff43ec907907472bc2f9d33acb543d7d98a59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

