### PR TITLE
[require-price-slugs] Patch 7: Update tests to use explicit price slugs

### DIFF
--- a/platform/flowglad-next/src/components/UsagePricesGridSection/UsagePriceCard.test.tsx
+++ b/platform/flowglad-next/src/components/UsagePricesGridSection/UsagePriceCard.test.tsx
@@ -121,16 +121,16 @@ describe('UsagePriceCard', () => {
       expect(screen.getByText('my-custom-slug')).toBeInTheDocument()
     })
 
-    it('falls back to displaying price id when slug is empty', () => {
+    it('displays the price slug for all valid prices', () => {
       const price = createTestPrice({
-        id: 'price_fallback_id',
-        slug: '',
+        id: 'price_test_id',
+        slug: 'another-test-slug',
       })
 
       render(<UsagePriceCard price={price} />)
 
       expect(
-        screen.getByText('price_fallback_id')
+        screen.getByText('another-test-slug')
       ).toBeInTheDocument()
     })
   })

--- a/platform/flowglad-next/src/components/checkout/total-billing-details.test.tsx
+++ b/platform/flowglad-next/src/components/checkout/total-billing-details.test.tsx
@@ -131,7 +131,7 @@ const mockUsagePrice = {
   createdByCommit: 'test',
   updatedByCommit: 'test',
   position: 0,
-  slug: '',
+  slug: 'usage-price',
 }
 
 const mockDiscount = {

--- a/platform/flowglad-next/src/server/routers/pricesRouter.rls.test.ts
+++ b/platform/flowglad-next/src/server/routers/pricesRouter.rls.test.ts
@@ -94,7 +94,7 @@ describe('pricesRouter - Default Price Constraints', () => {
             usageEventsPerUnit: null,
             usageMeterId: null,
             externalId: null,
-            slug: null,
+            slug: 'regular-price',
           },
           ctx
         )
@@ -406,7 +406,7 @@ describe('pricesRouter - Default Price Constraints', () => {
               usageEventsPerUnit: null,
               usageMeterId: null,
               externalId: null,
-              slug: null,
+              slug: 'other-price',
             },
             ctx
           )
@@ -519,7 +519,7 @@ describe('pricesRouter - Default Price Constraints', () => {
               usageEventsPerUnit: null,
               usageMeterId: null,
               externalId: null,
-              slug: null,
+              slug: 'another-price',
             },
             ctx
           )
@@ -683,7 +683,7 @@ describe('pricesRouter - Default Price Constraints', () => {
             usageEventsPerUnit: null,
             usageMeterId: null,
             externalId: null,
-            slug: null,
+            slug: 'another-default',
           },
           ctx
         )

--- a/platform/flowglad-next/src/server/routers/productsRouter.db.test.ts
+++ b/platform/flowglad-next/src/server/routers/productsRouter.db.test.ts
@@ -82,7 +82,7 @@ describe('productsRouter - Default Product Constraints', () => {
             usageEventsPerUnit: null,
             usageMeterId: null,
             externalId: null,
-            slug: null,
+            slug: 'regular-price',
           },
           ctx
         )
@@ -186,7 +186,7 @@ describe('productsRouter - Default Product Constraints', () => {
               usageEventsPerUnit: null,
               usageMeterId: null,
               externalId: null,
-              slug: null,
+              slug: 'regular-price-2',
             },
             ctx
           )

--- a/platform/flowglad-next/src/stubs/priceStubs.ts
+++ b/platform/flowglad-next/src/stubs/priceStubs.ts
@@ -26,7 +26,7 @@ export const subscriptionDummyPrice: Price.SubscriptionRecord = {
   updatedByCommit: 'test',
   position: 0,
   pricingModelId: 'test',
-  slug: '',
+  slug: 'subscription-dummy-price',
 }
 
 export const singlePaymentDummyPrice: Price.SinglePaymentRecord = {


### PR DESCRIPTION
## Summary

- Update test files to use explicit non-empty slugs instead of `slug: null` or `slug: ''`
- Replace 4 instances of `slug: null` in `pricesRouter.rls.test.ts`
- Replace 2 instances of `slug: null` in `productsRouter.db.test.ts`
- Update `priceStubs.ts` to use explicit slug for `subscriptionDummyPrice`
- Update component test files to use explicit slugs
- Preserved edge case tests that document defensive behavior for handling legacy data

## Test plan

- [x] `bun run check` passes (linting, formatting, type checking)
- [x] Unit tests pass (`bun test src/db/schema/prices.unit.test.ts`)
- [x] `isPriceChanged` tests pass (`bun test src/utils/pricingModel.isPriceChanged.db.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated tests to require explicit, non-empty price slugs. This aligns with the require-price-slugs changes and verifies slug display across UI and router tests.

- **Refactors**
  - Replaced slug: null/'' with explicit slugs in pricesRouter.rls.test.ts and productsRouter.db.test.ts.
  - Set subscriptionDummyPrice stub to 'subscription-dummy-price'.
  - Updated UsagePriceCard and total-billing-details tests to expect slug display.
  - Kept legacy null/undefined slug edge-case tests in isPriceChanged and prices unit tests.

<sup>Written for commit dce313d24ad0eeabe2589f0c78f6702a0020b720. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

