### PR TITLE
Link Slack review notifications directly to review URL

### DIFF
--- a/.github/workflows/pr-review-slack-reply.yml
+++ b/.github/workflows/pr-review-slack-reply.yml
@@ -21,7 +21,7 @@ jobs:
           SLACK_GITHUB_MAPPING: ${{ secrets.SLACK_GITHUB_MAPPING }}
           STATE: ${{ github.event.review.state }}
           TITLE: ${{ github.event.pull_request.title }}
-          URL: ${{ github.event.pull_request.html_url }}
+          URL: ${{ github.event.review.html_url }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@flowglad/javascript",


### PR DESCRIPTION
## What Does this PR Do?

Updates the PR review Slack notification to link directly to the specific review instead of the pull request page. This allows users to click the notification and jump straight to the review section.

Changed `github.event.pull_request.html_url` to `github.event.review.html_url` in the PR review Slack notification workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slack PR review notifications now link directly to the specific review using github.event.review.html_url instead of the PR page. This lets reviewers jump straight to the review thread.

<sup>Written for commit bf2c92e00a7d44991a8d9630a9b3f1c26f0406ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes to report. This update involves internal workflow configuration for the development process and does not impact end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->