### PR TITLE
fix verify-otp forwarding

### DIFF
--- a/platform/flowglad-next/src/app/api/billing-portal/verify-otp/route.ts
+++ b/platform/flowglad-next/src/app/api/billing-portal/verify-otp/route.ts
@@ -124,6 +124,13 @@ export async function POST(request: NextRequest) {
           'Content-Type': 'application/json',
           Cookie: cookieString,
           Origin: baseUrl,
+          // Forward protocol headers so BetterAuth knows the original request was HTTPS
+          // Without this, secure cookies won't be set in production (Vercel internal routing is HTTP)
+          'X-Forwarded-Proto':
+            request.headers.get('X-Forwarded-Proto') || 'https',
+          'X-Forwarded-Host':
+            request.headers.get('X-Forwarded-Host') ||
+            new URL(request.url).host,
         },
         body: JSON.stringify({ email, otp }),
       }


### PR DESCRIPTION
## What Does this PR Do?
fix "Customer auth response did not include session token cookie" error in POST /api/billing-portal/verify-otp

On Vercel (and similar platforms), internal server-to-server requests often go through internal routing that:
Doesn't include X-Forwarded-Proto: https header
May appear as HTTP to the receiving endpoint
BetterAuth checks the protocol and won't set Secure cookies if the request appears to be over HTTP. This is why the customer.session_token cookie isn't in the response.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing customer.session_token cookie in POST /api/billing-portal/verify-otp by forwarding HTTPS protocol headers so BetterAuth sets Secure cookies in production (e.g., Vercel). Resolves the "Customer auth response did not include session token cookie" error.

- **Bug Fixes**
  - Forward X-Forwarded-Proto and X-Forwarded-Host (with sensible defaults) when calling BetterAuth to preserve HTTPS context and set Secure cookies.

<sup>Written for commit 8a33f98620e3aa310bf35d5bb24a84b8f0336f09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP sign-in security by properly forwarding protocol and host headers in production environments, ensuring secure cookies are set correctly during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->