### PR TITLE
fix: full discount invoice line item bug

### DIFF
--- a/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
+++ b/platform/flowglad-next/src/subscriptions/billingRunHelpers.ts
@@ -578,7 +578,11 @@ export const executeBillingRunCalculationAndBookkeepingSteps = async (
       usageOverages,
       billingRunId: billingRun.id,
     })
-  await insertInvoiceLineItems(invoiceLineItemInserts, transaction)
+  // Only insert if there are line items - handles cases like 100% discounts
+  // where billing period items may be empty
+  if (invoiceLineItemInserts.length > 0) {
+    await insertInvoiceLineItems(invoiceLineItemInserts, transaction)
+  }
 
   // Update invoice with accurate subtotal and tax amounts from fee calculation
   // This ensures email templates display correct totals including discounts


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a billing run error when a 100% discount results in no invoice line items by skipping the insert. This prevents empty line item writes and keeps invoice totals and emails correct.

- **Bug Fixes**
  - Only call insertInvoiceLineItems when there are items to insert (handles full-discount periods).

<sup>Written for commit 939c63902aeb057efd3a99677613a68d578737c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced billing invoice processing to properly handle edge cases where no invoice line items exist, reducing unnecessary database operations during subscription billing cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->