### PR TITLE
give internal bot permission on new concierge channel

### DIFF
--- a/platform/flowglad-next/src/utils/discord.ts
+++ b/platform/flowglad-next/src/utils/discord.ts
@@ -24,6 +24,7 @@ export interface DiscordConfig {
   guildId: string
   conciergeCategoryPrefix: string
   flowgladTeamRoleId?: string
+  internalBotRoleId?: string
 }
 
 const DISCORD_CATEGORY_CHANNEL_LIMIT = 50
@@ -45,6 +46,7 @@ export function getDiscordConfig(): DiscordConfig {
     process.env.DISCORD_CONCIERGE_CATEGORY_PREFIX ??
     'Concierge Cohort'
   const flowgladTeamRoleId = process.env.DISCORD_FLOWGLAD_TEAM_ROLE_ID
+  const internalBotRoleId = process.env.DISCORD_INTERNAL_BOT_ROLE_ID
 
   if (!botToken) {
     panic('DISCORD_BOT_TOKEN environment variable is required')
@@ -58,6 +60,7 @@ export function getDiscordConfig(): DiscordConfig {
     guildId,
     conciergeCategoryPrefix,
     flowgladTeamRoleId,
+    internalBotRoleId,
   }
 }
 
@@ -255,6 +258,19 @@ async function createPrivateChannel(
       allow: (
         PermissionFlagsBits.ViewChannel |
         PermissionFlagsBits.SendMessages
+      ).toString(),
+      deny: '0',
+    })
+  }
+
+  // Add internal bot role if configured (for message monitoring)
+  if (config.internalBotRoleId) {
+    permissionOverwrites.push({
+      id: config.internalBotRoleId,
+      type: OverwriteType.Role,
+      allow: (
+        PermissionFlagsBits.ViewChannel |
+        PermissionFlagsBits.ReadMessageHistory
       ).toString(),
       deny: '0',
     })


### PR DESCRIPTION
## What Does this PR Do?
<!-- Please provide a clear and concise description of the changes in this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically grants the internal bot read-only access to newly created Concierge channels, enabling message monitoring without manual permission updates.

- **New Features**
  - Added optional internalBotRoleId to DiscordConfig (from DISCORD_INTERNAL_BOT_ROLE_ID).
  - When set, new Concierge channels allow ViewChannel and ReadMessageHistory for that role.

- **Migration**
  - Set DISCORD_INTERNAL_BOT_ROLE_ID to the internal bot role ID. If unset, behavior is unchanged.

<sup>Written for commit 8f69fd07cf95a54f5deb83b55b380df47f95e6b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for an internal Discord bot role that can be automatically granted access to private channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->