### PR TITLE
[require-price-slugs] Patch 5: Remove ?? null from price creation paths

### DIFF
--- a/platform/flowglad-next/src/utils/pricingModels/setupHelpers.ts
+++ b/platform/flowglad-next/src/utils/pricingModels/setupHelpers.ts
@@ -36,7 +36,7 @@ export const createProductPriceInsert = (
   const { productId, currency, livemode } = options
   const base = {
     name: price.name ?? null,
-    slug: price.slug ?? null,
+    slug: price.slug,
     unitPrice: price.unitPrice,
     isDefault: price.isDefault,
     active: price.active,

--- a/platform/flowglad-next/src/utils/pricingModels/setupTransaction.ts
+++ b/platform/flowglad-next/src/utils/pricingModels/setupTransaction.ts
@@ -177,7 +177,7 @@ const buildUsagePriceInserts = (
         usagePriceInserts.push({
           type: PriceType.Usage as const,
           name: price.name ?? null,
-          slug: price.slug ?? null,
+          slug: price.slug,
           unitPrice: price.unitPrice,
           isDefault: price.isDefault,
           active: price.active,

--- a/platform/flowglad-next/src/utils/pricingModels/updateTransaction.ts
+++ b/platform/flowglad-next/src/utils/pricingModels/updateTransaction.ts
@@ -217,7 +217,7 @@ const handleUsageMeterOperations = async (
           usageMeterPriceInserts.push({
             type: PriceType.Usage,
             name: price.name ?? null,
-            slug: price.slug ?? null,
+            slug: price.slug,
             unitPrice: price.unitPrice,
             isDefault: price.isDefault,
             active: price.active,
@@ -309,7 +309,7 @@ const handleUsageMeterOperations = async (
           priceDiff.toCreate.map((price) => ({
             type: PriceType.Usage,
             name: price.name ?? null,
-            slug: price.slug ?? null,
+            slug: price.slug,
             unitPrice: price.unitPrice,
             isDefault: price.isDefault,
             active: price.active,
@@ -375,7 +375,7 @@ const handleUsageMeterOperations = async (
             {
               type: PriceType.Usage,
               name: proposedPrice.name ?? null,
-              slug: proposedPrice.slug ?? null,
+              slug: proposedPrice.slug,
               unitPrice: proposedPrice.unitPrice,
               isDefault: proposedPrice.isDefault,
               active: proposedPrice.active,


### PR DESCRIPTION
## Summary

- Remove `slug: price.slug ?? null` patterns from price creation paths
- With slugs now required by the schema (Patches 2 & 3), the null coalescing is unnecessary
- Simplifies code by using `slug: price.slug` directly

## Files Modified

- `setupHelpers.ts:39` - `createProductPriceInsert` function
- `setupTransaction.ts:180` - `buildUsagePriceInserts` function
- `updateTransaction.ts:220,312,378` - usage meter price insert locations

## Test plan

- [x] `bun run check` passes
- [ ] Existing price creation tests pass
- [ ] No type errors introduced

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require non-null slugs in all price creation paths by replacing slug: price.slug ?? null with slug: price.slug, aligning with the schema change from patches 2 & 3. This simplifies inserts and prevents accidental null slugs.

- **Refactors**
  - setupHelpers.ts: createProductPriceInsert now uses slug: price.slug
  - setupTransaction.ts: buildUsagePriceInserts now uses slug: price.slug
  - updateTransaction.ts: usage meter price inserts (3 spots) now use slug: price.slug

<sup>Written for commit 9ce918d550e0c1e3249c149eabc6b264be42731d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

