### PR TITLE
fix verify-otp: add secure prefix for prod

### DIFF
--- a/platform/flowglad-next/src/app/api/billing-portal/verify-otp/route.ts
+++ b/platform/flowglad-next/src/app/api/billing-portal/verify-otp/route.ts
@@ -150,16 +150,19 @@ export async function POST(request: NextRequest) {
     const setCookieHeaders = authResponse.headers.getSetCookie()
 
     // Extract the session token from Set-Cookie headers to update session context
-    // Cookie format: customer.session_token=<token>; ...
+    // Cookie format: customer.session_token=<token>; ... OR __Secure-customer.session_token=<token>; ...
+    // Note: BetterAuth adds __Secure- prefix when cookie has Secure attribute (production)
     const sessionTokenCookieName = `${CUSTOMER_COOKIE_PREFIX}.session_token`
+    const secureSessionTokenCookieName = `__Secure-${CUSTOMER_COOKIE_PREFIX}.session_token`
     let sessionToken: string | null = null
 
     for (const cookie of setCookieHeaders) {
-      if (cookie.startsWith(`${sessionTokenCookieName}=`)) {
+      if (
+        cookie.startsWith(`${sessionTokenCookieName}=`) ||
+        cookie.startsWith(`${secureSessionTokenCookieName}=`)
+      ) {
         // Extract the token value (before the first semicolon)
-        const tokenMatch = cookie.match(
-          new RegExp(`^${sessionTokenCookieName}=([^;]+)`)
-        )
+        const tokenMatch = cookie.match(/=([^;]+)/)
         if (tokenMatch) {
           sessionToken = decodeURIComponent(tokenMatch[1])
         }
@@ -245,6 +248,13 @@ export async function POST(request: NextRequest) {
           organizationId,
           customerId,
           setCookieHeadersCount: setCookieHeaders.length,
+          // Debug: log what cookies ARE being returned (first 150 chars of each)
+          setCookieHeaders: setCookieHeaders.map((c) =>
+            c.substring(0, 150)
+          ),
+          expectedCookieName: sessionTokenCookieName,
+          baseUrl,
+          authResponseStatus: authResponse.status,
         },
       })
       return NextResponse.json(


### PR DESCRIPTION
## What Does this PR Do?
look for token in cookie with Secure prefix for prod

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix session token parsing in billing-portal OTP verification to support __Secure- prefixed cookies in production, preventing failed logins. Adds light diagnostics to help trace missing tokens.

- **Bug Fixes**
  - Parse both customer.session_token and __Secure-customer.session_token from Set-Cookie.
  - Simplify token extraction to read value before the first semicolon.
  - Add minimal debug data when token is missing (truncated cookies, expected name, status).

<sup>Written for commit 662af74333fb64e0957b30aca4956ff0e357e570. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP verification reliability by enhancing session token extraction to handle multiple secure cookie formats.
  * Enhanced error handling and logging for session management to provide better diagnostics when verification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->