### PR TITLE
[require-price-slugs] Patch 4: Remove fallback slug generation

### DIFF
--- a/platform/flowglad-next/src/utils/pricingModels/diffing.unit.test.ts
+++ b/platform/flowglad-next/src/utils/pricingModels/diffing.unit.test.ts
@@ -1117,8 +1117,7 @@ describe('diffUsageMeterPrices', () => {
 
     const result = diffUsageMeterPrices(
       existingPrices,
-      proposedPrices,
-      'test-meter'
+      proposedPrices
     )
 
     expect(result.toRemove).toHaveLength(1)
@@ -1132,29 +1131,23 @@ describe('diffUsageMeterPrices', () => {
   })
 
   it('returns empty diff arrays when both inputs are undefined', () => {
-    const result = diffUsageMeterPrices(
-      undefined,
-      undefined,
-      'test-meter'
-    )
+    const result = diffUsageMeterPrices(undefined, undefined)
     expect(result.toRemove).toEqual([])
     expect(result.toCreate).toEqual([])
     expect(result.toUpdate).toEqual([])
   })
 
   it('returns empty diff arrays when both inputs are empty arrays', () => {
-    const result = diffUsageMeterPrices([], [], 'test-meter')
+    const result = diffUsageMeterPrices([], [])
     expect(result.toRemove).toEqual([])
     expect(result.toCreate).toEqual([])
     expect(result.toUpdate).toEqual([])
   })
 
   it('identifies prices to create when existing is undefined', () => {
-    const result = diffUsageMeterPrices(
-      undefined,
-      [createUsagePrice({ slug: 'new-price' })],
-      'test-meter'
-    )
+    const result = diffUsageMeterPrices(undefined, [
+      createUsagePrice({ slug: 'new-price' }),
+    ])
     expect(result.toCreate).toHaveLength(1)
     expect(result.toCreate[0].slug).toBe('new-price')
     expect(result.toRemove).toEqual([])
@@ -1164,8 +1157,7 @@ describe('diffUsageMeterPrices', () => {
   it('identifies prices to remove when proposed is undefined', () => {
     const result = diffUsageMeterPrices(
       [createUsagePrice({ slug: 'old-price' })],
-      undefined,
-      'test-meter'
+      undefined
     )
     expect(result.toRemove).toHaveLength(1)
     expect(result.toRemove[0].slug).toBe('old-price')


### PR DESCRIPTION
## Summary
- Delete `getUsagePriceSlug` function that generated synthetic fallback slugs when prices lacked real slugs
- Update `toSluggedUsagePrices` to use `p.slug` directly (slugs are now required via Patches 2-3)
- Remove `meterSlug` parameter from `diffUsageMeterPrices` since it was only used for synthetic slug generation
- Remove unused `buildSyntheticUsagePriceSlug` import from `./slugHelpers`
- Update tests to match new function signatures

## Test plan
- [x] All existing `diffUsageMeterPrices` tests pass (93 tests)
- [x] `bun run check` passes
- [x] Type checking passes (after rebasing on Patches 1-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed synthetic usage price slug generation so diffing now uses real slugs only. This simplifies helpers and removes the meterSlug param, consistent with earlier patches that require slugs.

- **Refactors**
  - Deleted getUsagePriceSlug and the synthetic slug path.
  - toSluggedUsagePrices now reads p.slug directly.
  - diffUsageMeterPrices signature drops the meterSlug parameter.
  - Updated unit tests to match new function signatures.

<sup>Written for commit 8fff77c1a3e0ac6b15afdfcb3671dcefcf0bcd3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

