### PR TITLE
[billing-hooks-history] Add server handlers and FlowgladServer methods (no callers)

### DIFF
--- a/packages/server/src/FlowgladServer.ts
+++ b/packages/server/src/FlowgladServer.ts
@@ -211,6 +211,14 @@ export class FlowgladServer {
 
     let invoices = billing.invoices ?? []
 
+    if (params?.startingAfter !== undefined) {
+      const cursorIndex = invoices.findIndex(
+        (item) => item.invoice.id === params.startingAfter
+      )
+      invoices =
+        cursorIndex >= 0 ? invoices.slice(cursorIndex + 1) : invoices
+    }
+
     if (params?.limit !== undefined) {
       invoices = invoices.slice(0, params.limit)
     }

--- a/packages/server/src/subrouteHandlers/invoiceHandlers.ts
+++ b/packages/server/src/subrouteHandlers/invoiceHandlers.ts
@@ -28,7 +28,7 @@ export const getInvoices: SubRouteHandler<
   if (params.method !== HTTPMethod.POST) {
     error = {
       code: 'Method not allowed',
-      json: {},
+      json: { message: 'Method not allowed' },
     }
     status = 405
     return {
@@ -46,7 +46,10 @@ export const getInvoices: SubRouteHandler<
       status: 400,
       error: {
         code: 'Validation error',
-        json: { issues: parsed.error.issues },
+        json: {
+          message: 'Validation error',
+          issues: parsed.error.issues,
+        },
       },
     }
   }
@@ -62,7 +65,7 @@ export const getInvoices: SubRouteHandler<
     } else {
       error = {
         code: 'Unknown error',
-        json: {},
+        json: { message: 'Unknown error' },
       }
     }
     status = 500


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server handlers and FlowgladServer methods to fetch customer invoices and purchases with optional pagination. Adds cursor pagination for invoices and makes error responses clearer.

- **New Features**
  - FlowgladServer.getInvoices(params?) supports startingAfter and limit.
  - FlowgladServer.getPurchases(params?) supports limit; startingAfter is available in the schema for future pagination.

- **Bug Fixes**
  - Invoice handler errors now include clear messages for 405, 400 (with issues), and 500 responses.

<sup>Written for commit cdfc1aff1082f30192a22318a6138d62ad1e4338. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination support for invoices using the optional `startingAfter` parameter, enabling more efficient navigation through large invoice lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->